### PR TITLE
docs(sidebar): rename "Navigation Results"

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -179,7 +179,7 @@ const config = defineConfig({
                 link: '/guide/advanced/extending-router-link.html',
               },
               {
-                text: 'Navigation Failures',
+                text: 'Navigation Results',
                 link: '/guide/advanced/navigation-failures.html',
               },
               {


### PR DESCRIPTION
The original entry "Navigation Failures" is too narrow with respect to the page content. I was reading the first paragraphs and wondering how this is related to failures. Only a later section deals with failures. 