### PR TITLE
Docs and Router-Example typo fix.

### DIFF
--- a/packages/docs/api/index.md
+++ b/packages/docs/api/index.md
@@ -788,7 +788,7 @@ stringifyQuery?: (
 
 ## RouteRecordRaw
 
-Route record that can be provided by the user when adding routes via the [`routes` option](#routeroptions) or via [`router.addRoute()`](#addroute-2). There are three different kind of route records:
+Route record that can be provided by the user when adding routes via the [`routes` option](#routeroptions) or via [`router.addRoute()`](#addroute). There are three different kind of route records:
 
 - Single views records: have a `component` option
 - Multiple views records ([named views](../guide/essentials/named-views.md)): have a `components` option

--- a/packages/router/e2e/modal/index.html
+++ b/packages/router/e2e/modal/index.html
@@ -16,7 +16,7 @@
         border: none;
         margin: 0;
         padding: 0;
-        background-color: rgb(0, 0, 0, 0.5);
+        background-color: rgba(0, 0, 0, 0.5);
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
Docs-API: Links with typos. `(#addroute-2)` → `(#addroute)`
Router-Ex: Works fine, but typo in alpha value in css color. `rgb` → `rgba`