### PR TITLE
docs: Fixed typo in transition example

### DIFF
--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -39,7 +39,7 @@ const routes = [
 ```html
 <router-view v-slot="{ Component, route }">
   <!-- Use any custom transition and  to `fade` -->
-  <transition :name="route.meta.transitionName || 'fade'">
+  <transition :name="route.meta.transition || 'fade'">
     <component :is="Component" />
   </transition>
 </router-view>


### PR DESCRIPTION
Should be `route.meta.transition` instead of `route.meta.transitionName`