### PR TITLE
docs: document strict and sensitive option

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -849,17 +849,16 @@ Route record that can be provided by the user when adding routes via the [`route
 - **See Also**: [Passing props to Route Components](../guide/essentials/passing-props.md)
 
 ### sensitive
-- **Type**: `PathParserOptions` (Optional) 
+- **Type**: `boolean` (Optional) 
 - **Details**: 
 
-  Enables a more restrictive route matching. Makes the route case sensitive. `sensitive` can be passed on route level and now also when creating the router with `createRouter()` on the top level.
+  Makes the route matching case sensitive, defaults to `false`. Note this can also be set at a route level.
 
 ### strict
-- **Type**: `PathParserOptions` (Optional) 
+- **Type**: `boolean` (Optional) 
 - **Details**: 
 
-  Enables a more restrictive route matching. Disallows the check of an optional `/` at the end of the path. `strict` can be passed on route level and now also when creating the router with `createRouter()` on the top level.
-
+  Strictly checks the presence or absence of a trailing slash (`/`) at the end of the path. Defaults to `false` meaning that by default a route `/users` matches both `/users` and `/users/`. Note this can also be set at a route level.
 
 ### meta
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -848,6 +848,19 @@ Route record that can be provided by the user when adding routes via the [`route
 
 - **See Also**: [Passing props to Route Components](../guide/essentials/passing-props.md)
 
+### sensitive
+- **Type**: `PathParserOptions` (Optional) 
+- **Details**: 
+
+  Enables a more restrictive route matching. Makes the route case sensitive. `sensitive` can be passed on route level and now also when creating the router with `createRouter()` on the top level.
+
+### strict
+- **Type**: `PathParserOptions` (Optional) 
+- **Details**: 
+
+  Enables a more restrictive route matching. Disallows the check of an optional `/` at the end of the path. `strict` can be passed on route level and now also when creating the router with `createRouter()` on the top level.
+
+
 ### meta
 
 - **Type**: [`RouteMeta`](#routemeta) (Optional)

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -80,15 +80,17 @@ const routes = [
 As mentioned in [the migration guide](../migration/index#removal-of-pathtoregexpoptions). `pathToRegexpOptions` and `caseSensitive` have been replaced with `sensitive` and `strict` options. Beside passing them per route, they can now also be directly passed when creating the router with `createRouter()`:
 ```js
 const router = createRouter({
-  history: createWebHistory("/"),
-  [
-    // will match /users and /users/posva
-    { path: '/users/:userId', sensitive: true },
-    // will match /users and /users/42
-    { path: '/users/:userId(\\d+)?' },
+  history: createWebHistory(),
+  routes: [
+    // will match /users/posva but not:
+    // - /users/posva/ because of strict: true
+    // - /Users/posva because of sensitive: true
+    { path: '/users/:id', sensitive: true },
+    // will match /users, /Users, and /users/42 but not /users/ or /users/42/
+    { path: '/users/:id?' },
   ]
   strict: true,
-});
+})
 ```
 
 ## Optional parameters

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -76,6 +76,7 @@ const routes = [
 ```
 
 ## Sensitive and strict route options 
+
 As mentioned in this section [Removal of PathToRegexOptions](../migration/index#removal-of-pathtoregexpoptions). `pathToRegexpOptions` and `caseSensitive` have been replaced with `sensitive` and `strict` options. Beside passing them per route, they can now also be directly passed when creating the router with `createRouter()` like this. 
 ```js
 const router = createRouter({

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -75,6 +75,22 @@ const routes = [
 ]
 ```
 
+## Sensitive and strict route options 
+As mentioned in this section [Removal of PathToRegexOptions](../migration/index#removal-of-pathtoregexpoptions). `pathToRegexpOptions` and `caseSensitive` have been replaced with `sensitive` and `strict` options. Beside passing them per route, they can now also be directly passed when creating the router with `createRouter()` like this. 
+```js
+const router = createRouter({
+  history: createWebHistory("/"),
+  [
+    // will match /users and /users/posva
+    { path: '/users/:userId', sensitive: true },
+    // will match /users and /users/42
+    { path: '/users/:userId(\\d+)?' },
+  ]
+  strict: true,
+});
+```
+
+
 ## Optional parameters
 
 You can also mark a parameter as optional by using the `?` modifier (0 or 1):

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -92,6 +92,18 @@ const router = createRouter({
   strict: true,
 })
 ```
+And if they are applied directly on a specific route:
+```js
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    // will match /users/posva/ but not /Users/posva
+    { path: '/users/:id', sensitive: true },
+    // will match /users, /Users, and /users/42 but not /users/42/
+    { path: '/users/:id?', strict: true },
+  ]
+})
+```
 
 ## Optional parameters
 

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -91,7 +91,6 @@ const router = createRouter({
 });
 ```
 
-
 ## Optional parameters
 
 You can also mark a parameter as optional by using the `?` modifier (0 or 1):

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -77,7 +77,7 @@ const routes = [
 
 ## Sensitive and strict route options 
 
-As mentioned in this section [Removal of PathToRegexOptions](../migration/index#removal-of-pathtoregexpoptions). `pathToRegexpOptions` and `caseSensitive` have been replaced with `sensitive` and `strict` options. Beside passing them per route, they can now also be directly passed when creating the router with `createRouter()` like this. 
+As mentioned in [the migration guide](../migration/index#removal-of-pathtoregexpoptions). `pathToRegexpOptions` and `caseSensitive` have been replaced with `sensitive` and `strict` options. Beside passing them per route, they can now also be directly passed when creating the router with `createRouter()`:
 ```js
 const router = createRouter({
   history: createWebHistory("/"),

--- a/docs/guide/essentials/route-matching-syntax.md
+++ b/docs/guide/essentials/route-matching-syntax.md
@@ -77,7 +77,8 @@ const routes = [
 
 ## Sensitive and strict route options 
 
-As mentioned in [the migration guide](../migration/index#removal-of-pathtoregexpoptions). `pathToRegexpOptions` and `caseSensitive` have been replaced with `sensitive` and `strict` options. Beside passing them per route, they can now also be directly passed when creating the router with `createRouter()`:
+By default, all routes are case-insensitive and match routes with or without a trailing slash. e.g. a route `/users` matches `/users`, `/users/`, and even `/Users/`. This behavior can be configured with the `strict` and `sensitive` options, they can be set both at a router and route level:
+
 ```js
 const router = createRouter({
   history: createWebHistory(),
@@ -89,19 +90,7 @@ const router = createRouter({
     // will match /users, /Users, and /users/42 but not /users/ or /users/42/
     { path: '/users/:id?' },
   ]
-  strict: true,
-})
-```
-And if they are applied directly on a specific route:
-```js
-const router = createRouter({
-  history: createWebHistory(),
-  routes: [
-    // will match /users/posva/ but not /Users/posva
-    { path: '/users/:id', sensitive: true },
-    // will match /users, /Users, and /users/42 but not /users/42/
-    { path: '/users/:id?', strict: true },
-  ]
+  strict: true, // applies to all routes
 })
 ```
 


### PR DESCRIPTION
- [x] Add section to documentation like requested in #1277  https://next.router.vuejs.org/guide/essentials/route-matching-syntax.html
- [x] Link documentation between new documentation and migration guide from Vue 2 router
- [x] Update examples in documentation to match the correct implementation and configuration in router
- [x] Update RouteRecordRaw API docs with `sensitive` and `strict`

Hi @posva 
I have two open points that I would need your feedback on:
- Is the example with setting` strict true` on the top level and setting `sensitive` on a specific route enough or should I add more examples? Or do you prefer a different example?
- In the corresponding closed issue it's mentioned that  documentation should also be on the API docs for the RouteRecordRaw - is this needed from your perspective? 

I will complete this change once I have your response. 

Thanks and regards!