### PR TITLE
docs(nested-routes): add note for named routes

### DIFF
--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -96,6 +96,36 @@ const routes = [
   },
 ]
 ```
-**Note that if you use named routes you have to use the name of the child with the empty path to get the same effect**
 
 A working demo of this example can be found [here](https://codesandbox.io/s/nested-views-vue-router-4-examples-hl326?initialpath=%2Fusers%2Feduardo).
+
+
+## Nested Named Routes
+There are some differences if you use [Named Routes](./named-routes.md#named-routes).
+
+If you route to `user` it will show the `User` component.
+
+You have to route to a child like `user-home` if you want to render something in the  `User`'s `router-view` because the empty path property will be ignored here.
+
+```js
+const routes = [
+  {
+    path: '/user/:id',
+    name: 'user'
+    component: User,
+    children: [
+      // UserHome will be rendered inside User's <router-view>
+      // when "user-home" is matched
+      { path: '', name:"user-home", component: UserHome },
+
+      {
+        // UserPosts will be rendered inside User's <router-view>
+        // when "user-posts" is matched
+        path: 'posts',
+        name: 'user-posts',
+        component: UserPosts,
+      }
+    ],
+  },
+]
+```

--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -99,33 +99,32 @@ const routes = [
 
 A working demo of this example can be found [here](https://codesandbox.io/s/nested-views-vue-router-4-examples-hl326?initialpath=%2Fusers%2Feduardo).
 
-
 ## Nested Named Routes
-There are some differences if you use [Named Routes](./named-routes.md#named-routes).
 
-If you route to `user` it will show the `User` component.
-
-You have to route to a child like `user-home` if you want to render something in the  `User`'s `router-view` because the empty path property will be ignored here.
+When dealing with [Named Routes](./named-routes.md), you usually **name the children routes**:
 
 ```js
 const routes = [
   {
     path: '/user/:id',
-    name: 'user'
     component: User,
-    children: [
-      // UserHome will be rendered inside User's <router-view>
-      // when "user-home" is matched
-      { path: '', name:"user-home", component: UserHome },
+    // notice how only the child route has a name
+    children: [{ path: '', name: 'user', component: UserHome }],
+  },
+]
+```
 
-      {
-        // UserPosts will be rendered inside User's <router-view>
-        // when "user-posts" is matched
-        path: 'posts',
-        name: 'user-posts',
-        component: UserPosts,
-      }
-    ],
+This will ensure navigating to `/user/:id` will always display the nested route.
+
+In some scenarios, you may want to navigate to a named route without navigating to the nested route. For example, if you want to navigate to `/user/:id` without displaying the nested route. In that case, you can **also** name the parent route but note **that reloading the page will always display the nested child** as it's considered a navigation to the path `/users/:id` instead of the named route:
+
+```js
+const routes = [
+  {
+    path: '/user/:id',
+    name: 'user-parent'
+    component: User,
+    children: [{ path: '', name: 'user', component: UserHome }],
   },
 ]
 ```

--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -96,5 +96,6 @@ const routes = [
   },
 ]
 ```
+**Note that if you use named routes you have to use the name of the child with the empty path to get the same effect**
 
 A working demo of this example can be found [here](https://codesandbox.io/s/nested-views-vue-router-4-examples-hl326?initialpath=%2Fusers%2Feduardo).


### PR DESCRIPTION
To avoid something like #1493

now it is clear why it works like this, clarified it in the docs as a reminder