### PR TITLE
connect translated korean docs.

### DIFF
--- a/packages/docs/.vitepress/config/index.ts
+++ b/packages/docs/.vitepress/config/index.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   locales: {
     root: { label: 'English', lang: 'en-US', link: '/', ...enConfig },
     zh: { label: '简体中文', lang: 'zh-CN', link: '/zh/', ...zhConfig },
+    ko: { label: '한국어', lang: 'ko-KR', link: 'https://router.vuejs.kr/' },
   },
 })


### PR DESCRIPTION
Added Korean language document (external link).
It works exactly the same.
https://router.vuejs.org/* → https://router.vuejs.kr/*