### PR TITLE
Critical Bug: Undefined URLs

### DIFF
--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -287,7 +287,8 @@ function useHistoryStateNavigation(base: string) {
       )
     }
 
-    changeLocation(currentState.current, currentState, true)
+    if (currentState.current)
+      changeLocation(currentState.current, currentState, true)
 
     const state: StateEntry = assign(
       {},

--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -215,12 +215,19 @@ function useHistoryStateNavigation(base: string) {
      * base tag we can just use everything after the `#`.
      */
     const hashIndex = base.indexOf('#')
-    const url =
-      hashIndex > -1
-        ? (location.host && document.querySelector('base')
-            ? base
-            : base.slice(hashIndex)) + to
-        : createBaseLocation() + base + to
+
+    let url = ''
+
+    if (hashIndex > -1) {
+      if (location.host && document.querySelector('base')) {
+        url = base
+      } else {
+        url = base.slice(hashIndex) + (to ?? '')
+      }
+    } else {
+      url = createBaseLocation() + base + (to ?? '')
+    }
+
     try {
       // BROWSER QUIRK
       // NOTE: Safari throws a SecurityError when calling this function 100 times in 30 seconds

--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -222,10 +222,10 @@ function useHistoryStateNavigation(base: string) {
       if (location.host && document.querySelector('base')) {
         url = base
       } else {
-        url = base.slice(hashIndex) + (to ?? '')
+        url = base.slice(hashIndex) + (to !== undefined ? to : '')
       }
     } else {
-      url = createBaseLocation() + base + (to ?? '')
+      url = createBaseLocation() + base + (to !== undefined ? to : '')
     }
 
     try {


### PR DESCRIPTION
While using the latest version of vue and single-spa, i found that the url builder was adding undefined to the URL.
For me this happened when i went several levels below the current page.
This code avoids adding "undefined" to the URL when the "to" is undefined, when i want to return to the root of the SPA without doing a page refresh.

