### PR TITLE
docs: simple typo code correction

### DIFF
--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -122,7 +122,7 @@ In some scenarios, you may want to navigate to a named route without navigating 
 const routes = [
   {
     path: '/user/:id',
-    name: 'user-parent'
+    name: 'user-parent',
     component: User,
     children: [{ path: '', name: 'user', component: UserHome }],
   },

--- a/packages/docs/zh/guide/essentials/nested-routes.md
+++ b/packages/docs/zh/guide/essentials/nested-routes.md
@@ -122,7 +122,7 @@ const routes = [
 const routes = [
   {
     path: '/user/:id',
-    name: 'user-parent'
+    name: 'user-parent',
     component: User,
     children: [{ path: '', name: 'user', component: UserHome }],
   },


### PR DESCRIPTION
Add missing `,` string in example code.
The Chinese document was also revised at the same time.