### PR TITLE
 Maybe it's unnecessary to add this judgement

### DIFF
--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -243,8 +243,7 @@ export function resolveRelativePath(to: string, from: string): string {
     fromSegments.slice(0, position).join('/') +
     '/' +
     toSegments
-      // ensure we use at least the last element in the toSegments
-      .slice(toPosition - (toPosition === toSegments.length ? 1 : 0))
+      .slice(toPosition)
       .join('/')
   )
 }

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -242,8 +242,6 @@ export function resolveRelativePath(to: string, from: string): string {
   return (
     fromSegments.slice(0, position).join('/') +
     '/' +
-    toSegments
-      .slice(toPosition)
-      .join('/')
+    toSegments.slice(toPosition).join('/')
   )
 }


### PR DESCRIPTION
The final element in the `toSegments` will always be empty or a string that is not `.` or `..`.

As a result, the `toPosition` will not increment when it exits the `for loop` and it will always be shorter than `toSegments' length`.