### PR TITLE
feat: warn against named parent routes

### DIFF
--- a/__tests__/matcher/addingRemoving.spec.ts
+++ b/__tests__/matcher/addingRemoving.spec.ts
@@ -441,5 +441,79 @@ describe('Matcher: adding and removing records', () => {
       )
       expect('same param named').not.toHaveBeenWarned()
     })
+
+    it('warn if child route missing a required name', () => {
+      createRouterMatcher(
+        [
+          {
+            name: 'UserRoute',
+            path: '/user/:id',
+            component: component,
+            children: [{ path: '', component: component }],
+          },
+        ],
+        {}
+      )
+      expect('route needs a name').toHaveBeenWarned()
+    })
+
+    it('does not warn warn if child route has a required name', () => {
+      createRouterMatcher(
+        [
+          {
+            name: 'UserRoute',
+            path: '/user/:id',
+            component: component,
+            children: [{ path: '', name: 'UserHome', component: component }],
+          },
+        ],
+        {}
+      )
+      expect('route needs a name').not.toHaveBeenWarned()
+    })
+
+    it('warn if child route missing a required name', () => {
+      createRouterMatcher(
+        [
+          {
+            name: 'AAAA',
+            path: '/aaaa',
+            component: component,
+            children: [
+              {
+                path: 'bbbb',
+                name: 'BBBB',
+                component: component,
+                children: [{ path: '', component: component }],
+              },
+            ],
+          },
+        ],
+        {}
+      )
+      expect('route needs a name').toHaveBeenWarned()
+    })
+
+    it('does not warn warn if child route has a required name', () => {
+      createRouterMatcher(
+        [
+          {
+            name: 'AAAA',
+            path: '/aaaa',
+            component: component,
+            children: [
+              {
+                path: 'bbbb',
+                name: 'BBBB',
+                component: component,
+                children: [{ path: '', name: 'CCCC', component: component }],
+              },
+            ],
+          },
+        ],
+        {}
+      )
+      expect('route needs a name').not.toHaveBeenWarned()
+    })
   })
 })

--- a/__tests__/matcher/addingRemoving.spec.ts
+++ b/__tests__/matcher/addingRemoving.spec.ts
@@ -454,7 +454,7 @@ describe('Matcher: adding and removing records', () => {
         ],
         {}
       )
-      expect('route needs a name').toHaveBeenWarned()
+      expect('has a child without a name').toHaveBeenWarned()
     })
 
     it('does not warn warn if child route has a required name', () => {
@@ -469,7 +469,7 @@ describe('Matcher: adding and removing records', () => {
         ],
         {}
       )
-      expect('route needs a name').not.toHaveBeenWarned()
+      expect('has a child without a name').not.toHaveBeenWarned()
     })
 
     it('warn if child route missing a required name', () => {
@@ -491,7 +491,7 @@ describe('Matcher: adding and removing records', () => {
         ],
         {}
       )
-      expect('route needs a name').toHaveBeenWarned()
+      expect('has a child without a name').toHaveBeenWarned()
     })
 
     it('does not warn warn if child route has a required name', () => {
@@ -513,7 +513,7 @@ describe('Matcher: adding and removing records', () => {
         ],
         {}
       )
-      expect('route needs a name').not.toHaveBeenWarned()
+      expect('has a child without a name').not.toHaveBeenWarned()
     })
   })
 })

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -471,7 +471,7 @@ function checkChildMissingNameWithEmptyPath(
     !mainNormalizedRecord.path
   ) {
     warn(
-      `A child route with an empth path that has a named parent route needs a name`
+      `The route named "${parent.record.name}" has a child without a name and an empty path. Using that name won't render the empty path child so you probably want to move the name to the child instead. If this is intentional, add a name to the child route to remove the warning.
     )
   }
 }

--- a/src/matcher/index.ts
+++ b/src/matcher/index.ts
@@ -79,6 +79,9 @@ export function createRouterMatcher(
     // used later on to remove by name
     const isRootAdd = !originalRecord
     const mainNormalizedRecord = normalizeRouteRecord(record)
+    if (__DEV__) {
+      checkChildMissingNameWithEmptyPath(mainNormalizedRecord, parent)
+    }
     // we might be the child of an alias
     mainNormalizedRecord.aliasOf = originalRecord && originalRecord.record
     const options: PathParserOptions = mergeOptions(globalOptions, record)
@@ -448,6 +451,28 @@ function checkSameParams(a: RouteRecordMatcher, b: RouteRecordMatcher) {
       return warn(
         `Alias "${b.record.path}" and the original record: "${a.record.path}" should have the exact same param named "${key.name}"`
       )
+  }
+}
+
+/**
+ * A route with a name and a child with an empty path without a name should warn when adding the route
+ *
+ * @param mainNormalizedRecord - RouteRecordNormalized
+ * @param parent - RouteRecordMatcher
+ */
+function checkChildMissingNameWithEmptyPath(
+  mainNormalizedRecord: RouteRecordNormalized,
+  parent?: RouteRecordMatcher
+) {
+  if (
+    parent &&
+    parent.record.name &&
+    !mainNormalizedRecord.name &&
+    !mainNormalizedRecord.path
+  ) {
+    warn(
+      `A child route with an empth path that has a named parent route needs a name`
+    )
   }
 }
 


### PR DESCRIPTION
(fix #1376[,#1376])
A route with a name and a child with an empty path without a name should warn when adding the route (inside of the matcher)