### PR TITLE
fix(types): normalized Query can have undefined properties

### DIFF
--- a/packages/router/src/query.ts
+++ b/packages/router/src/query.ts
@@ -28,7 +28,7 @@ export type LocationQueryValueRaw = LocationQueryValue | number | undefined
  */
 export type LocationQuery = Record<
   string,
-  LocationQueryValue | LocationQueryValue[]
+  LocationQueryValue | LocationQueryValue[] | undefined
 >
 /**
  * Loose {@link LocationQuery} object that can be passed to functions like


### PR DESCRIPTION
When a query param is not present the query value is `undefined`, but the type is only `string | null`.

Here is the extract of code where I had this problem:
```
const route = useRoute();
const sortBy = ref(route.query.sort_by.toString())
```

I got `Cannot read property 'toString' of undefined` but the linter didn't give any errors.