### PR TITLE
feat(types): let property of `RouteParams` optional (fix #1184)

### DIFF
--- a/src/RouterLink.ts
+++ b/src/RouterLink.ts
@@ -302,8 +302,8 @@ function includesParams(
     } else {
       if (
         !Array.isArray(outerValue) ||
-        outerValue.length !== innerValue.length ||
-        innerValue.some((value, i) => value !== outerValue[i])
+        outerValue.length !== innerValue?.length ||
+        innerValue?.some((value, i) => value !== outerValue[i])
       )
         return false
     }

--- a/src/location.ts
+++ b/src/location.ts
@@ -158,7 +158,14 @@ export function isSameRouteLocationParams(
   if (Object.keys(a).length !== Object.keys(b).length) return false
 
   for (const key in a) {
-    if (!isSameRouteLocationParamsValue(a[key], b[key])) return false
+    const aValue = a[key],
+      bValue = b[key]
+    if (
+      aValue === undefined ||
+      bValue === undefined ||
+      !isSameRouteLocationParamsValue(aValue, bValue)
+    )
+      return false
   }
 
   return true

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,7 +32,9 @@ export type RouteParamValue = string
  * @internal
  */
 export type RouteParamValueRaw = RouteParamValue | number | null | undefined
-export type RouteParams = Record<string, RouteParamValue | RouteParamValue[]>
+export type RouteParams = {
+  [P in string]?: RouteParamValue | RouteParamValue[]
+}
 export type RouteParamsRaw = Record<
   string,
   RouteParamValueRaw | Exclude<RouteParamValueRaw, null | undefined>[]

--- a/test-dts/routeParams.test-d.ts
+++ b/test-dts/routeParams.test-d.ts
@@ -1,0 +1,7 @@
+import { RouteParams, RouteParamsRaw, expectType } from './index'
+
+const params: RouteParams | RouteParamsRaw = { name: 'value' }
+// @ts-expect-error
+expectType<undefined>(params.nonExist)
+// @ts-expect-error
+expectType<string>(params.name)


### PR DESCRIPTION
BREAKING CHANGE: Users will have to write undefined type guards against `route.param`

close #1184