### PR TITLE
docs: beforeRouteEnter next callback

### DIFF
--- a/packages/docs/guide/advanced/data-fetching.md
+++ b/packages/docs/guide/advanced/data-fetching.md
@@ -71,7 +71,7 @@ export default {
 ## Fetching Before Navigation
 
 With this approach we fetch the data before actually navigating to the new
-route. We can perform the data fetching in the `beforeRouteEnter` guard in the incoming component, and only call `next` when the fetch is complete (*the callback provided to next will be evaluated after the component is mounted*):
+route. We can perform the data fetching in the `beforeRouteEnter` guard in the incoming component, and only call `next` when the fetch is complete. The callback passed to `next` will be called **after the component is mounted**:
 
 ```js
 export default {

--- a/packages/docs/guide/advanced/data-fetching.md
+++ b/packages/docs/guide/advanced/data-fetching.md
@@ -71,7 +71,7 @@ export default {
 ## Fetching Before Navigation
 
 With this approach we fetch the data before actually navigating to the new
-route. We can perform the data fetching in the `beforeRouteEnter` guard in the incoming component, and only call `next` when the fetch is complete:
+route. We can perform the data fetching in the `beforeRouteEnter` guard in the incoming component, and only call `next` when the fetch is complete (*the callback provided to next will be evaluated after the component is mounted*):
 
 ```js
 export default {


### PR DESCRIPTION
In my testing with v4.1.5 the callback provided to next within beforeRouteEnter is evaluated *after* mount. I'm not 100% sure it's actually what happens reliably, but it's what my test showed. Seems like quite strange behavior if it is indeed true, so thought should make note in doc.