### PR TITLE
Add readonly to children routes

### DIFF
--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -266,7 +266,7 @@ export interface _RouteRecordBase extends PathParserOptions {
   /**
    * Array of nested routes.
    */
-  children?: RouteRecordRaw[]
+  children?: Readonly<RouteRecordRaw[]>
 
   /**
    * Allow passing down params as props to the component rendered by `router-view`.
@@ -365,7 +365,7 @@ export interface RouteRecordMultipleViewsWithChildren extends _RouteRecordBase {
   components?: Record<string, RawRouteComponent> | null | undefined
   component?: never
 
-  children: RouteRecordRaw[]
+  children: Readonly<RouteRecordRaw[]>
 
   /**
    * Allow passing down params as props to the component rendered by


### PR DESCRIPTION
Following [the pattern in routes for RouterOption](https://github.com/vuejs/router/blob/main/packages/router/src/router.ts#L129), I think children should also accept `Readonly<RouteRecordRaw[]>` for consistency.

