### PR TITLE
chore: modify the way to get __dirname

### DIFF
--- a/packages/router/rollup.config.mjs
+++ b/packages/router/rollup.config.mjs
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import { promises as fsp } from 'node:fs'
-import {dirname} from 'node:path'
 import ts from 'rollup-plugin-typescript2'
 import replace from '@rollup/plugin-replace'
 import resolve from '@rollup/plugin-node-resolve'
@@ -8,10 +7,11 @@ import commonjs from '@rollup/plugin-commonjs'
 import chalk from 'chalk'
 import pkg from './package.json' assert { type: 'json' }
 import {terser} from 'rollup-plugin-terser'
+import {fileURLToPath} from 'url'
 
 const name = pkg.name
 
-const __dirname = dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const banner = `/*!
   * ${pkg.name} v${pkg.version}


### PR DESCRIPTION
use dirname(new URL(import.meta.url).pathname) in node.js v18.15.0 have a bug,can't parse the directory correctly