### PR TITLE
Update explanation on HTML mode

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -39,7 +39,7 @@ const router = createRouter({
 })
 ```
 
-When using history mode, the URL will look "normal," e.g. `https://example.com/user/id`. Beautiful!
+When using HTML mode, the URL will look "normal," e.g. `https://example.com/user/id`. Beautiful!
 
 Here comes a problem, though: Since our app is a single page client side app, without a proper server configuration, the users will get a 404 error if they access `https://example.com/user/id` directly in their browser. Now that's ugly.
 

--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -39,7 +39,7 @@ const router = createRouter({
 })
 ```
 
-When using HTML mode, the URL will look "normal," e.g. `https://example.com/user/id`. Beautiful!
+When using `createWebHistory()`, the URL will look "normal," e.g. `https://example.com/user/id`. Beautiful!
 
 Here comes a problem, though: Since our app is a single page client side app, without a proper server configuration, the users will get a 404 error if they access `https://example.com/user/id` directly in their browser. Now that's ugly.
 


### PR DESCRIPTION
On the HTML mode section: i think it's good to specify  HTML mode and not history mode this will make the sentence sound more clear **When using HTML mode, the URL will look "normal," e.g. `https://example.com/user/id`. Beautiful!**