### PR TITLE
Docs: Remove Vue School BTS 21 banner

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class="main-container" :class="{ 'has-top-banner': showTopBanner }">
-    <BannerTop v-if="showTopBanner" @close="closeBannerTop" />
+  <div class="main-container">
     <ParentLayout>
       <template #sidebar-top>
         <div class="sponsors sponsors-top">
@@ -42,31 +41,16 @@ import { defineAsyncComponent } from 'vue'
 import DefaultTheme from 'vitepress/dist/client/theme-default'
 import sponsors from '../components/sponsors.json'
 
-const BannerTop = defineAsyncComponent(() =>
-  import('../components/BannerTop.vue')
-)
-
 export default {
   name: 'Layout',
   components: {
-    ParentLayout: DefaultTheme.Layout,
-    BannerTop,
+    ParentLayout: DefaultTheme.Layout
   },
   data() {
     return {
-      sponsors,
-      showTopBanner: false,
+      sponsors
     }
-  },
-  mounted() {
-    this.showTopBanner = !localStorage.getItem('VS_BTS_BANNER_CLOSED')
-  },
-  methods: {
-    closeBannerTop() {
-      this.showTopBanner = false
-      localStorage.setItem('VS_BTS_BANNER_CLOSED', 1)
-    },
-  },
+  }
 }
 </script>
 


### PR DESCRIPTION
This PR removes the Vue School BTS banner from the top of next.router.vuejs.org.

The landing page will keep working after the promo ends, so the link (https://vueschool.io/sales/back-to-school?friend=vuerouter) will still be valid.