### PR TITLE
feat: expose RouterView and RouterLink as GlobalComponents

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "release": "bash scripts/release.sh",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1",
     "build": "rollup -c rollup.config.js",
-    "build:dts": "api-extractor run --local --verbose && tail -n +7 src/globalExtensions.ts >> dist/vue-router.d.ts",
+    "build:dts": "api-extractor run --local --verbose && tail -n +9 src/globalExtensions.ts >> dist/vue-router.d.ts",
     "build:playground": "vue-tsc --noEmit && vite build --config playground/vite.config.js",
     "build:e2e": "vue-tsc --noEmit && vite build --config e2e/vite.config.js",
     "build:size": "yarn run build && rollup -c size-checks/rollup.config.js",

--- a/src/globalExtensions.ts
+++ b/src/globalExtensions.ts
@@ -4,6 +4,8 @@ import {
   RouteLocationNormalizedLoaded,
 } from './types'
 import { Router } from './router'
+import { RouterView } from './RouterView'
+import { RouterLink } from './RouterLink'
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomOptions {
@@ -54,5 +56,10 @@ declare module '@vue/runtime-core' {
      * {@link Router} instance used by the application.
      */
     $router: Router
+  }
+
+  export interface GlobalComponents {
+    RouterView: typeof RouterView
+    RouterLink: typeof RouterLink
   }
 }


### PR DESCRIPTION
This allows Volar to provide intellisense and syntax highlighting.

Without the GlobalComponents interface:

![image](https://user-images.githubusercontent.com/36966635/163684832-c6c5b322-b42d-4ac8-bdac-f9d8b0f9520f.png)
![image](https://user-images.githubusercontent.com/36966635/163684880-cec0a3d7-1242-4713-adda-59441e805bef.png)

With the GlobalComponents interface:

![image](https://user-images.githubusercontent.com/36966635/163684854-a016d11a-e594-463b-8679-d77d182f6691.png)
![image](https://user-images.githubusercontent.com/36966635/163684867-4a38f28e-4a02-4761-9ef8-b5138139553c.png)
