### PR TITLE
chore: bronze sponsor link [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Vue Router is part of the Vue Ecosystem and is an MIT-licensed open source proje
       <img src="https://avatars.githubusercontent.com/u/2486424?u=7b0c73ae5d090ce53bf59473094e9606fe082c59&v=4" height="26px" alt="Stanislas OrmiÃ¨res" />
     </picture>
   </a>
-    <a href="www.vuejs.de" target="_blank" rel="noopener noreferrer">
+    <a href="https://www.vuejs.de" target="_blank" rel="noopener noreferrer">
     <picture>
       <source srcset="https://avatars.githubusercontent.com/u/4183726?u=6b50a8ea16de29d2982f43c5640b1db9299ebcd1&v=4" media="(prefers-color-scheme: dark)" height="26px" alt="Antony Konstantinidis" />
       <img src="https://avatars.githubusercontent.com/u/4183726?u=6b50a8ea16de29d2982f43c5640b1db9299ebcd1&v=4" height="26px" alt="Antony Konstantinidis" />


### PR DESCRIPTION
GitHub treats non-https-prefixed links as relative paths, resulting in 

https://github.com/vuejs/router/blob/main/www.vuejs.de

![Screenshot 2022-09-28 at 09 48 17](https://user-images.githubusercontent.com/9140811/192708074-aaccb9d6-ff24-47fb-a77e-3410cf8dd2e8.png)
