### PR TITLE
fix: changeLocation error occurred when I use Vue and React in QianKun

### DIFF
--- a/src/history/html5.ts
+++ b/src/history/html5.ts
@@ -77,6 +77,15 @@ function useHistoryListeners(
     let delta = 0
 
     if (state) {
+      // handle scenarios where the state value is illegal, such as micro front-end scenarios that coexist with React
+      if (!state.current) {
+        state = assign({}, historyState.value, {
+          back: historyState.value.current,
+          current: to,
+          position: historyState.value.position + 1,
+        })
+      }
+
       currentLocation.value = to
       historyState.value = state
 


### PR DESCRIPTION
## issue

[Bug] changeLocation error occurred when I use Vue and React in QianKun (a micro frontend frame) 
​
I use `QianKun` as the micro front-end framework. The main app is based on `Vue3` and `vue-router@4.0.12`, and one of the sub apps is based on `React16`. The React sub app is loaded when I navigate to the route path `"/mfe-react-center/page2"`. And then i will click a button, by doing so, the app will navigate to another page of the React sub app, and the route path is `"/mfe-react-center/page3"`. Meanwhile, the vue-router of the main app catched the popstate event, and the `popStateHandler` will get the parameter `state`, but the data structure of the parameter `state` does not meet the requirements of `vue-router` because the `popstate event` is triggerred by the React sub app. finally, `historyState.value` will get an incorrect value.

```
{
  key: "furyvw",
  state: undefined
}
```

![企业微信截图_1637053160917.png](https://cdn.nlark.com/yuque/0/2021/png/319482/1637138446514-c08f1711-e878-4926-80df-63804de74b54.png#clientId=u3d30e086-b0dc-4&crop=0&crop=0&crop=1&crop=1&from=paste&height=583&id=u8e72a6b4&margin=%5Bobject%20Object%5D&name=%E4%BC%81%E4%B8%9A%E5%BE%AE%E4%BF%A1%E6%88%AA%E5%9B%BE_1637053160917.png&originHeight=583&originWidth=618&originalType=binary&ratio=1&rotation=0&showTitle=false&size=44486&status=done&style=none&taskId=u6d5a909c-dbd3-4f8b-a8f8-08698693607&title=&width=618)
​

An error occurred when I try to navigate to another page by clicking the menus of the main app. Instead of the expected `http://localhost:3000/mfe-vue-center/page4`, we get `http://localhost:3000undefined`.

```
Uncaught (in promise) DOMException: Failed to execute 'replace' on 'Location': 'http://localhost:3000undefined' is not a valid URL.
```

![vue-router错误.png](https://cdn.nlark.com/yuque/0/2021/png/319482/1637138303570-78de4b05-2aa2-495e-a3cf-83f2a11724b5.png#clientId=u3d30e086-b0dc-4&crop=0&crop=0&crop=1&crop=1&from=ui&id=u8d775e7b&margin=%5Bobject%20Object%5D&name=vue-router%E9%94%99%E8%AF%AF.png&originHeight=610&originWidth=802&originalType=binary&ratio=1&rotation=0&showTitle=false&size=22492&status=done&style=none&taskId=u37936f66-31c1-4c92-bed0-ad60b83f43f&title=)


I found the releated code of vue-router：

```
// source code of push method of vue-router
const currentState = assign(
  {}, 
  // use current history state to gracefully handle a wrong call to
  // history.replaceState
  // https://github.com/vuejs/vue-router-next/issues/366
  historyState.value,
  history.state,
  {
    forward: to,
    scroll: computeScrollPosition(),
  }
);
changeLocation(currentState.current, currentState, true);
const state = assign({}, buildState(currentLocation.value, to, null), { position: currentState.position + 1 }, data);
changeLocation(to, state, false);
```

As mentioned above, `historyState.value` refers to an incorrect value. When I navigate to another page through the menus of the main app, the `push` method of vue-router is executed, and the `currentState` gets a value without the property `current`, and then `changeLocation` is executed and get a value `http://localhost:3000undefined`. Obviously, the navigation will be failed.

Therefore, the core of the problem is that the route navigation within the React sub app is monitored by the `popStateHandler` of vue-router of the main app, but the `state` passed does not match the data structure expected by vue-router.
​

Although I could solve this problem by changing all the navigation scenarios of the React sub app to notify the main app and let the main app control the navigation, the change will be very invasive. And I think a lot of people will have the same problem when using micro front end, so I want to solve this problem through PR!
​

## PR

For the problem mentioned in the issue, I analyzed some code execution process of vue-router and got the solution.


Let's analyze the process of initialization and route navigation of vue-router to see how state changes.

**Step 1: Initialization analysis**
First, when the web application first loads, `history.state` has no value.
​
In history mode, the method `createWebHistory` will be called, and then the method `useHistoryStateNavigation` will be called. During the execution of method `useHistoryStateNavigation`, `currentLocation` and `historyState` will be initialized。

```
let currentLocation = {
  value: createCurrentLocation(base, location),
};
let historyState = { value: history.state };
```

Then we will check the value of `historyState.value`, and since there is no initial `history.state` value, we will perform a `changeLocation` method in replace mode, During the execution of method `changeLocation`, `historyState.value = state` will be executed, so `historyState` has a value.

So the value of `historyState.value` is going to look something like this:

```
{
  back: null,
  current: "/mfe-vue-center/page1"
  forward: null,
  position: 30,
  replaced: true,
  scroll: false
}
```

**Step 2: Click the main app menu and navigate by vue-router**

The `push` method will be called for navigation, and the value of parameter `to` is `"/mfe-react-center/page2"`. During the execution of method `push`, `currentState` will be computed, and the value is described below:

```
{
  back: null,
  current: "/mfe-vue-center/page1",
  forward: "/mfe-react-center/page2",
  position: 30,
  replaced: true,
  scroll: {left: 0, top: 0}
}
```

Then the first `changeLocation` method will be executed in replace mode. after the execution, `currentState` and `historyState.value` will get the same value.

```
changeLocation(currentState.current, currentState, true);
const state = assign({}, buildState(currentLocation.value, to, null), { position: currentState.position + 1 }, data);
changeLocation(to, state, false);
```

vue-router then calculates a new state by `buildState`. The logic behind `buildState` is to change the value of `back` and `current`. `back` receives the value of `currentLocation.value` and `current` receives the value of the parameter `to` passed through the `push` method.

the new value of `state` is described below:

```
{
  back: "/mfe-vue-center/page1",
  current: "/mfe-react-center/page2",
  forward: null,
  position: 31,
  replaced: false,
  scroll: null
}
```

Then a method `changeLocation(to, state, false)` is performed, and the value of `historyState.value` will be the same as the value of the new `state`.
​

The reason why `changeLocation` are performed twice is that the first time is mainly to correct the current `history.state` value to ensure the correctness of the `forward` property and facilitate subsequent `forward` operations. The second time is when the real `pushState` is performed based on the new `state` (`back` and `current` are updated on the second time). I have to say, this is a great design!

Finally, update the value of  `currentLocation` by `currentLocation.value = to`.

**Step 3: Navigate within the React sub app**
​

The react-router `push` method is triggered by clicking the button inside the React sub app, hoping to jump to the path `"/mfe-react-center/page3"`. And `popStateHandler` of vue-router in the main app is then triggered, and the value of the parameter `state` is described below.

```
{  key: "paf114",  state: undefined }
```

`historyState.value` records the value of `state`.

**Step 4: Click the main app menu and navigate to another page by vue-router**

Then I will click the main app menu and navigate to another page. `push` method will be executed, and the value of `currentState` will be like this: 

```
{  forward: "/mfe-vue-center/page4",  key: "paf114",  scroll: {left: 0, top: 0},  state: undefined }
```

Because the `currentState.current` is `undefined`, performing the first `changeLocation` will throw an error. We will get a url with a value `"http://localhost:3000undefined"`, and `location.assign` will be executed, this will cause the browser to jump to the Error page.

```
Uncaught (in promise) DOMException: Failed to execute 'replace' on 'Location': 'http://localhost:3000undefined' is not a valid URL.
```

Therefore, the solution is to verify the validity of the state. If the state is not valid, the valid state should be calculated by other reliable values.

We can hack like this：

```
if (!state.current) {
  state = assign({}, historyState.value, {
    back: historyState.value.current,
    current: to,
    position: historyState.value.position + 1,
  })
}
```

The idea is to update the value of `back` and `current` attributes of `state` based on the value of `historyState.value.current` and `to`.