### PR TITLE
docs: add redirect guard example

### DIFF
--- a/docs/guide/advanced/navigation-guards.md
+++ b/docs/guide/advanced/navigation-guards.md
@@ -28,14 +28,18 @@ And can optionally return any of the following values:
 - `false`: cancel the current navigation. If the browser URL was changed (either manually by the user or via back button), it will be reset to that of the `from` route.
 - A [Route Location](../../api/#routelocationraw): Redirect to a different location by passing a route location as if you were calling [`router.push()`](../../api/#push), which allows you to pass options like `replace: true` or `name: 'home'`. The current navigation is dropped and a new one is created with the same `from`.
 
-```js
-router.beforeEach(async (to, from) => {
-  if (!someConditional(to)) return {
-    name: 'AlternativeRoute',
-    replace: true
-  }
-})
-```
+  ```js
+  router.beforeEach(async (to, from) => {
+    if (
+      // make sure the user is authenticated
+      !isAuthenticated &&
+      // ❗️ Avoid an infinite redirect
+      to.name !== 'Login'
+    ) {
+      // redirect the user to the login page
+      return { name: 'Login' }
+    }
+  })
 
 It's also possible to throw an `Error` if an unexpected situation was met. This will also cancel the navigation and call any callback registered via [`router.onError()`](../../api/#onerror).
 

--- a/docs/guide/advanced/navigation-guards.md
+++ b/docs/guide/advanced/navigation-guards.md
@@ -28,6 +28,15 @@ And can optionally return any of the following values:
 - `false`: cancel the current navigation. If the browser URL was changed (either manually by the user or via back button), it will be reset to that of the `from` route.
 - A [Route Location](../../api/#routelocationraw): Redirect to a different location by passing a route location as if you were calling [`router.push()`](../../api/#push), which allows you to pass options like `replace: true` or `name: 'home'`. The current navigation is dropped and a new one is created with the same `from`.
 
+```js
+router.beforeEach(async (to, from) => {
+  if (!someConditional(to)) return {
+    name: 'AlternativeRoute',
+    replace: true
+  }
+})
+```
+
 It's also possible to throw an `Error` if an unexpected situation was met. This will also cancel the navigation and call any callback registered via [`router.onError()`](../../api/#onerror).
 
 If nothing, `undefined` or `true` is returned, **the navigation is validated**, and the next navigation guard is called.


### PR DESCRIPTION
Added an example where the guard returns a route location object, to help clarify what can be returned from a navigation guard. This supplements the examples where the guard returns false or a simple string path.