### PR TITLE
docs(lazy-loading): manualChunks as proper link

### DIFF
--- a/docs/guide/advanced/lazy-loading.md
+++ b/docs/guide/advanced/lazy-loading.md
@@ -59,14 +59,13 @@ webpack will group any async module with the same chunk name into the same async
 
 ### With Vite
 
-In Vite you can define the chunks under the [`rollupOptions`](https://vitejs.dev/config/#build-rollupoptions):
+In Vite you can define the chunks under the [`rollupOptions`](https://vitejs.dev/config/#build-rollupoptions) using [`output.manualChunks`](https://rollupjs.org/guide/en/#outputmanualchunks):
 
 ```js
 // vite.config.js
 export default defineConfig({
   build: {
     rollupOptions: {
-      // https://rollupjs.org/guide/en/#outputmanualchunks
       output: {
         manualChunks: {
           'group-user': [


### PR DESCRIPTION
Allows users to click on it without extracting from the example source code and copying it to the clipboard.