### PR TITLE
docs: mention both `useRoute` and `useRouter` functions

### DIFF
--- a/packages/docs/guide/advanced/composition-api.md
+++ b/packages/docs/guide/advanced/composition-api.md
@@ -9,7 +9,7 @@ The introduction of `setup` and Vue's [Composition API](https://v3.vuejs.org/gui
 
 ## Accessing the Router and current Route inside `setup`
 
-Because we don't have access to `this` inside of `setup`, we cannot directly access `this.$router` or `this.$route` anymore. Instead we use the `useRouter` function:
+Because we don't have access to `this` inside of `setup`, we cannot directly access `this.$router` or `this.$route` anymore. Instead we use the `useRouter` and `useRoute` functions:
 
 ```js
 import { useRouter, useRoute } from 'vue-router'


### PR DESCRIPTION
I found this a little enhancement for the `Composition API` section.
It is to let clear what functions you need to use to access the
`Router` and `Route` objects inside a `setup` method.