### PR TITLE
docs: mention abstract history mode in the guide

### DIFF
--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -45,12 +45,13 @@ Here comes a problem, though: Since our app is a single page client side app, wi
 
 Not to worry: To fix the issue, all you need to do is add a simple catch-all fallback route to your server. If the URL doesn't match any static assets, it should serve the same `index.html` page that your app lives in. Beautiful, again!
 
-## Abstract mode
+## Memory mode
 
-The abstract history mode is created with `createMemoryHistory()`:
+The memory history mode doesn't assume a browser environment and therefore doesn't interact with the URL **nor automatically triggers the initial navigation**. This makes it perfect for Node environment and SSR. It is created with `createMemoryHistory()` and **requires you to push the initial navigation** after calling `app.use(router)`.
 
 ```js
 import { createRouter, createMemoryHistory } from 'vue-router'
+
 const router = createRouter({
   history: createMemoryHistory(),
   routes: [
@@ -59,7 +60,7 @@ const router = createRouter({
 })
 ```
 
-When using `createMemoryHistory()` the URL will not change when navigating between routes and no entries will be created in the browser history. The history is kept "hidden" within the javascript. The history will not persist when leaving or reloading the app, you get a fresh start every time your app is reloaded. Vue Router will always try to resolve the root `'/'` path when the app is loaded.
+While it's not recommended, you can use this mode inside Browser applications but note **there will be no history**, meaning you won't be able to go _back_ or _forward_.
 
 ## Example Server Configurations
 

--- a/docs/guide/essentials/history-mode.md
+++ b/docs/guide/essentials/history-mode.md
@@ -45,6 +45,22 @@ Here comes a problem, though: Since our app is a single page client side app, wi
 
 Not to worry: To fix the issue, all you need to do is add a simple catch-all fallback route to your server. If the URL doesn't match any static assets, it should serve the same `index.html` page that your app lives in. Beautiful, again!
 
+## Abstract mode
+
+The abstract history mode is created with `createMemoryHistory()`:
+
+```js
+import { createRouter, createMemoryHistory } from 'vue-router'
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    //...
+  ],
+})
+```
+
+When using `createMemoryHistory()` the URL will not change when navigating between routes and no entries will be created in the browser history. The history is kept "hidden" within the javascript. The history will not persist when leaving or reloading the app, you get a fresh start every time your app is reloaded. Vue Router will always try to resolve the root `'/'` path when the app is loaded.
+
 ## Example Server Configurations
 
 **Note**: The following examples assume you are serving your app from the root folder. If you deploy to a subfolder, you should use [the `publicPath` option of Vue CLI](https://cli.vuejs.org/config/#publicpath) and the related [`base` property of the router](../../api/#createwebhistory). You also need to adjust the examples below to use the subfolder instead of the root folder (e.g. replacing `RewriteBase /` with `RewriteBase /name-of-your-subfolder/`).


### PR DESCRIPTION
I spent a lot of time searching for what turned out to be the "abstract history mode". I was only able to find a mention of this mode in the ["Migrating from Vue 2" section](https://router.vuejs.org/guide/migration/index.html#new-history-option-to-replace-mode).

The abstract mode can be a very useful tool for some micro-services or wizard-like apps. In some applications it may be considered a bad practice, but I think there are very valid applications where SEO does not matter and the app should not return the current view after reload.