### PR TITLE
fix(matcher): add child before parent when using `addRoute` (fix #1124)

### DIFF
--- a/__tests__/matcher/addingRemoving.spec.ts
+++ b/__tests__/matcher/addingRemoving.spec.ts
@@ -388,6 +388,36 @@ describe('Matcher: adding and removing records', () => {
     })
   })
 
+  it('adds empty paths as children', () => {
+    const matcher = createRouterMatcher([], {})
+    matcher.addRoute({ path: '/', component, name: 'parent' })
+    const parent = matcher.getRecordMatcher('parent')
+    expect(matcher.resolve({ path: '/' }, currentLocation)).toMatchObject({
+      name: 'parent',
+    })
+    matcher.addRoute({ path: '', component, name: 'child' }, parent)
+    expect(matcher.resolve({ path: '/' }, currentLocation)).toMatchObject({
+      name: 'child',
+    })
+  })
+
+  it('adding dynamic child with root path', () => {
+    const matcher = createRouterMatcher([], {})
+    matcher.addRoute({ path: '/parent', component, name: 'parent' })
+    const parent = matcher.getRecordMatcher('parent')
+    expect(matcher.resolve({ path: '/parent' }, currentLocation)).toMatchObject(
+      {
+        name: 'parent',
+      }
+    )
+    matcher.addRoute({ path: '/:id', component, name: 'child' }, parent)
+    expect(matcher.resolve({ path: '/parent' }, currentLocation)).toMatchObject(
+      {
+        name: 'parent',
+      }
+    )
+  })
+
   describe('warnings', () => {
     mockWarn()
 

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -211,12 +211,24 @@ export function createRouterMatcher(
     return matchers
   }
 
+  function isChildOf(
+    child: RouteRecordMatcher,
+    parent: RouteRecordMatcher
+  ): Boolean {
+    return parent.children.some(currChild => {
+      if (currChild === child) return true
+
+      return isChildOf(child, currChild)
+    })
+  }
+
   function insertMatcher(matcher: RouteRecordMatcher) {
     let i = 0
     // console.log('i is', { i })
     while (
       i < matchers.length &&
-      comparePathParserScore(matcher, matchers[i]) >= 0
+      comparePathParserScore(matcher, matchers[i]) >= 0 &&
+      !isChildOf(matcher, matchers[i])
     )
       i++
     // console.log('END i is', { i })


### PR DESCRIPTION
fix(matcher): correctly renders child when it is added dynamically and both it and its parent have an empty path

close #1124 