### PR TITLE
feat: support for typescript named routes

### DIFF
--- a/__tests__/errors.spec.ts
+++ b/__tests__/errors.spec.ts
@@ -16,7 +16,7 @@ import {
   RouteLocationNormalized,
 } from '../src/types'
 
-const routes: RouteRecordRaw[] = [
+const routes: Readonly<RouteRecordRaw>[] = [
   { path: '/', component: components.Home },
   { path: '/redirect', redirect: '/' },
   { path: '/foo', component: components.Foo, name: 'Foo' },

--- a/__tests__/matcher/resolve.spec.ts
+++ b/__tests__/matcher/resolve.spec.ts
@@ -42,7 +42,7 @@ describe('RouterMatcher.resolve', () => {
       throw new Error('not handled')
     } else {
       // use one single record
-      // @ts-expect-error: One way or the other it failse
+      // @ts-expect-error: One way or the other it false
       if (!resolved.matched) resolved.matched = record.map(normalizeRouteRecord)
       // allow passing an expect.any(Array)
       else if (Array.isArray(resolved.matched))

--- a/__tests__/matcher/resolve.spec.ts
+++ b/__tests__/matcher/resolve.spec.ts
@@ -42,9 +42,11 @@ describe('RouterMatcher.resolve', () => {
       throw new Error('not handled')
     } else {
       // use one single record
+      // @ts-expect-error: One way or the other it failse
       if (!resolved.matched) resolved.matched = record.map(normalizeRouteRecord)
       // allow passing an expect.any(Array)
       else if (Array.isArray(resolved.matched))
+        // @ts-expect-error: same as above
         resolved.matched = resolved.matched.map(m => ({
           ...normalizeRouteRecord(m as any),
           aliasOf: m.aliasOf,
@@ -58,6 +60,7 @@ describe('RouterMatcher.resolve', () => {
     const startCopy: MatcherLocation = {
       ...start,
       matched: start.matched.map(m => ({
+        // @ts-expect-error: okay...
         ...normalizeRouteRecord(m),
         aliasOf: m.aliasOf,
       })) as MatcherLocation['matched'],

--- a/__tests__/mount.ts
+++ b/__tests__/mount.ts
@@ -4,17 +4,24 @@ import {
   routeLocationKey,
   routerViewLocationKey,
 } from '../src/injectionSymbols'
+import { RouteLocationNormalized } from 'src'
 
-export function createMockedRoute(initialValue: RouteLocationNormalizedLoose) {
+export function createMockedRoute(
+  initialValue: RouteLocationNormalizedLoose | RouteLocationNormalized
+) {
   const route = {} as {
     [k in keyof RouteLocationNormalizedLoose]: ComputedRef<
       RouteLocationNormalizedLoose[k]
     >
   }
 
-  const routeRef = shallowRef(initialValue)
+  const routeRef = shallowRef<
+    RouteLocationNormalized | RouteLocationNormalizedLoose
+  >(initialValue)
 
-  function set(newRoute: RouteLocationNormalizedLoose) {
+  function set(
+    newRoute: RouteLocationNormalizedLoose | RouteLocationNormalized
+  ) {
     routeRef.value = newRoute
     return nextTick()
   }

--- a/__tests__/mount.ts
+++ b/__tests__/mount.ts
@@ -4,7 +4,7 @@ import {
   routeLocationKey,
   routerViewLocationKey,
 } from '../src/injectionSymbols'
-import { RouteLocationNormalized } from 'src'
+import { RouteLocationNormalized } from '../src'
 
 export function createMockedRoute(
   initialValue: RouteLocationNormalizedLoose | RouteLocationNormalized

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -17,6 +17,7 @@ import {
   createRouter,
   Router,
   RouterView,
+  RouteRecordNormalized,
 } from '../src'
 
 export const tick = (time?: number) =>
@@ -57,7 +58,7 @@ export interface RouteRecordViewLoose
   instances: Record<string, any>
   enterCallbacks: Record<string, Function[]>
   props: Record<string, _RouteRecordProps>
-  aliasOf: RouteRecordViewLoose | undefined
+  aliasOf: RouteRecordNormalized | RouteRecordViewLoose | undefined
   children?: RouteRecordRaw[]
   components: Record<string, RouteComponent> | null | undefined
 }

--- a/playground/router.ts
+++ b/playground/router.ts
@@ -176,6 +176,8 @@ export const router = createRouter({
   },
 })
 
+// TODO: move to pnpm, workspaces, and use an alias 'vue-router' to be closer to a real project
+
 declare module '../src' {
   export interface Config {
     Router: typeof router

--- a/playground/router.ts
+++ b/playground/router.ts
@@ -161,7 +161,7 @@ export const router = createRouter({
         { path: 'settings', component },
       ],
     },
-  ],
+  ] as const,
   async scrollBehavior(to, from, savedPosition) {
     await scrollWaiter.wait()
     if (savedPosition) {
@@ -175,6 +175,12 @@ export const router = createRouter({
     return false
   },
 })
+
+declare module '../src' {
+  export interface Config {
+    Router: typeof router
+  }
+}
 
 const delay = (t: number) => new Promise(resolve => setTimeout(resolve, t))
 

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["*.ts", "api", "../src/global.d.ts", "shim.d.ts"],
+  "include": ["./**/*.ts", "api", "../src/global.d.ts", "shim.d.ts"],
   "compilerOptions": {
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,

--- a/src/RouterLink.ts
+++ b/src/RouterLink.ts
@@ -37,12 +37,13 @@ import { routerKey, routeLocationKey } from './injectionSymbols'
 import { RouteRecord } from './matcher/types'
 import { NavigationFailure } from './errors'
 import { isBrowser, noop } from './utils'
+import { RouterTyped } from './typedRouter'
 
 export interface RouterLinkOptions {
   /**
    * Route Location the link should navigate to when clicked on.
    */
-  to: RouteLocationRaw
+  to: Parameters<RouterTyped['push']>[0]
   /**
    * Calls `router.replace` instead of `router.push`.
    */

--- a/src/globalExtensions.ts
+++ b/src/globalExtensions.ts
@@ -3,9 +3,9 @@ import {
   NavigationGuard,
   RouteLocationNormalizedLoaded,
 } from './types'
-import { Router } from './router'
 import { RouterView } from './RouterView'
 import { RouterLink } from './RouterLink'
+import { RouterTyped } from './typedRouter'
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomOptions {
@@ -55,7 +55,7 @@ declare module '@vue/runtime-core' {
     /**
      * {@link Router} instance used by the application.
      */
-    $router: Router
+    $router: RouterTyped
   }
 
   export interface GlobalComponents {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,10 @@ export type {
   RouteLocationMatched,
   RouteLocationOptions,
   RouteRecordRedirectOption,
+  RouteNamedLocation,
+  defineRoutes,
+  NamedLocationMap,
+  ExtractNamedRoutes,
   // route records
   _RouteRecordBase,
   RouteMeta,

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ export type {
   RouteLocationMatched,
   RouteLocationOptions,
   RouteRecordRedirectOption,
-  RouteNamedLocation,
   defineRoutes,
   NamedLocationMap,
   ExtractNamedRoutes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export type {
   RouteRecordRedirectOption,
   NamedLocationMap,
   ExtractNamedRoutes,
+  ExtractRoutes,
   // route records
   _RouteRecordBase,
   RouteMeta,

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export type {
   _ExtractFirstParamName,
   _RemoveRegexpFromParam,
   _RemoveUntilClosingPar,
+  JoinPath,
 } from './types/paths'
 export type { RouteNamedMap } from './types/named'
 export type { Config, RouterTyped } from './typedRouter'

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ export type {
   RouteLocationMatched,
   RouteLocationOptions,
   RouteRecordRedirectOption,
-  defineRoutes,
   NamedLocationMap,
   ExtractNamedRoutes,
   // route records

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export type {
   _RemoveUntilClosingPar,
 } from './types/paths'
 export type { RouteNamedMap } from './types/named'
+export type { Config, RouterTyped } from './typedRouter'
 
 export { createRouter } from './router'
 export type { Router, RouterOptions, RouterScrollBehavior } from './router'

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,6 @@ export type {
   RouteLocationMatched,
   RouteLocationOptions,
   RouteRecordRedirectOption,
-  NamedLocationMap,
-  ExtractNamedRoutes,
-  ExtractRoutes,
   // route records
   _RouteRecordBase,
   RouteMeta,

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export type {
   _RemoveRegexpFromParam,
   _RemoveUntilClosingPar,
 } from './types/paths'
+export type { RouteNamedMap } from './types/named'
 
 export { createRouter } from './router'
 export type { Router, RouterOptions, RouterScrollBehavior } from './router'

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export type {
   _ExtractFirstParamName,
   _RemoveRegexpFromParam,
   _RemoveUntilClosingPar,
-  JoinPath,
+  _JoinPath as JoinPath,
 } from './types/paths'
 export type { RouteNamedMap } from './types/named'
 export type { Config, RouterTyped } from './typedRouter'

--- a/src/injectionSymbols.ts
+++ b/src/injectionSymbols.ts
@@ -1,7 +1,7 @@
 import { InjectionKey, ComputedRef, Ref } from 'vue'
 import { RouteLocationNormalizedLoaded } from './types'
-import { Router } from './router'
 import { RouteRecordNormalized } from './matcher/types'
+import { RouterTyped } from './typedRouter'
 
 /**
  * RouteRecord being rendered by the closest ancestor Router View. Used for
@@ -30,7 +30,9 @@ export const viewDepthKey = Symbol(
  *
  * @internal
  */
-export const routerKey = Symbol(__DEV__ ? 'router' : '') as InjectionKey<Router>
+export const routerKey = Symbol(
+  __DEV__ ? 'router' : ''
+) as InjectionKey<RouterTyped>
 
 /**
  * Allows overriding the current route returned by `useRoute` in tests. rl

--- a/src/location.ts
+++ b/src/location.ts
@@ -165,8 +165,8 @@ export function isSameRouteLocationParams(
 }
 
 function isSameRouteLocationParamsValue(
-  a: RouteParamValue | RouteParamValue[],
-  b: RouteParamValue | RouteParamValue[]
+  a: RouteParamValue | readonly RouteParamValue[],
+  b: RouteParamValue | readonly RouteParamValue[]
 ): boolean {
   return Array.isArray(a)
     ? isEquivalentArray(a, b)

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -56,7 +56,7 @@ export interface RouterMatcher {
  * @param globalOptions - global route options
  */
 export function createRouterMatcher(
-  routes: RouteRecordRaw[],
+  routes: Readonly<RouteRecordRaw[]>,
   globalOptions: PathParserOptions
 ): RouterMatcher {
   // normalized ordered array of matchers

--- a/src/matcher/pathParserRanker.ts
+++ b/src/matcher/pathParserRanker.ts
@@ -1,7 +1,7 @@
 import { Token, TokenType } from './pathTokenizer'
 import { assign } from '../utils'
 
-export type PathParams = Record<string, string | string[]>
+export type PathParams = Record<string, string | readonly string[]>
 
 /**
  * A param in a url like `/users/:id`
@@ -241,13 +241,16 @@ export function tokensToParser(
           path += token.value
         } else if (token.type === TokenType.Param) {
           const { value, repeatable, optional } = token
-          const param: string | string[] = value in params ? params[value] : ''
+          const param: string | readonly string[] =
+            value in params ? params[value] : ''
 
           if (Array.isArray(param) && !repeatable)
             throw new Error(
               `Provided param "${value}" is an array but it is not repeatable (* or + modifiers)`
             )
-          const text: string = Array.isArray(param) ? param.join('/') : param
+          const text: string = Array.isArray(param)
+            ? (param as string[]).join('/')
+            : (param as string)
           if (!text) {
             if (optional) {
               // if we have more than one optional param like /:a?-static and there are more segments, we don't need to

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,8 +13,6 @@ import {
   RouteLocationOptions,
   MatcherLocationRaw,
   RouteParams,
-  RouteNamedLocation,
-  NamedLocationMap,
 } from './types'
 import { RouterHistory, HistoryState, NavigationType } from './history/common'
 import {

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,6 +14,7 @@ import {
   MatcherLocationRaw,
   RouteParams,
   RouteLocationNamedRaw,
+  RouteLocationPathRaw,
 } from './types'
 import { RouterHistory, HistoryState, NavigationType } from './history/common'
 import {
@@ -260,7 +261,7 @@ export interface Router<Options extends RouterOptions = RouterOptions> {
   >(
     to: RouteNamedMapGeneric extends RouteMap
       ? RouteLocationRaw
-      : RouteLocationNamedRaw<RouteMap, Name>
+      : RouteLocationNamedRaw<RouteMap, Name> | RouteLocationPathRaw | string
   ): Promise<NavigationFailure | void | undefined>
 
   /**
@@ -275,7 +276,7 @@ export interface Router<Options extends RouterOptions = RouterOptions> {
   >(
     to: RouteNamedMapGeneric extends RouteMap
       ? RouteLocationRaw
-      : RouteLocationNamedRaw<RouteMap, Name>
+      : RouteLocationNamedRaw<RouteMap, Name> | RouteLocationPathRaw | string
   ): Promise<NavigationFailure | void | undefined>
 
   /**
@@ -1185,9 +1186,7 @@ export function createRouter<Options extends RouterOptions>(
     resolve,
     options,
 
-    // @ts-expect-error: FIXME: can't type this one correctly without too much hussle
     push,
-    // @ts-expect-error: same
     replace,
     go,
     back: () => go(-1),

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,6 +13,8 @@ import {
   RouteLocationOptions,
   MatcherLocationRaw,
   RouteParams,
+  RouteNamedLocation,
+  NamedLocationMap,
 } from './types'
 import { RouterHistory, HistoryState, NavigationType } from './history/common'
 import {
@@ -253,6 +255,16 @@ export interface Router {
    * @param to - Route location to navigate to
    */
   push(to: RouteLocationRaw): Promise<NavigationFailure | void | undefined>
+  /**
+   * Programmatically navigate to a new URL by pushing an entry in the history
+   * stack.
+   *
+   * @param to - typed route location
+   */
+  push<T extends keyof NamedLocationMap>(
+    to: RouteNamedLocation<T>
+  ): Promise<NavigationFailure | void | undefined>
+
   /**
    * Programmatically navigate to a new URL by replacing the current entry in
    * the history stack.

--- a/src/router.ts
+++ b/src/router.ts
@@ -255,13 +255,6 @@ export interface Router {
    * @param to - Route location to navigate to
    */
   push(to: RouteLocationRaw): Promise<NavigationFailure | void | undefined>
-  /**
-   * Programmatically navigate to a new URL by pushing an entry in the history
-   * stack.
-   *
-   * @param to - typed route location
-   */
-  // push(to: RouteNamedLocation): Promise<NavigationFailure | void | undefined>
 
   /**
    * Programmatically navigate to a new URL by replacing the current entry in

--- a/src/router.ts
+++ b/src/router.ts
@@ -254,15 +254,15 @@ export interface Router {
    *
    * @param to - Route location to navigate to
    */
-  push(to: RouteLocationRaw): Promise<NavigationFailure | void | undefined>
+  // push(to: RouteLocationRaw): Promise<NavigationFailure | void | undefined>
   /**
    * Programmatically navigate to a new URL by pushing an entry in the history
    * stack.
    *
    * @param to - typed route location
    */
-  push<T extends keyof NamedLocationMap>(
-    to: RouteNamedLocation<T>
+  push(
+    to: RouteNamedLocation
   ): Promise<NavigationFailure | void | undefined>
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -254,16 +254,14 @@ export interface Router {
    *
    * @param to - Route location to navigate to
    */
-  // push(to: RouteLocationRaw): Promise<NavigationFailure | void | undefined>
+  push(to: RouteLocationRaw): Promise<NavigationFailure | void | undefined>
   /**
    * Programmatically navigate to a new URL by pushing an entry in the history
    * stack.
    *
    * @param to - typed route location
    */
-  push(
-    to: RouteNamedLocation
-  ): Promise<NavigationFailure | void | undefined>
+  // push(to: RouteNamedLocation): Promise<NavigationFailure | void | undefined>
 
   /**
    * Programmatically navigate to a new URL by replacing the current entry in

--- a/src/router.ts
+++ b/src/router.ts
@@ -185,7 +185,7 @@ export interface RouterOptions extends PathParserOptions {
 /**
  * Router instance
  */
-export interface Router {
+export interface Router<Options extends RouterOptions = RouterOptions> {
   /**
    * @internal
    */
@@ -197,7 +197,7 @@ export interface Router {
   /**
    * Original options object passed to create the Router
    */
-  readonly options: RouterOptions
+  readonly options: Options
 
   /**
    * Allows turning off the listening of history events. This is a low level api for micro-frontends.
@@ -360,7 +360,9 @@ export interface Router {
  *
  * @param options - {@link RouterOptions}
  */
-export function createRouter(options: RouterOptions): Router {
+export function createRouter<Options extends RouterOptions>(
+  options: Options
+): Router<Options> {
   const matcher = createRouterMatcher(options.routes, options)
   const parseQuery = options.parseQuery || originalParseQuery
   const stringifyQuery = options.stringifyQuery || originalStringifyQuery
@@ -1157,7 +1159,7 @@ export function createRouter(options: RouterOptions): Router {
   let started: boolean | undefined
   const installedApps = new Set<App>()
 
-  const router: Router = {
+  const router: Router<Options> = {
     currentRoute,
     listening: true,
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -128,7 +128,7 @@ export interface RouterOptions extends PathParserOptions {
   /**
    * Initial list of routes that should be added to the router.
    */
-  routes: RouteRecordRaw[]
+  routes: Readonly<RouteRecordRaw[]>
   /**
    * Function to control scrolling when navigating between pages. Can return a
    * Promise to delay scrolling. Check {@link ScrollBehavior}.

--- a/src/typedRouter.ts
+++ b/src/typedRouter.ts
@@ -1,0 +1,7 @@
+import { Router } from './router'
+
+export interface Config {
+  // Router: unknown
+}
+
+export type RouterTyped = Config extends Record<'Router', infer R> ? R : Router

--- a/src/typedRouter.ts
+++ b/src/typedRouter.ts
@@ -1,5 +1,26 @@
-import { Router } from './router'
+import type { Router } from './router'
 
+/**
+ * Vue Router Configuration that allows to add global types for better type support.
+ *
+ * @example
+ *
+ * ```ts
+ * const router = createRouter({
+ *   // ...
+ *   routes: [
+ *     // ...
+ *   ] as const // IMPORTANT
+ * })
+ *
+ * declare module 'vue-router' {
+ *   export interface Config {
+ *     // allow global functions to get a typed router
+ *     Router: typeof router
+ *   }
+ * }
+ * ```
+ */
 export interface Config {
   // Router: unknown
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,13 @@ import { RouteRecord, RouteRecordNormalized } from '../matcher/types'
 import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
 
+export {
+  RouteNamedLocation,
+  NamedLocationMap,
+  defineRoutes,
+  ExtractNamedRoutes,
+} from './named'
+
 export type Lazy<T> = () => Promise<T>
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -216,10 +216,6 @@ export interface _RouteRecordBase extends PathParserOptions {
   redirect?: RouteRecordRedirectOption
 
   /**
-   * Array of nested routes.
-   */
-  children?: RouteRecordRaw[]
-  /**
    * Aliases for the record. Allows defining extra paths that will behave like a
    * copy of the record. Allows having paths shorthands like `/users/:id` and
    * `/u/:id`. All `alias` and `path` values must share the same params.
@@ -298,7 +294,7 @@ export interface RouteRecordSingleViewWithChildren extends _RouteRecordBase {
   /**
    * Array of nested routes.
    */
-  children: RouteRecordRaw[]
+  children: Readonly<RouteRecordRaw[]>
 
   /**
    * Allow passing down params as props to the component rendered by `router-view`.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -199,14 +199,15 @@ export type _RouteRecordProps =
  * Common properties among all kind of {@link RouteRecordRaw}
  * @internal
  */
-export interface _RouteRecordBase extends PathParserOptions {
+export interface _RouteRecordBase<Path extends string = string>
+  extends PathParserOptions {
   /**
    * Path of the record. Should start with `/` unless the record is the child of
    * another record.
    *
    * @example `/users/:id` matches `/users/1` as well as `/users/posva`.
    */
-  path: string
+  path: Path
 
   /**
    * Where to redirect if the route is directly matched. The redirection happens
@@ -269,7 +270,8 @@ export type RouteRecordRedirectOption =
 /**
  * Route Record defining one single component with the `component` option.
  */
-export interface RouteRecordSingleView extends _RouteRecordBase {
+export interface RouteRecordSingleView<Path extends string = string>
+  extends _RouteRecordBase<Path> {
   /**
    * Component to display when the URL matches this route.
    */
@@ -284,7 +286,8 @@ export interface RouteRecordSingleView extends _RouteRecordBase {
 /**
  * Route Record defining one single component with a nested view.
  */
-export interface RouteRecordSingleViewWithChildren extends _RouteRecordBase {
+export interface RouteRecordSingleViewWithChildren<Path extends string = string>
+  extends _RouteRecordBase<Path> {
   /**
    * Component to display when the URL matches this route.
    */
@@ -305,7 +308,8 @@ export interface RouteRecordSingleViewWithChildren extends _RouteRecordBase {
 /**
  * Route Record defining multiple named components with the `components` option.
  */
-export interface RouteRecordMultipleViews extends _RouteRecordBase {
+export interface RouteRecordMultipleViews<Path extends string = string>
+  extends _RouteRecordBase<Path> {
   /**
    * Components to display when the URL matches this route. Allow using named views.
    */
@@ -323,7 +327,9 @@ export interface RouteRecordMultipleViews extends _RouteRecordBase {
 /**
  * Route Record defining multiple named components with the `components` option and children.
  */
-export interface RouteRecordMultipleViewsWithChildren extends _RouteRecordBase {
+export interface RouteRecordMultipleViewsWithChildren<
+  Path extends string = string
+> extends _RouteRecordBase<Path> {
   /**
    * Components to display when the URL matches this route. Allow using named views.
    */
@@ -344,18 +350,19 @@ export interface RouteRecordMultipleViewsWithChildren extends _RouteRecordBase {
  * Route Record that defines a redirect. Cannot have `component` or `components`
  * as it is never rendered.
  */
-export interface RouteRecordRedirect extends _RouteRecordBase {
+export interface RouteRecordRedirect<Path extends string = string>
+  extends _RouteRecordBase<Path> {
   redirect: RouteRecordRedirectOption
   component?: never
   components?: never
 }
 
-export type RouteRecordRaw =
-  | RouteRecordSingleView
-  | RouteRecordSingleViewWithChildren
-  | RouteRecordMultipleViews
-  | RouteRecordMultipleViewsWithChildren
-  | RouteRecordRedirect
+export type RouteRecordRaw<Path extends string = string> =
+  | RouteRecordSingleView<Path>
+  | RouteRecordSingleViewWithChildren<Path>
+  | RouteRecordMultipleViews<Path>
+  | RouteRecordMultipleViewsWithChildren<Path>
+  | RouteRecordRedirect<Path>
 
 /**
  * Initial route location where the router is. Can be used in navigation guards

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
 import { NamedLocationMap } from './named'
 
-export { NamedLocationMap, defineRoutes, ExtractNamedRoutes } from './named'
+export { NamedLocationMap, ExtractNamedRoutes } from './named'
 
 export type Lazy<T> = () => Promise<T>
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,9 +72,11 @@ export interface LocationAsName {
 /**
  * @internal
  */
-export interface LocationAsRelativeRaw {
-  name?: {} extends NamedLocationMap ? RouteRecordName : keyof NamedLocationMap
-  params?: RouteParamsRaw
+export interface LocationAsRelativeRaw<
+  T extends keyof NamedLocationMap = keyof NamedLocationMap
+> {
+  name?: {} extends NamedLocationMap ? RouteRecordName : T
+  params?: {} extends NamedLocationMap ? RouteParamsRaw : NamedLocationMap[T]
 }
 
 export interface LocationAsRelative {
@@ -218,6 +220,10 @@ export interface _RouteRecordBase extends PathParserOptions {
    */
   redirect?: RouteRecordRedirectOption
 
+  /**
+   * Array of nested routes.
+   */
+  children?: RouteRecordRaw[] | Readonly<RouteRecordRaw[]>
   /**
    * Aliases for the record. Allows defining extra paths that will behave like a
    * copy of the record. Allows having paths shorthands like `/users/:id` and

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,8 +6,6 @@ import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
 import { RouteNamedMapGeneric } from './named'
 
-export { NamedLocationMap, ExtractNamedRoutes, ExtractRoutes } from './named'
-
 export type Lazy<T> = () => Promise<T>
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,7 +79,7 @@ export interface LocationAsRelativeRaw<
 }
 
 // this one didn't work 🤔
-// export type _LocationAsRelativeRaw<
+// export type LocationAsRelativeRaw<
 //   RouteMap extends RouteNamedMapGeneric = RouteNamedMapGeneric
 // > = {
 //   [N in keyof RouteMap]: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -218,7 +218,7 @@ export interface _RouteRecordBase extends PathParserOptions {
   /**
    * Array of nested routes.
    */
-  children?: RouteRecordRaw[] | Readonly<RouteRecordRaw[]>
+  children?: RouteRecordRaw[]
   /**
    * Aliases for the record. Allows defining extra paths that will behave like a
    * copy of the record. Allows having paths shorthands like `/users/:id` and

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
 import { NamedLocationMap } from './named'
 
-export { NamedLocationMap, ExtractNamedRoutes } from './named'
+export { NamedLocationMap, ExtractNamedRoutes, ExtractRoutes } from './named'
 
 export type Lazy<T> = () => Promise<T>
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ import { Ref, ComponentPublicInstance, Component, DefineComponent } from 'vue'
 import { RouteRecord, RouteRecordNormalized } from '../matcher/types'
 import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
+import { NamedLocationMap } from './named'
 
 export {
   RouteNamedLocation,
@@ -72,7 +73,7 @@ export interface LocationAsName {
  * @internal
  */
 export interface LocationAsRelativeRaw {
-  name?: RouteRecordName
+  name?: {} extends NamedLocationMap ? RouteRecordName : keyof NamedLocationMap
   params?: RouteParamsRaw
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,16 @@ export interface LocationAsRelativeRaw<
     : RouteMap[Name]['paramsRaw']
 }
 
+// this one didn't work 🤔
+// export type _LocationAsRelativeRaw<
+//   RouteMap extends RouteNamedMapGeneric = RouteNamedMapGeneric
+// > = {
+//   [N in keyof RouteMap]: {
+//     name?: N
+//     params?: RouteMap[N]['paramsRaw']
+//   }
+// }[keyof RouteMap]
+
 export interface LocationAsRelative<
   RouteMap extends RouteNamedMapGeneric = RouteNamedMapGeneric,
   Name extends keyof RouteMap = keyof RouteMap

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,12 +6,7 @@ import { HistoryState } from '../history/common'
 import { NavigationFailure } from '../errors'
 import { NamedLocationMap } from './named'
 
-export {
-  RouteNamedLocation,
-  NamedLocationMap,
-  defineRoutes,
-  ExtractNamedRoutes,
-} from './named'
+export { NamedLocationMap, defineRoutes, ExtractNamedRoutes } from './named'
 
 export type Lazy<T> = () => Promise<T>
 export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,14 +1,98 @@
-import { RouteLocationOptions, RouteRecordRaw } from '.'
+import { RouteLocationOptions, RouteRecordRaw, _RouteRecordBase } from '.'
+
+// export type ExtractNameRoute<T extends Readonly<RouteRecordRaw>> =
+//   | ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : never)
+//   | ([T] extends [{ children: Readonly<RouteRecordRaw[]> }]
+//       ? ExtractNamedRoutes<T['children']>
+//       : never)
+
+export type ExtractNamedRoute<T extends Readonly<_RouteRecordBase>> = [
+  T
+] extends [{ name: string; readonly children?: any[] }]
+  ? { [K in T['name']]: unknown } &
+      ([T['children']] extends [Readonly<Array<_RouteRecordBase>>]
+        ? ExtractNamedRoutes<T['children']>
+        : {})
+  : never
 
 export type ExtractNamedRoutes<
-  T extends Array<RouteRecordRaw>
-> = T extends Array<infer R>
-  ? [R] extends [{ name: string /*params?: infer Params*/ }]
-    ? {
-        [K in R['name']]: unknown /*TODO add params*/ /*R['params'] extends Params ? Params : Params*/
-      }
-    : never
+  T extends Readonly<Array<_RouteRecordBase>> | undefined
+> = T extends Readonly<Array<infer R>>
+  ? // ? [R] extends [{ name: string /*params?: infer Params*/ }]
+    [R] extends [_RouteRecordBase]
+    ? ExtractNamedRoute<R>
+    : {}
   : never
+
+// const routes = [
+//   {
+//     path: 'my-path',
+//     name: 'test',
+//     component: Comp,
+//   },
+//   {
+//     path: 'my-path',
+//     name: 'my-other-path',
+//     component: Comp,
+//   },
+//   {
+//     path: 'random',
+//     name: 'tt',
+//     children: [
+//       {
+//         path: 'random-child',
+//         name: 'random-child',
+//         component: Comp,
+//       },
+//     ],
+//   },
+// ] as const
+
+// type TypedRoutes = ExtractNamedRoutes<typeof routes>
+
+// declare const Comp: () => any
+
+// const routes = [
+//   {
+//     path: 'my-path',
+//     name: 'test',
+//     component: Comp,
+//   },
+//   {
+//     path: 'my-path',
+//     // name: 'my-other-path',
+//     component: Comp,
+//   },
+// ] as const
+
+// type XXX = ExtractNamedRoutes<
+//   Readonly<
+//     [
+//       {
+//         path: 'ttt'
+//         name: 'sddsd'
+//         component: any
+//         children: [
+//           {
+//             path: 'ttt'
+//             name: 'child'
+//             component: any
+//           },
+//           {
+//             path: 'ttt'
+//             name: 'child-other'
+//             component: any
+//           }
+//         ]
+//       }
+//     ]
+//   >
+// >
+
+// interface XXW extends XXX {}
+
+// const xxx2: XXW
+// type TypedRoutes = ExtractNamedRoutes<typeof routes>
 
 //   export type ExtractNamedRoutes<
 //   T extends Array<RouteRecordRaw> | Readonly<Array<RouteRecordRaw>>
@@ -40,25 +124,25 @@ export interface RouteNamedLocation<
   // params: NamedLocationMap[T]
 }
 
-declare const r: [
-  {
-    name: 'test'
-    params: {
-      number: 1
-    }
-  },
-  {
-    name: 'LOL'
-    params: {
-      sss: 'sss'
-    }
-  },
-  {
-    name: 'other'
-  },
-  {
-    path: 'ssss'
-  }
-]
+// declare const r: [
+//   {
+//     name: 'test'
+//     params: {
+//       number: 1
+//     }
+//   },
+//   {
+//     name: 'LOL'
+//     params: {
+//       sss: 'sss'
+//     }
+//   },
+//   {
+//     name: 'other'
+//   },
+//   {
+//     path: 'ssss'
+//   }
+// ]
 
-declare const x: ExtractNamedRoutes<typeof r>
+// declare const x: ExtractNamedRoutes<typeof r>

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,4 +1,6 @@
-import { Router } from '../router'
+import type { RouteRecordRaw } from '.'
+import type { Router } from '../router'
+import { JoinPath, ParamsFromPath } from './paths'
 
 /**
  * This will flat the routes into an object with `key` === `router.name`
@@ -43,3 +45,36 @@ export type ExtractRoutes<T extends Router> = ExtractNamedRoutes<
  * ```
  */
 export interface NamedLocationMap {}
+
+export type RouteNamedMap<
+  Routes extends Readonly<RouteRecordRaw[]>,
+  Prefix extends string = ''
+> = Routes extends readonly [infer R, ...infer Rest]
+  ? Rest extends Readonly<RouteRecordRaw[]>
+    ? (R extends {
+        name?: infer Name
+        path: infer Path
+        children?: infer Children
+      }
+        ? Path extends string
+          ? (Name extends string
+              ? {
+                  [N in Name]: ParamsFromPath<JoinPath<Prefix, Path>>
+                }
+              : {
+                  // NO_NAME: 1
+                }) &
+              (Children extends Readonly<RouteRecordRaw[]>
+                ? RouteNamedMap<Children, JoinPath<Prefix, Path>>
+                : {
+                    // NO_CHILDREN: 1
+                  })
+          : never // Path must be a string
+        : {
+            // EMPTY: 1
+          }) &
+        RouteNamedMap<Rest>
+    : never // R must be a valid route record
+  : {
+      // END: 1
+    }

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -33,10 +33,11 @@ export function defineRoutes<
 }
 export interface NamedLocationMap {}
 
-export interface RouteNamedLocation<T extends keyof NamedLocationMap>
-  extends RouteLocationOptions {
+export interface RouteNamedLocation<
+  T extends keyof NamedLocationMap = keyof NamedLocationMap
+> extends RouteLocationOptions {
   name: T
-  params: NamedLocationMap[T]
+  // params: NamedLocationMap[T]
 }
 
 declare const r: [

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -7,35 +7,6 @@ export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
         ? ExtractNamedRoutes<T['children']>
         : {})
 
-// declare const test: ExtractNamedRoutes<
-//   [
-//     {
-//       path: 'my-path'
-//       name: 'test'
-//       children: []
-//     },
-//     {
-//       path: 'my-path'
-//       name: 'my-other-path'
-//       // children: []
-//     },
-//     {
-//       path: 'random'
-//       name: 'tt'
-//       children: [
-//         {
-//           path: 'random-child'
-//           name: 'random-child'
-//         }
-//       ]
-//     }
-//   ]
-// >
-// test
-// test['my-other-path']
-// test.test, test.tt
-// test['random-child']
-
 export function defineRoutes<
   T extends Array<RouteRecordRaw | Readonly<RouteRecordRaw>>
 >(routes: T): ExtractNamedRoutes<T> {

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,0 +1,63 @@
+import { RouteLocationOptions, RouteRecordRaw } from '.'
+
+export type ExtractNamedRoutes<
+  T extends Array<RouteRecordRaw>
+> = T extends Array<infer R>
+  ? [R] extends [{ name: string /*params?: infer Params*/ }]
+    ? {
+        [K in R['name']]: unknown /*TODO add params*/ /*R['params'] extends Params ? Params : Params*/
+      }
+    : never
+  : never
+
+//   export type ExtractNamedRoutes<
+//   T extends Array<RouteRecordRaw> | Readonly<Array<RouteRecordRaw>>
+// > = T extends Array<infer R>
+//   ? [R] extends [{ name: string /*params?: infer Params*/ }]
+//     ? {
+//         [K in R['name']]: unknown /*TODO add params*/ /*R['params'] extends Params ? Params : Params*/
+//       }
+//     : never
+//   : T extends Readonly<Array<infer R>>
+//   ? [R] extends [{ name: string /*params?: infer Params*/ }]
+//     ? {
+//         [K in R['name']]: unknown /*TODO add params*/ /*R['params'] extends Params ? Params : Params*/
+//       }
+//     : never
+//   : never
+
+export function defineRoutes<
+  T extends Array<RouteRecordRaw | Readonly<RouteRecordRaw>>
+>(routes: T): ExtractNamedRoutes<T> {
+  return routes as any
+}
+export interface NamedLocationMap {}
+
+export interface RouteNamedLocation<T extends keyof NamedLocationMap>
+  extends RouteLocationOptions {
+  name: T
+  params: NamedLocationMap[T]
+}
+
+declare const r: [
+  {
+    name: 'test'
+    params: {
+      number: 1
+    }
+  },
+  {
+    name: 'LOL'
+    params: {
+      sss: 'sss'
+    }
+  },
+  {
+    name: 'other'
+  },
+  {
+    path: 'ssss'
+  }
+]
+
+declare const x: ExtractNamedRoutes<typeof r>

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,28 +1,7 @@
 import { RouteRecordRaw, _RouteRecordBase } from '.'
 
-type OptionalPropertyNames<T> = {
-  [K in keyof T]-?: {} extends { [P in K]: T[K] } ? K : never
-}[keyof T]
-
-type SpreadProperties<L, R, K extends keyof L & keyof R> = {
-  [P in K]: L[P] | Exclude<R[P], undefined>
-}
-
-type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
-
-type SpreadTwo<L, R> = Id<
-  Pick<L, Exclude<keyof L, keyof R>> &
-    Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
-    Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
-    SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>
->
-
-type Spread<A extends readonly [...any]> = A extends [infer L, ...infer R]
-  ? SpreadTwo<L, Spread<R>>
-  : unknown
-
 export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
-  ? ExtractNamedRoutes<NamedRoutes<U>>
+  ? ExtractNamedRoutes<RouteFix<U>>
   : ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : {}) &
       ([T] extends [{ children?: undefined | unknown | any }]
         ? T['children'] extends undefined
@@ -30,7 +9,8 @@ export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
           : ExtractNamedRoutes<T['children']>
         : {})
 
-type RouteFiller<T> = T extends { name: string; children: any }
+// Needed to populate the missing props
+type RouteFix<T> = T extends { name: string; children: any }
   ? T
   : T extends { name: string }
   ? T & { children: never[] }
@@ -38,62 +18,60 @@ type RouteFiller<T> = T extends { name: string; children: any }
   ? T & { name: '' }
   : { name: ''; children: never }
 
-export type NamedRoutes<T> = RouteFiller<T>
+// // declare const xxx: NamedRoutes<
+// //   | {
+// //       name: 'LOL'
+// //     }
+// //   | { name: 'xxx' }
+// //   | { children: {} }
+// // >
+// // xxx.name
 
-// declare const xxx: NamedRoutes<
-//   | {
-//       name: 'LOL'
+// declare const typed: ExtractNamedRoutes<
+//   [
+//     {
+//       path: 'my-path'
+//       name: 'test'
+//       // children must be declared :(
+//       // children: []
+//     },
+//     {
+//       path: 'my-path'
+//       name: 'my-other-path'
+//       // children must be declared :(
+//       // children: []
+//     },
+//     {
+//       path: 'random'
+//       name: 'tt'
+//       children: [
+//         {
+//           path: 'random-child'
+//           name: 'random-child'
+//           // children: []
+//         }
+//       ]
+//     },
+//     {
+//       name: '1'
+//       children: [
+//         {
+//           name: '2'
+//           children: [{ name: '3'; children: [{ name: '4' }] }]
+//         }
+//       ]
 //     }
-//   | { name: 'xxx' }
-//   | { children: {} }
+//   ]
 // >
-// xxx.name
 
-declare const typed: ExtractNamedRoutes<
-  [
-    {
-      path: 'my-path'
-      name: 'test'
-      // children must be declared :(
-      // children: []
-    },
-    {
-      path: 'my-path'
-      name: 'my-other-path'
-      // children must be declared :(
-      // children: []
-    },
-    {
-      path: 'random'
-      name: 'tt'
-      children: [
-        {
-          path: 'random-child'
-          name: 'random-child'
-          // children: []
-        }
-      ]
-    },
-    {
-      name: '1'
-      children: [
-        {
-          name: '2'
-          children: [{ name: '3'; children: [{ name: '4' }] }]
-        }
-      ]
-    }
-  ]
->
-
-typed['my-other-path']
-typed['random-child']
-typed.test
-typed.tt
-typed[1]
-typed[2]
-typed[3]
-typed[4]
+// typed['my-other-path']
+// typed['random-child']
+// typed.test
+// typed.tt
+// typed[1]
+// typed[2]
+// typed[3]
+// typed[4]
 
 export function defineRoutes<
   T extends Array<RouteRecordRaw | Readonly<RouteRecordRaw>>

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,5 +1,7 @@
-import { RouteRecordRaw, _RouteRecordBase } from '.'
-
+/**
+ * This will flat the routes into an object with `key` === `router.name`
+ * and the value will be `unknown` since we don't have way to describe params types
+ */
 export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
   ? ExtractNamedRoutes<RouteFix<U>>
   : ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : {}) &
@@ -13,70 +15,25 @@ export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
 type RouteFix<T> = T extends { name: string; children: any }
   ? T
   : T extends { name: string }
-  ? T & { children: never[] }
+  ? T & { children: never }
   : T extends { children: any }
-  ? T & { name: '' }
-  : { name: ''; children: never }
+  ? T & { name: never }
+  : { name: never; children: never }
 
-// // declare const xxx: NamedRoutes<
-// //   | {
-// //       name: 'LOL'
-// //     }
-// //   | { name: 'xxx' }
-// //   | { children: {} }
-// // >
-// // xxx.name
-
-// declare const typed: ExtractNamedRoutes<
-//   [
-//     {
-//       path: 'my-path'
-//       name: 'test'
-//       // children must be declared :(
-//       // children: []
-//     },
-//     {
-//       path: 'my-path'
-//       name: 'my-other-path'
-//       // children must be declared :(
-//       // children: []
-//     },
-//     {
-//       path: 'random'
-//       name: 'tt'
-//       children: [
-//         {
-//           path: 'random-child'
-//           name: 'random-child'
-//           // children: []
-//         }
-//       ]
-//     },
-//     {
-//       name: '1'
-//       children: [
-//         {
-//           name: '2'
-//           children: [{ name: '3'; children: [{ name: '4' }] }]
-//         }
-//       ]
-//     }
-//   ]
-// >
-
-// typed['my-other-path']
-// typed['random-child']
-// typed.test
-// typed.tt
-// typed[1]
-// typed[2]
-// typed[3]
-// typed[4]
-
-export function defineRoutes<
-  T extends Array<RouteRecordRaw | Readonly<RouteRecordRaw>>
->(routes: T): ExtractNamedRoutes<T> {
-  return routes as any
-}
-
+/**
+ * Used to define typed named locations
+ * @example
+ * ```ts
+ * declare module 'vue-router' {
+ *   interface NamedLocationMap {
+ *    // 'home' no params
+ *    home: {}
+ *    // 'product' `{id: string}` required parameter
+ *    product: {
+ *      id: string
+ *    }
+ *   }
+ * }
+ * ```
+ */
 export interface NamedLocationMap {}

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,148 +1,45 @@
-import { RouteLocationOptions, RouteRecordRaw, _RouteRecordBase } from '.'
+import { RouteRecordRaw, _RouteRecordBase } from '.'
 
-// export type ExtractNameRoute<T extends Readonly<RouteRecordRaw>> =
-//   | ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : never)
-//   | ([T] extends [{ children: Readonly<RouteRecordRaw[]> }]
-//       ? ExtractNamedRoutes<T['children']>
-//       : never)
-
-export type ExtractNamedRoute<T extends Readonly<_RouteRecordBase>> = [
-  T
-] extends [{ name: string; readonly children?: any[] }]
-  ? { [K in T['name']]: unknown } &
-      ([T['children']] extends [Readonly<Array<_RouteRecordBase>>]
+export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
+  ? ExtractNamedRoutes<U>
+  : ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : {}) &
+      ([T] extends [{ children?: undefined | unknown | any }]
         ? ExtractNamedRoutes<T['children']>
         : {})
-  : never
 
-export type ExtractNamedRoutes<
-  T extends Readonly<Array<_RouteRecordBase>> | undefined
-> = T extends Readonly<Array<infer R>>
-  ? // ? [R] extends [{ name: string /*params?: infer Params*/ }]
-    [R] extends [_RouteRecordBase]
-    ? ExtractNamedRoute<R>
-    : {}
-  : never
-
-// const routes = [
-//   {
-//     path: 'my-path',
-//     name: 'test',
-//     component: Comp,
-//   },
-//   {
-//     path: 'my-path',
-//     name: 'my-other-path',
-//     component: Comp,
-//   },
-//   {
-//     path: 'random',
-//     name: 'tt',
-//     children: [
-//       {
-//         path: 'random-child',
-//         name: 'random-child',
-//         component: Comp,
-//       },
-//     ],
-//   },
-// ] as const
-
-// type TypedRoutes = ExtractNamedRoutes<typeof routes>
-
-// declare const Comp: () => any
-
-// const routes = [
-//   {
-//     path: 'my-path',
-//     name: 'test',
-//     component: Comp,
-//   },
-//   {
-//     path: 'my-path',
-//     // name: 'my-other-path',
-//     component: Comp,
-//   },
-// ] as const
-
-// type XXX = ExtractNamedRoutes<
-//   Readonly<
-//     [
-//       {
-//         path: 'ttt'
-//         name: 'sddsd'
-//         component: any
-//         children: [
-//           {
-//             path: 'ttt'
-//             name: 'child'
-//             component: any
-//           },
-//           {
-//             path: 'ttt'
-//             name: 'child-other'
-//             component: any
-//           }
-//         ]
-//       }
-//     ]
-//   >
+// declare const test: ExtractNamedRoutes<
+//   [
+//     {
+//       path: 'my-path'
+//       name: 'test'
+//       children: []
+//     },
+//     {
+//       path: 'my-path'
+//       name: 'my-other-path'
+//       // children: []
+//     },
+//     {
+//       path: 'random'
+//       name: 'tt'
+//       children: [
+//         {
+//           path: 'random-child'
+//           name: 'random-child'
+//         }
+//       ]
+//     }
+//   ]
 // >
-
-// interface XXW extends XXX {}
-
-// const xxx2: XXW
-// type TypedRoutes = ExtractNamedRoutes<typeof routes>
-
-//   export type ExtractNamedRoutes<
-//   T extends Array<RouteRecordRaw> | Readonly<Array<RouteRecordRaw>>
-// > = T extends Array<infer R>
-//   ? [R] extends [{ name: string /*params?: infer Params*/ }]
-//     ? {
-//         [K in R['name']]: unknown /*TODO add params*/ /*R['params'] extends Params ? Params : Params*/
-//       }
-//     : never
-//   : T extends Readonly<Array<infer R>>
-//   ? [R] extends [{ name: string /*params?: infer Params*/ }]
-//     ? {
-//         [K in R['name']]: unknown /*TODO add params*/ /*R['params'] extends Params ? Params : Params*/
-//       }
-//     : never
-//   : never
+// test
+// test['my-other-path']
+// test.test, test.tt
+// test['random-child']
 
 export function defineRoutes<
   T extends Array<RouteRecordRaw | Readonly<RouteRecordRaw>>
 >(routes: T): ExtractNamedRoutes<T> {
   return routes as any
 }
+
 export interface NamedLocationMap {}
-
-export interface RouteNamedLocation<
-  T extends keyof NamedLocationMap = keyof NamedLocationMap
-> extends RouteLocationOptions {
-  name: T
-  // params: NamedLocationMap[T]
-}
-
-// declare const r: [
-//   {
-//     name: 'test'
-//     params: {
-//       number: 1
-//     }
-//   },
-//   {
-//     name: 'LOL'
-//     params: {
-//       sss: 'sss'
-//     }
-//   },
-//   {
-//     name: 'other'
-//   },
-//   {
-//     path: 'ssss'
-//   }
-// ]
-
-// declare const x: ExtractNamedRoutes<typeof r>

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,11 +1,99 @@
 import { RouteRecordRaw, _RouteRecordBase } from '.'
 
+type OptionalPropertyNames<T> = {
+  [K in keyof T]-?: {} extends { [P in K]: T[K] } ? K : never
+}[keyof T]
+
+type SpreadProperties<L, R, K extends keyof L & keyof R> = {
+  [P in K]: L[P] | Exclude<R[P], undefined>
+}
+
+type Id<T> = T extends infer U ? { [K in keyof U]: U[K] } : never
+
+type SpreadTwo<L, R> = Id<
+  Pick<L, Exclude<keyof L, keyof R>> &
+    Pick<R, Exclude<keyof R, OptionalPropertyNames<R>>> &
+    Pick<R, Exclude<OptionalPropertyNames<R>, keyof L>> &
+    SpreadProperties<L, R, OptionalPropertyNames<R> & keyof L>
+>
+
+type Spread<A extends readonly [...any]> = A extends [infer L, ...infer R]
+  ? SpreadTwo<L, Spread<R>>
+  : unknown
+
 export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
-  ? ExtractNamedRoutes<U>
+  ? ExtractNamedRoutes<NamedRoutes<U>>
   : ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : {}) &
       ([T] extends [{ children?: undefined | unknown | any }]
-        ? ExtractNamedRoutes<T['children']>
+        ? T['children'] extends undefined
+          ? {}
+          : ExtractNamedRoutes<T['children']>
         : {})
+
+type RouteFiller<T> = T extends { name: string; children: any }
+  ? T
+  : T extends { name: string }
+  ? T & { children: never[] }
+  : T extends { children: any }
+  ? T & { name: '' }
+  : { name: ''; children: never }
+
+export type NamedRoutes<T> = RouteFiller<T>
+
+// declare const xxx: NamedRoutes<
+//   | {
+//       name: 'LOL'
+//     }
+//   | { name: 'xxx' }
+//   | { children: {} }
+// >
+// xxx.name
+
+declare const typed: ExtractNamedRoutes<
+  [
+    {
+      path: 'my-path'
+      name: 'test'
+      // children must be declared :(
+      // children: []
+    },
+    {
+      path: 'my-path'
+      name: 'my-other-path'
+      // children must be declared :(
+      // children: []
+    },
+    {
+      path: 'random'
+      name: 'tt'
+      children: [
+        {
+          path: 'random-child'
+          name: 'random-child'
+          // children: []
+        }
+      ]
+    },
+    {
+      name: '1'
+      children: [
+        {
+          name: '2'
+          children: [{ name: '3'; children: [{ name: '4' }] }]
+        }
+      ]
+    }
+  ]
+>
+
+typed['my-other-path']
+typed['random-child']
+typed.test
+typed.tt
+typed[1]
+typed[2]
+typed[3]
+typed[4]
 
 export function defineRoutes<
   T extends Array<RouteRecordRaw | Readonly<RouteRecordRaw>>

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,50 +1,5 @@
 import type { RouteParams, RouteParamsRaw, RouteRecordRaw } from '.'
-import type { Router } from '../router'
 import type { JoinPath, ParamsFromPath, ParamsRawFromPath } from './paths'
-
-/**
- * This will flat the routes into an object with `key` === `router.name`
- * and the value will be `unknown` since we don't have way to describe params types
- */
-export type ExtractNamedRoutes<T> = [T] extends [ReadonlyArray<infer U>]
-  ? ExtractNamedRoutes<RouteFix<U>>
-  : ([T] extends [{ name: string }] ? { [K in T['name']]: unknown } : {}) &
-      ([T] extends [{ children?: undefined | unknown | any }]
-        ? T['children'] extends undefined
-          ? {}
-          : ExtractNamedRoutes<T['children']>
-        : {})
-
-// Needed to populate the missing props
-type RouteFix<T> = T extends { name: string; children: any }
-  ? T
-  : T extends { name: string }
-  ? T & { children: never }
-  : T extends { children: any }
-  ? T & { name: never }
-  : { name: never; children: never }
-
-export type ExtractRoutes<T extends Router> = ExtractNamedRoutes<
-  T['options']['routes']
->
-
-/**
- * Used to define typed named locations
- * @example
- * ```ts
- * declare module 'vue-router' {
- *   interface NamedLocationMap {
- *    // 'home' no params
- *    home: {}
- *    // 'product' `{id: string}` required parameter
- *    product: {
- *      id: string
- *    }
- *   }
- * }
- * ```
- */
-export interface NamedLocationMap {}
 
 export type RouteNamedMap<
   Routes extends Readonly<RouteRecordRaw[]>,

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,6 +1,6 @@
-import type { RouteRecordRaw } from '.'
+import type { RouteParams, RouteParamsRaw, RouteRecordRaw } from '.'
 import type { Router } from '../router'
-import { JoinPath, ParamsFromPath } from './paths'
+import type { JoinPath, ParamsFromPath, ParamsRawFromPath } from './paths'
 
 /**
  * This will flat the routes into an object with `key` === `router.name`
@@ -57,13 +57,20 @@ export type RouteNamedMap<
         children?: infer Children
       }
         ? Path extends string
-          ? (Name extends string
+          ? (Name extends string | symbol
               ? {
-                  [N in Name]: ParamsFromPath<JoinPath<Prefix, Path>>
+                  [N in Name]: {
+                    // name: N
+                    params: ParamsFromPath<JoinPath<Prefix, Path>>
+                    // TODO: ParamsRawFromPath
+                    paramsRaw: ParamsRawFromPath<JoinPath<Prefix, Path>>
+                    path: JoinPath<Prefix, Path>
+                  }
                 }
               : {
                   // NO_NAME: 1
                 }) &
+              // Recurse children
               (Children extends Readonly<RouteRecordRaw[]>
                 ? RouteNamedMap<Children, JoinPath<Prefix, Path>>
                 : {
@@ -73,8 +80,18 @@ export type RouteNamedMap<
         : {
             // EMPTY: 1
           }) &
-        RouteNamedMap<Rest>
+        RouteNamedMap<Rest, Prefix>
     : never // R must be a valid route record
   : {
       // END: 1
     }
+
+export type RouteNamedMapGeneric = Record<
+  string | symbol | number,
+  // TODO: use RouteParams, RouteParamRaw
+  {
+    params: RouteParams
+    paramsRaw: RouteParamsRaw
+    path: string
+  }
+>

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,5 +1,5 @@
 import type { RouteParams, RouteParamsRaw, RouteRecordRaw } from '.'
-import type { JoinPath, ParamsFromPath, ParamsRawFromPath } from './paths'
+import type { _JoinPath, ParamsFromPath, ParamsRawFromPath } from './paths'
 
 export type RouteNamedMap<
   Routes extends Readonly<RouteRecordRaw[]>,
@@ -16,10 +16,10 @@ export type RouteNamedMap<
               ? {
                   [N in Name]: {
                     // name: N
-                    params: ParamsFromPath<JoinPath<Prefix, Path>>
+                    params: ParamsFromPath<_JoinPath<Prefix, Path>>
                     // TODO: ParamsRawFromPath
-                    paramsRaw: ParamsRawFromPath<JoinPath<Prefix, Path>>
-                    path: JoinPath<Prefix, Path>
+                    paramsRaw: ParamsRawFromPath<_JoinPath<Prefix, Path>>
+                    path: _JoinPath<Prefix, Path>
                   }
                 }
               : {
@@ -27,7 +27,7 @@ export type RouteNamedMap<
                 }) &
               // Recurse children
               (Children extends Readonly<RouteRecordRaw[]>
-                ? RouteNamedMap<Children, JoinPath<Prefix, Path>>
+                ? RouteNamedMap<Children, _JoinPath<Prefix, Path>>
                 : {
                     // NO_CHILDREN: 1
                   })
@@ -43,7 +43,6 @@ export type RouteNamedMap<
 
 export type RouteNamedMapGeneric = Record<
   string | symbol | number,
-  // TODO: use RouteParams, RouteParamRaw
   {
     params: RouteParams
     paramsRaw: RouteParamsRaw

--- a/src/types/named.ts
+++ b/src/types/named.ts
@@ -1,3 +1,5 @@
+import { Router } from '../router'
+
 /**
  * This will flat the routes into an object with `key` === `router.name`
  * and the value will be `unknown` since we don't have way to describe params types
@@ -19,6 +21,10 @@ type RouteFix<T> = T extends { name: string; children: any }
   : T extends { children: any }
   ? T & { name: never }
   : { name: never; children: never }
+
+export type ExtractRoutes<T extends Router> = ExtractNamedRoutes<
+  T['options']['routes']
+>
 
 /**
  * Used to define typed named locations

--- a/src/types/paths.ts
+++ b/src/types/paths.ts
@@ -86,18 +86,38 @@ export type _ModifierParamValue<
   ? _ParamValueZeroOrOne<isRaw>
   : never
 
+/**
+ * Utility type for raw and non raw params like :id+
+ *
+ * @internal
+ */
 export type _ParamValueOneOrMore<isRaw extends boolean> = true extends isRaw
   ? readonly [string | number, ...(string | number)[]]
   : readonly [string, ...string[]]
 
+/**
+ * Utility type for raw and non raw params like :id*
+ *
+ * @internal
+ */
 export type _ParamValueZeroOrMore<isRaw extends boolean> = true extends isRaw
   ? readonly (string | number)[] | undefined | null
   : readonly string[] | undefined | null
 
+/**
+ * Utility type for raw and non raw params like :id?
+ *
+ * @internal
+ */
 export type _ParamValueZeroOrOne<isRaw extends boolean> = true extends isRaw
   ? RouteParamValueRaw
   : string
 
+/**
+ * Utility type for raw and non raw params like :id
+ *
+ * @internal
+ */
 export type _ParamValue<isRaw extends boolean> = true extends isRaw
   ? string | number
   : string
@@ -188,7 +208,7 @@ export type _ExtractFirstParamName<S extends string> =
     : S
 
 /**
- * Join an array of param values
+ * Join an array of param values for repeated params
  *
  * @internal
  */
@@ -215,7 +235,7 @@ export type _ParamToString<V> = V extends null | undefined | readonly string[]
   ? ''
   : V extends string
   ? V
-  : `oops`
+  : never
 
 /**
  * Possible values for a Modifier.
@@ -299,7 +319,12 @@ export type ParamKeysFromPath<P extends string = string> = string extends P
   ? readonly PathParserParamKey[] // Generic version
   : _ExtractPathParamKeys<_RemoveRegexpFromParam<P>>
 
-export type JoinPath<
+/**
+ * Joins a prefix and a path putting a `/` between them when necessary
+ *
+ * @internal
+ */
+export type _JoinPath<
   Prefix extends string,
   Path extends string
 > = Path extends `/${string}`

--- a/src/types/paths.ts
+++ b/src/types/paths.ts
@@ -1,4 +1,16 @@
 /**
+ * Extract an object of params given a path like `/users/:id`.
+ *
+ * @example
+ * ```ts
+ * type P = ParamsFromPath<'/:id/b/:c*'> // { id: string; c?: string[] }
+ * ```
+ */
+export type ParamsFromPath<P extends string = string> = string extends P
+  ? PathParams // Generic version
+  : _ExtractParamsPath<_RemoveRegexpFromParam<P>>
+
+/**
  * Generic possible params from a path (after parsing).
  */
 export type PathParams = Record<
@@ -55,13 +67,6 @@ export type _ExtractParamsPath<P extends string> =
         : _ParamToObject<PP, ''>) &
         _ExtractParamsPath<Rest>
     : {}
-
-/**
- * Extract an object of params given a path like `/users/:id`.
- */
-export type ParamsFromPath<P extends string = string> = string extends P
-  ? PathParams // Generic version
-  : _ExtractParamsPath<_RemoveRegexpFromParam<P>>
 
 /**
  * Gets the possible type of a param based on its modifier M.
@@ -275,3 +280,12 @@ export type _ExtractPathParamKeys<P extends string> =
 export type ParamKeysFromPath<P extends string = string> = string extends P
   ? readonly PathParserParamKey[] // Generic version
   : _ExtractPathParamKeys<_RemoveRegexpFromParam<P>>
+
+export type JoinPath<
+  Prefix extends string,
+  Path extends string
+> = Path extends `/${string}`
+  ? Path
+  : '' extends Prefix
+  ? never
+  : `${Prefix}${Prefix extends `${string}/` ? '' : '/'}${Path}`

--- a/src/useApi.ts
+++ b/src/useApi.ts
@@ -1,13 +1,13 @@
 import { inject } from 'vue'
 import { routerKey, routeLocationKey } from './injectionSymbols'
-import { Router } from './router'
+import { RouterTyped } from './typedRouter'
 import { RouteLocationNormalizedLoaded } from './types'
 
 /**
  * Returns the router instance. Equivalent to using `$router` inside
  * templates.
  */
-export function useRouter(): Router {
+export function useRouter(): RouterTyped {
   return inject(routerKey)!
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,9 @@
-import { RouteParams, RouteComponent, RouteParamsRaw } from '../types'
+import {
+  RouteParams,
+  RouteComponent,
+  RouteParamsRaw,
+  RouteParamValueRaw,
+} from '../types'
 
 export * from './env'
 
@@ -16,7 +21,9 @@ export function applyToParams(
 
   for (const key in params) {
     const value = params[key]
-    newParams[key] = Array.isArray(value) ? value.map(fn) : fn(value)
+    newParams[key] = Array.isArray(value)
+      ? value.map(fn)
+      : fn(value as Exclude<RouteParamValueRaw, any[]>)
   }
 
   return newParams

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -1,5 +1,5 @@
-// export * from '../dist/vue-router'
-export * from '../src'
+export * from '../dist/vue-router'
+// export * from '../src'
 
 export function describe(_name: string, _fn: () => void): void
 export function expectType<T>(value: T): void

--- a/test-dts/index.d.ts
+++ b/test-dts/index.d.ts
@@ -1,4 +1,5 @@
-export * from '../dist/vue-router'
+// export * from '../dist/vue-router'
+export * from '../src'
 
 export function describe(_name: string, _fn: () => void): void
 export function expectType<T>(value: T): void

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -8,15 +8,11 @@ const routes = [
     path: 'my-path',
     name: 'test',
     component: Comp,
-    // children must be declared :(
-    children: [],
   },
   {
     path: 'my-path',
     name: 'my-other-path',
     component: Comp,
-    // children must be declared :(
-    children: [],
   },
   {
     path: 'random',
@@ -26,7 +22,6 @@ const routes = [
         path: 'random-child',
         name: 'random-child',
         component: Comp,
-        children: [],
       },
     ],
   },

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -1,9 +1,11 @@
-import { defineRoutes } from './index'
+// NOTE `ExtractNamedRoutes` is not exposed on build, you might need to add export to the type manually
+
+import { ExtractNamedRoutes, Router } from './index'
 import { DefineComponent } from 'vue'
 
 declare const Comp: DefineComponent
 
-const routes = defineRoutes([
+const routes = [
   {
     path: 'my-path',
     name: 'test',
@@ -19,11 +21,16 @@ const routes = defineRoutes([
   //   path: 'my-path',
   //   component: Comp,
   // } as const,
-])
+]
+
+type TypedRoutes = ExtractNamedRoutes<typeof routes>
 
 declare module './index' {
-  interface RouteMeta {
-    requiresAuth?: boolean
-    nested: { foo: string }
-  }
+  interface NamedLocationMap extends TypedRoutes {}
 }
+
+declare const router: Router
+
+router.push({
+  name: '',
+})

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -30,7 +30,12 @@ const routes = [
     children: [
       {
         name: '2',
-        children: [{ name: '3', children: [{ name: '4' }] }],
+        children: [
+          {
+            name: '3',
+            children: [{ name: '4' }, { path: '', children: [{ name: '5' }] }],
+          },
+        ],
       },
     ],
   },
@@ -46,6 +51,7 @@ typed[1]
 typed[2]
 typed[3]
 typed[4]
+typed[5]
 //@ts-expect-error
 typed['non-existing']
 

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -25,14 +25,36 @@ const routes = [
       },
     ],
   },
-] as const
+]
 
-type TypedRoutes = ExtractNamedRoutes<typeof routes>
+type TypedRoutes = ExtractNamedRoutes< [
+  {
+    path: 'my-path',
+    name: 'test',
+    // component: ,
+  },
+  {
+    path: 'my-path',
+    name: 'my-other-path',
+    // component: Comp,
+  },
+  {
+    path: 'random',
+    name: 'tt',
+    children: [
+      {
+        path: 'random-child',
+        name: 'random-child',
+        component: {},
+      },
+    ],
+  },
+]>
 
 declare module './index' {
-  interface NamedLocationMap {
+  interface NamedLocationMap  {
     'my-other-path': {
-      sss: number
+      sss:  number
     }
   }
 }
@@ -43,9 +65,9 @@ router.push({
   name: 'my-other-path',
   params: {
     sss: 1,
-    // @ts-expect-error
-    xxxx: '22',
-  },
+    // @ts-expect-error does not exist
+    xxxx: '22'
+  }
 })
 
 router.push({

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -8,11 +8,15 @@ const routes = [
     path: 'my-path',
     name: 'test',
     component: Comp,
+    // children must be declared :(
+    children: [],
   },
   {
     path: 'my-path',
     name: 'my-other-path',
     component: Comp,
+    // children must be declared :(
+    children: [],
   },
   {
     path: 'random',
@@ -22,39 +26,35 @@ const routes = [
         path: 'random-child',
         name: 'random-child',
         component: Comp,
+        children: [],
       },
     ],
   },
-]
-
-type TypedRoutes = ExtractNamedRoutes< [
   {
-    path: 'my-path',
-    name: 'test',
-    // component: ,
-  },
-  {
-    path: 'my-path',
-    name: 'my-other-path',
-    // component: Comp,
-  },
-  {
-    path: 'random',
-    name: 'tt',
+    name: '1',
     children: [
       {
-        path: 'random-child',
-        name: 'random-child',
-        component: {},
+        name: '2',
+        children: [{ name: '3' }],
       },
     ],
   },
-]>
+] as const
+
+declare const typed: ExtractNamedRoutes<typeof routes>
+
+typed['my-other-path']
+typed['random-child']
+typed.test
+typed.tt
+typed[1]
+typed[2]
+typed[3]
 
 declare module './index' {
-  interface NamedLocationMap  {
+  interface NamedLocationMap {
     'my-other-path': {
-      sss:  number
+      sss: number
     }
   }
 }
@@ -66,8 +66,8 @@ router.push({
   params: {
     sss: 1,
     // @ts-expect-error does not exist
-    xxxx: '22'
-  }
+    xxxx: '22',
+  },
 })
 
 router.push({

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -35,7 +35,7 @@ const routes = [
     children: [
       {
         name: '2',
-        children: [{ name: '3' }],
+        children: [{ name: '3', children: [{ name: '4' }] }],
       },
     ],
   },
@@ -50,6 +50,9 @@ typed.tt
 typed[1]
 typed[2]
 typed[3]
+typed[4]
+//@ts-expect-error
+typed['non-existing']
 
 declare module './index' {
   interface NamedLocationMap {

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -5,11 +5,10 @@ import {
   expectType,
   RouteNamedMap,
   RouterTyped,
-  Router,
   RouteLocationRaw,
+  JoinPath,
 } from './index'
 import { DefineComponent } from 'vue'
-import { JoinPath } from 'src/types/paths'
 
 declare const component: DefineComponent
 declare const components: { default: DefineComponent }
@@ -59,7 +58,7 @@ for (const method of methods) {
   r2[method]({ name: 'UserDetails', params: { id: '2' } })
   // accepts numbers
   r2[method]({ name: 'UserDetails', params: { id: 2 } })
-  // @ts-expect-error: fails an null
+  // @ts-expect-error: fails on null
   r2[method]({ name: 'UserDetails', params: { id: null } })
   // @ts-expect-error: and undefined
   r2[method]({ name: 'UserDetails', params: { id: undefined } })
@@ -77,10 +76,15 @@ for (const method of methods) {
   r2[method]({ name: Symbol() })
   // any path is still valid
   r2[method]('/path')
+  r2.push('/path')
+  r2.replace('/path')
   // relative push can have any of the params
   r2[method]({ params: { a: 2 } })
   r2[method]({ params: {} })
   r2[method]({ params: { opt: 'hey' } })
+  // FIXME: is it possible to support this version
+  // // @ts-expect-error: does not accept any params
+  // r2[method]({ name: 'nested', params: { eo: 'true' } })
 }
 
 r2.push({} as unknown as RouteLocationRaw)
@@ -133,8 +137,8 @@ expectType<{
   // @ts-expect-error
 }>(createMap(r2.options.routes))
 
-declare module '../src' {
-  // declare module '../dist/vue-router' {
+// declare module '../src' {
+declare module '../dist/vue-router' {
   export interface Config {
     Router: typeof r2
   }

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -30,13 +30,22 @@ const routes = [
 type TypedRoutes = ExtractNamedRoutes<typeof routes>
 
 declare module './index' {
-  interface NamedLocationMap extends TypedRoutes {}
+  interface NamedLocationMap {
+    'my-other-path': {
+      sss: number
+    }
+  }
 }
 
 declare const router: Router
 
 router.push({
   name: 'my-other-path',
+  params: {
+    sss: 1,
+    // @ts-expect-error
+    xxxx: '22',
+  },
 })
 
 router.push({

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -1,0 +1,29 @@
+import { defineRoutes } from './index'
+import { DefineComponent } from 'vue'
+
+declare const Comp: DefineComponent
+
+const routes = defineRoutes([
+  {
+    path: 'my-path',
+    name: 'test',
+    component: Comp,
+  } as const,
+  {
+    path: 'my-path',
+    name: 'my-other-path',
+    component: Comp,
+  } as const,
+
+  // {
+  //   path: 'my-path',
+  //   component: Comp,
+  // } as const,
+])
+
+declare module './index' {
+  interface RouteMeta {
+    requiresAuth?: boolean
+    nested: { foo: string }
+  }
+}

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -7,6 +7,7 @@ import {
   RouterTyped,
   RouteLocationRaw,
   JoinPath,
+  useRouter,
 } from './index'
 import { DefineComponent } from 'vue'
 
@@ -82,11 +83,16 @@ for (const method of methods) {
   r2[method]({ params: { a: 2 } })
   r2[method]({ params: {} })
   r2[method]({ params: { opt: 'hey' } })
+
+  // routes with no params
+  r2[method]({ name: 'nested' })
+  r2[method]({ name: 'nested', params: {} })
   // FIXME: is it possible to support this version
   // // @ts-expect-error: does not accept any params
   // r2[method]({ name: 'nested', params: { eo: 'true' } })
 }
 
+// still allow generics to be passed for convenience
 r2.push({} as unknown as RouteLocationRaw)
 r2.replace({} as unknown as RouteLocationRaw)
 
@@ -144,11 +150,7 @@ declare module '../dist/vue-router' {
   }
 }
 
-function getTypedRouter(): RouterTyped {
-  return {} as any
-}
-
-const typedRouter = getTypedRouter()
+const typedRouter = useRouter()
 // this one is true if we comment out the line with Router: typeof r2
 // expectType<Router>(typedRouter)
 expectType<typeof r2>(typedRouter)

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -1,4 +1,9 @@
-import { ExtractNamedRoutes, Router } from './index'
+import {
+  ExtractNamedRoutes,
+  Router,
+  ExtractRoutes,
+  createRouter,
+} from './index'
 import { DefineComponent } from 'vue'
 
 declare const Comp: DefineComponent
@@ -58,7 +63,7 @@ typed['non-existing']
 declare module './index' {
   interface NamedLocationMap {
     'my-other-path': {
-      sss: number
+      id: string
     }
   }
 }
@@ -68,9 +73,9 @@ declare const router: Router
 router.push({
   name: 'my-other-path',
   params: {
-    sss: 1,
+    id: '222',
     // @ts-expect-error does not exist
-    xxxx: '22',
+    nonExistent: '22',
   },
 })
 
@@ -78,3 +83,14 @@ router.push({
   // @ts-expect-error location name does not exist
   name: 'random-location',
 })
+
+const otherRouter = createRouter({
+  history: {} as any,
+  routes: [{ path: 'e', name: 'test', component: Comp }] as const,
+})
+
+declare const otherRoutes: ExtractRoutes<typeof otherRouter>
+
+otherRoutes.test
+// @ts-expect-error
+otherRoutes.test2

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -4,7 +4,6 @@ import {
   RouteRecordRaw,
   expectType,
   RouteNamedMap,
-  RouterTyped,
   RouteLocationRaw,
   JoinPath,
   useRouter,

--- a/test-dts/namedRoutes.test-d.ts
+++ b/test-dts/namedRoutes.test-d.ts
@@ -1,5 +1,3 @@
-// NOTE `ExtractNamedRoutes` is not exposed on build, you might need to add export to the type manually
-
 import { ExtractNamedRoutes, Router } from './index'
 import { DefineComponent } from 'vue'
 
@@ -10,18 +8,24 @@ const routes = [
     path: 'my-path',
     name: 'test',
     component: Comp,
-  } as const,
+  },
   {
     path: 'my-path',
     name: 'my-other-path',
     component: Comp,
-  } as const,
-
-  // {
-  //   path: 'my-path',
-  //   component: Comp,
-  // } as const,
-]
+  },
+  {
+    path: 'random',
+    name: 'tt',
+    children: [
+      {
+        path: 'random-child',
+        name: 'random-child',
+        component: Comp,
+      },
+    ],
+  },
+] as const
 
 type TypedRoutes = ExtractNamedRoutes<typeof routes>
 
@@ -32,5 +36,10 @@ declare module './index' {
 declare const router: Router
 
 router.push({
-  name: '',
+  name: 'my-other-path',
+})
+
+router.push({
+  // @ts-expect-error location name does not exist
+  name: 'random-location',
 })


### PR DESCRIPTION
WIP to support typescript named routes

![image](https://user-images.githubusercontent.com/4620458/114203756-59ebef80-9950-11eb-8c99-c265780a8523.png)


~~## Limitations
`ExtractNamedRoutes` needs all the routes to have `children:[]` declare if one has `children`.
All the routes must have `name`~~

Close #1160