### PR TITLE
fix(compat): force router-link mode to Vue 3

### DIFF
--- a/src/RouterLink.ts
+++ b/src/RouterLink.ts
@@ -183,6 +183,7 @@ export function useLink(props: UseLinkOptions) {
 
 export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
   name: 'RouterLink',
+  compatConfig: { MODE: 3 },
   props: {
     to: {
       type: [String, Object] as PropType<RouteLocationRaw>,


### PR DESCRIPTION
In particular, without this `<router-link @click="foo">` does not trigger `foo` under the compat build. 