### PR TITLE
docs: fix bottom links' url

### DIFF
--- a/packages/docs/.vitepress/config/en.ts
+++ b/packages/docs/.vitepress/config/en.ts
@@ -16,7 +16,7 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
 
   themeConfig: {
     editLink: {
-      pattern: 'https://github.com/vuejs/router/edit/v2/packages/docs/:path',
+      pattern: 'https://github.com/vuejs/router/edit/main/packages/docs/:path',
       text: 'Suggest changes to this page',
     },
 

--- a/packages/docs/.vitepress/config/zh.ts
+++ b/packages/docs/.vitepress/config/zh.ts
@@ -16,7 +16,7 @@ export const zhConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
 
   themeConfig: {
     editLink: {
-      pattern: 'https://github.com/vuejs/router/edit/v2/packages/docs/:path',
+      pattern: 'https://github.com/vuejs/router/edit/main/packages/docs/:path',
       text: '对本页提出修改建议',
     },
 


### PR DESCRIPTION
Fix when i click bottom navigtor, it doesn't  redirect to the correct source code  of the current docs's page.