### PR TITLE
fix: a bug in playground,'this' could not be used in setup function and tries will not be modified

### DIFF
--- a/playground/views/GuardedWithLeave.vue
+++ b/playground/views/GuardedWithLeave.vue
@@ -7,24 +7,25 @@
 
 <script>
 // @ts-check
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 import { onBeforeRouteLeave } from '../../src'
 
 export default defineComponent({
   name: 'GuardedWithLeave',
-  data: () => ({ tries: 0 }),
+  data: () => ({}),
 
   setup() {
     console.log('setup in cant leave')
+    const tries = ref(0)
     onBeforeRouteLeave(function (to, from, next) {
       if (window.confirm('Do you really want to leave?')) next()
       else {
         // @ts-ignore
-        this.tries++
+        tries.value++
         next(false)
       }
     })
-    return {}
+    return { tries }
   },
 })
 </script>


### PR DESCRIPTION
Find a bug in playground,'this' could not be used in setup function and tries will not be modified.We can use tries as a ref object instead.