### PR TITLE
types(useRoute): add generic for params

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,7 +105,7 @@ export interface RouteLocationMatched extends RouteRecordNormalized {
  *
  * @internal
  */
-export interface _RouteLocationBase {
+export interface _RouteLocationBase<Params extends RouteParams = RouteParams> {
   /**
    * Percentage encoded pathname section of the URL.
    */
@@ -130,7 +130,7 @@ export interface _RouteLocationBase {
   /**
    * Object of decoded params extracted from the `path`.
    */
-  params: RouteParams
+  params: Params
   /**
    * Contains the location we were initially trying to access before ending up
    * on the current location.
@@ -146,7 +146,9 @@ export interface _RouteLocationBase {
 /**
  * {@link RouteLocationRaw} with
  */
-export interface RouteLocationNormalizedLoaded extends _RouteLocationBase {
+export interface RouteLocationNormalizedLoaded<
+  Params extends RouteParams = RouteParams
+> extends _RouteLocationBase<Params> {
   /**
    * Array of {@link RouteLocationMatched} containing only plain components (any
    * lazy-loaded components have been loaded and were replaced inside of the

--- a/src/useApi.ts
+++ b/src/useApi.ts
@@ -1,7 +1,7 @@
 import { inject } from 'vue'
 import { routerKey, routeLocationKey } from './injectionSymbols'
 import { Router } from './router'
-import { RouteLocationNormalizedLoaded } from './types'
+import { RouteLocationNormalizedLoaded, RouteParams } from './types'
 
 /**
  * Returns the router instance. Equivalent to using `$router` inside
@@ -15,6 +15,8 @@ export function useRouter(): Router {
  * Returns the current route location. Equivalent to using `$route` inside
  * templates.
  */
-export function useRoute(): RouteLocationNormalizedLoaded {
-  return inject(routeLocationKey)!
+export function useRoute<
+  Params extends RouteParams = RouteParams
+>(): RouteLocationNormalizedLoaded<Params> {
+  return inject<RouteLocationNormalizedLoaded<Params>>(routeLocationKey)!
 }


### PR DESCRIPTION
### Version
4.0.12

### Steps to reproduce
Pass params to function with typed arguments

![image](https://user-images.githubusercontent.com/30187840/137604039-186b749a-a626-45e3-a0f7-83d743b35635.png)

Error message
Argument of type 'string | string[]' is not assignable to parameter of type 'string'.
  Type 'string[]' is not assignable to type 'string'.

### What is expected?
Possability to pass generic for params types, like in react-router-dom hook useParams
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/09ce5bbfc2d507d35f6e8185a1f6a617bfca20fc/types/reach__router/index.d.ts#L182

### How will it look like
`type Params = {`
`    id: string`
`    type: ResourceType`
`}`
`const route = useRoute<Params>()`