### PR TITLE
docs: fix zh docs dynamic transition name mismatch error

### DIFF
--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -38,8 +38,8 @@ const routes = [
 
 ```html
 <router-view v-slot="{ Component, route }">
-  <!-- Use any custom transition and fallback to `fade` -->
-  <transition :name="route.meta.transition || 'fade'">
+  <!-- Use any custom transition and  to `fade` -->
+  <transition :name="route.meta.transitionName || 'fade'">
     <component :is="Component" />
   </transition>
 </router-view>

--- a/packages/docs/zh/guide/advanced/transitions.md
+++ b/packages/docs/zh/guide/advanced/transitions.md
@@ -52,7 +52,7 @@ const routes = [
 ```html
 <!-- 使用动态过渡名称 -->
 <router-view v-slot="{ Component, route }">
-  <transition :name="route.meta.transition">
+  <transition :name="route.meta.transitionName">
     <component :is="Component" />
   </transition>
 </router-view>

--- a/packages/docs/zh/guide/advanced/transitions.md
+++ b/packages/docs/zh/guide/advanced/transitions.md
@@ -39,7 +39,7 @@ const routes = [
 ```html
 <router-view v-slot="{ Component, route }">
   <!-- 使用任何自定义过渡和回退到 `fade` -->
-  <transition :name="route.meta.transition || 'fade'">
+  <transition :name="route.meta.transitionName || 'fade'">
     <component :is="Component" />
   </transition>
 </router-view>


### PR DESCRIPTION
In en docs they both being **meta.transitionName**
In zh docs, **route.meta.transition** mismatch with **to.meta.transitionName**