### PR TITLE
docs: Change type to LocationQueryValue to accurately reflect source.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1010,7 +1010,7 @@ Normalized route location. Does not have any [redirect records](#routerecordraw)
 
 ### query
 
-- **Type**: `Record<string, string | string[]>`
+- **Type**: `Record<string, LocationQueryValue | LocationQueryValue[]>`
 - **Details**:
 
   Dictionary of decoded query params extracted from the `search` section of the URL.


### PR DESCRIPTION
In the source, the type of RouteLocationNormalized.query is a Record<string, LocationQueryValue | LocationQueryValue[]>.  LocationQueryValue isn't exactly a string, but is a (string | null). I think it makes sense to update the docs, especially since LocationQueryValue isn't assignable to string.