### PR TITLE
fix(types): allow `symbol` type

### DIFF
--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -65,7 +65,7 @@ export interface MatcherLocationAsName {
  * @internal
  */
 export interface LocationAsRelativeRaw {
-  name?: string
+  name?: RouteRecordName
   params?: RouteParamsRaw
 }
 


### PR DESCRIPTION
In v4.1.0, the `symbol` type was accidentally removed (https://github.com/vuejs/router/commit/06aefa8d4ea0b4f7d01de091025dea09057e4917#76)
