### PR TITLE
fix: Adjustment to NavigationGuardWithThis within dts file

### DIFF
--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -513,7 +513,7 @@ export interface NavigationGuardWithThis<T> {
     this: T,
     to: RouteLocationNormalized,
     from: RouteLocationNormalized,
-    next: NavigationGuardNext
+    next?: NavigationGuardNext
   ): NavigationGuardReturn | Promise<NavigationGuardReturn>
 }
 


### PR DESCRIPTION
According to the documentation [here](https://router.vuejs.org/guide/advanced/navigation-guards.html#optional-third-argument-next), the "next" argument for navigation guards should be optional. Within the typescript dts file, this is typed as a required argument. Causes issues when attempting to type custom route guards with NavigationGuardWithThis.