### PR TITLE
docs: replace zh docs edit link text in chinese

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -200,6 +200,7 @@ const config = defineConfig({
       '/zh/': {
         label: '中文',
         selectText: '选择语言',
+        editLinkText: '对本页提出修改建议',
         nav: [
           {
             text: '教程',

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -200,7 +200,7 @@ const config = defineConfig({
       '/zh/': {
         label: '中文',
         selectText: '选择语言',
-        editLinkText: '对本页提出修改建议',
+        editLinkText: '为此页提供修改建议',
         nav: [
           {
             text: '教程',


### PR DESCRIPTION
Currently, the edit link text in zh docs is in english.
This PR fixes it.