### PR TITLE
chore: modify the way to get folders

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -344,6 +344,7 @@ async function getChangedPackages() {
     )
     lastTag = stdout
   }
+  // globby expects `/` even on windows
   const folders = await globby((join(__dirname, '../packages/*').replace(/\\/g,'/')), {
     onlyFiles: false,
   })

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -344,7 +344,7 @@ async function getChangedPackages() {
     )
     lastTag = stdout
   }
-  const folders = await globby(join(__dirname, '../packages/*'), {
+  const folders = await globby((join(__dirname, '../packages/*').replace(/\\/g,'/')), {
     onlyFiles: false,
   })
 


### PR DESCRIPTION
globby is have a bug in windows,can see this issues :https://github.com/sindresorhus/globby/issues/179. It's not a serious bug，But it makes learning to code tricky.