### PR TITLE
Show Vue School logo in free weekend banner mobile

### DIFF
--- a/docs/.vitepress/components/VueSchool/BannerTop.vue
+++ b/docs/.vitepress/components/VueSchool/BannerTop.vue
@@ -60,14 +60,17 @@
   top: 20px;
 }
 #vs .vs-logo .logo-small {
-  display: none;
+  width: 30px;
+  margin-left: -5px;
+  margin-top: 5px;
 }
 #vs .vs-logo .logo-big {
   display: none;
 }
 @media (min-width: 768px) {
   #vs .vs-logo .logo-small {
-    display: inline-block;
+    width: auto;
+    margin: 0;
   }
 }
 @media (min-width: 1024px) {


### PR DESCRIPTION
This PR updates the free weekend banner to include the logo in the mobile viewport.

[Screenshot](https://imgur.com/a/6DnCDWr)

Related to https://github.com/vuejs/router/pull/1359