### PR TITLE
Incorrect text as link format

### DIFF
--- a/packages/docs/api/interfaces/RouterLinkProps.md
+++ b/packages/docs/api/interfaces/RouterLinkProps.md
@@ -71,4 +71,4 @@ Route Location the link should navigate to when clicked on.
 
 #### Inherited from %{#Properties-to-Inherited-from}%
 
-RouterLinkOptions.to
+<span>RouterLinkOptions.to</span>


### PR DESCRIPTION
Text is incorrectly treated as link in documentation