### PR TITLE
docs: Invalid logo link (#1309) [skip ci]

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -67,7 +67,7 @@ export function addDevtools(app: App, router: Router, matcher: RouterMatcher) {
       label: 'Vue Router',
       packageName: 'vue-router',
       homepage: 'https://next.router.vuejs.org/',
-      logo: 'https://vuejs.org/images/icons/favicon-96x96.png',
+      logo: 'https://router.vuejs.org/logo.png',
       componentStateTypes: ['Routing'],
       app,
     },

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -66,7 +66,7 @@ export function addDevtools(app: App, router: Router, matcher: RouterMatcher) {
       id: 'org.vuejs.router' + (id ? '.' + id : ''),
       label: 'Vue Router',
       packageName: 'vue-router',
-      homepage: 'https://next.router.vuejs.org/',
+      homepage: 'https://router.vuejs.org',
       logo: 'https://router.vuejs.org/logo.png',
       componentStateTypes: ['Routing'],
       app,


### PR DESCRIPTION
The logo link is no longer valid due to the update of the official website。