### PR TITLE
docs: Added note about using named routes in nested routes

### DIFF
--- a/docs/guide/essentials/nested-routes.md
+++ b/docs/guide/essentials/nested-routes.md
@@ -97,4 +97,19 @@ const routes = [
 ]
 ```
 
+Note that in empty nested route, if you want to access `/user/eduardo` via a named route or `router-link`, you need to put the name on the child:
+
+```js
+const routes = [
+  {
+    path: '/user/:id',
+    component: User,
+    children: [
+      // Add the named on the child
+      { name: 'UserRoute', path: '', component: UserHome },
+    ],
+  },
+]
+```
+
 A working demo of this example can be found [here](https://codesandbox.io/s/nested-views-vue-router-4-examples-hl326?initialpath=%2Fusers%2Feduardo).


### PR DESCRIPTION
When I use named routes in nested routes, I have no idea about the why the empty nested path no work, same result after I read documentation about nested routes. Until i saw this issues #1254.
```js
const routes = [
  {
    name: 'UserRoute',
    path: '/user/:id',
    component: User,
    children: [
      // It can't show the `UserHome` component, when I link to User by named route.
      { path: '', component: UserHome },
    ],
  },
]
```
I thought if we could add some notes about using named routes in nested routes, it might help some guys avoid this problem.