### PR TITLE
docs: remove dead link

### DIFF
--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -5,7 +5,7 @@
   title="Learn about route transitions"
 />
 
-In order to use transitions on your route components and animate navigations, you need to use the [v-slot API](../../api/#v-slot-api-3-1-0):
+In order to use transitions on your route components and animate navigations, you need to use the v-slot API:
 
 ```html
 <router-view v-slot="{ Component }">

--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -5,7 +5,7 @@
   title="Learn about route transitions"
 />
 
-In order to use transitions on your route components and animate navigations, you need to use the [v-slot API](../../api/#router-view-s-v-slot):
+In order to use transitions on your route components and animate navigations, you need to use the [v-slot API](../../api/#v-slot-api-3-1-0):
 
 ```html
 <router-view v-slot="{ Component }">


### PR DESCRIPTION
Edit link to v-slot API documentation 

from:
https://router.vuejs.org/api/#router-view-s-v-slot

to:
https://v3.router.vuejs.org/api/#v-slot-api-3-1-0