### PR TITLE
feat(types): add option to extend `RouteRecordName`

### DIFF
--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -205,9 +205,22 @@ export type RouteComponent = Component | DefineComponent
 export type RawRouteComponent = RouteComponent | Lazy<RouteComponent>
 
 /**
+ * Interface to add available RouteRecordName values
+ *
+ * @example
+ *    declare module 'vue-router' {
+ *        export interface RouteRecords {
+ *           [key: 'app' | 'contact-us' | 'services' | 'index']: never;
+ *        }
+ *    }
+ */
+export interface RouteRecords {
+}
+
+/**
  * Possible values for a user-defined route record's name
  */
-export type RouteRecordName = string | symbol
+export type RouteRecordName = keyof RouteRecords | string | symbol
 
 /**
  * @internal

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -214,8 +214,7 @@ export type RawRouteComponent = RouteComponent | Lazy<RouteComponent>
  *        }
  *    }
  */
-export interface RouteRecords {
-}
+export interface RouteRecords {}
 
 /**
  * Possible values for a user-defined route record's name


### PR DESCRIPTION
This change allows for editing the `RouteRecordName` in the a module augmentation.

### TIP:
I have a route names map which I use to refer to names in router function.

```ts
export const routeNames = {
    public: {
        index: 'index',
        features: 'features',
        pricing: 'pricing',
        s: {
            index: 's-thing',
            edit: 's-thing-edit'
        }
    },
    app: {
        index: 'app',
    },
    fallback: 'all'
} as const;
```

Considering the above map.
In my app I created a little helper type:
```ts
type RouteNames<T extends Record<string, any>> = {
    [K in keyof T]: T[K] extends Record<string, any> ? RouteNames<T[K]> : T[K];
}[keyof T];
```
Which I could use in the module augmentation as if this PR gets merged
```ts
// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
export interface RouteRecords extends Record<RouteNames<typeof routeNames>, never> {}
```