### PR TITLE
docs: remove old link

### DIFF
--- a/docs/guide/essentials/passing-props.md
+++ b/docs/guide/essentials/passing-props.md
@@ -78,5 +78,3 @@ const routes = [
 The URL `/search?q=vue` would pass `{query: 'vue'}` as props to the `SearchUser` component.
 
 Try to keep the `props` function stateless, as it's only evaluated on route changes. Use a wrapper component if you need state to define the props, that way vue can react to state changes.
-
-For advanced usage, check out the [example](https://github.com/vuejs/vue-router/blob/dev/examples/route-props/app.js).


### PR DESCRIPTION
The link was leading to the old vue-router 3.x example.
Removed misleading line