### PR TITLE
Update `pushWithQuery` example function

### DIFF
--- a/packages/docs/guide/advanced/composition-api.md
+++ b/packages/docs/guide/advanced/composition-api.md
@@ -24,6 +24,7 @@ export default {
         name: 'search',
         query: {
           ...route.query,
+          ...query,
         },
       })
     }


### PR DESCRIPTION
The `pushWithQuery` function accepts a `query` argument that was not used. I updated the docs to how I assume the function was mean to be set up.