### PR TITLE
chore: add link to Vue2 router aka Vue Router 3 (#1595) [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # vue-router [![release candidate](https://img.shields.io/npm/v/vue-router.svg)](https://www.npmjs.com/package/vue-router) [![CircleCI](https://badgen.net/circleci/github/vuejs/router/main)](https://circleci.com/gh/vuejs/router)
 
-> This is the repository for Vue Router 4 (for Vue 3)
+> - This is the repository for Vue Router 4 (for Vue 3)
+> - For Vue Router 3 (for Vue 2) see [vuejs/vue-router](https://github.com/vuejs/vue-router).
 
 <h2 align="center">Supporting Vue Router</h2>
 


### PR DESCRIPTION
- Bullet points used, since without them the quote gets merged in one line.
- The same style is also used in the [README of vue-router 3](https://github.com/vuejs/vue-router/blob/dev/README.md?plain=1#L3-L5).
- Since vue-router v1 is old already I didn't see the need to add a link for that.