### PR TITLE
docs: improve meta extending

### DIFF
--- a/docs/guide/advanced/meta.md
+++ b/docs/guide/advanced/meta.md
@@ -61,7 +61,9 @@ router.beforeEach((to, from) => {
 It is possible to type the meta field by extending the `RouteMeta` interface from `vue-router`:
 
 ```ts
-// Ensure this file is parsed as a module regardless of dependencies.
+// This can be directly added to any of your `.ts` files like `router.ts`
+// It can also be added to a `.d.ts` file, in which case you will need to add an export
+// to ensure it is treated as a module
 export {}
 
 import 'vue-router'

--- a/docs/guide/advanced/meta.md
+++ b/docs/guide/advanced/meta.md
@@ -58,10 +58,12 @@ router.beforeEach((to, from) => {
 
 ## TypeScript
 
-It is possible to type the meta field by extending the `RouteMeta` interface:
+It is possible to type the meta field by extending the `RouteMeta` interface from `vue-router`:
 
 ```ts
-// typings.d.ts or router.ts
+// Ensure this file is parsed as a module regardless of dependencies.
+export {}
+
 import 'vue-router'
 
 declare module 'vue-router' {


### PR DESCRIPTION
The given documentation was not working.
To augment (and not replace) the existing RouteMeta interface of vue-router, one has to define a module.