### PR TITLE
docs: add link to vue router video course on home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ home: true
 heroImage: /logo.png
 actionText: Get Started →
 actionLink: /installation.html
+altActionLink: https://vueschool.io/courses/vue-router-4-for-everyone
+altActionText: Free Video Course
 
 features:
   - title: 🛣 Expressive route syntax

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ home: true
 heroImage: /logo.png
 actionText: Get Started →
 actionLink: /installation.html
-altActionLink: https://vueschool.io/courses/vue-router-4-for-everyone
+altActionLink: https://vueschool.io/courses/vue-router-4-for-everyone?friend=vuerouter
 altActionText: Free Video Course
 
 features:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ home: true
 heroImage: /logo.png
 actionText: Get Started →
 actionLink: /installation.html
-altActionLink: https://vueschool.io/courses/vue-router-4-for-everyone?friend=vuerouter
+altActionLink: https://vueschool.io/courses/vue-router-4-for-everyone?friend=vuerouter&utm_source=vuerouter&utm_medium=link&utm_campaign=homepage
 altActionText: Free Video Course
 
 features:


### PR DESCRIPTION
add a link to the Vue Router video course on the homepage
![Screen Shot 2022-02-22 at 4 40 34 PM](https://user-images.githubusercontent.com/7635209/155231737-5ca9b7d1-c9f4-4800-b5ee-b9488d36c4ae.png)

Thanks!