### PR TITLE
chore: refactor checkFileSize function with async file reading 

### DIFF
--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -5,6 +5,10 @@ const { gzip } = require('zlib')
 const { compress } = require('brotli')
 
 async function checkFileSize(filePath) {
+  const stat = await fs.stat(filePath).catch(() => null)
+  if (!stat || !stat.isFile()) {
+    return
+  }
   const file = await fs.readFile(filePath)
   const minSize = (file.length / 1024).toFixed(2) + 'kb'
   const [gzipped, compressed] = await Promise.all([gzip(file), compress(file)])

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -1,29 +1,38 @@
-const fs = require('fs')
+const fs = require('fs').promises
 const path = require('path')
 const chalk = require('chalk')
-const { gzipSync } = require('zlib')
+const { gzip } = require('zlib')
 const { compress } = require('brotli')
 
-function checkFileSize(filePath) {
-  if (!fs.existsSync(filePath)) {
-    return
+async function checkFileSize(filePath) {
+  try {
+    const file = await fs.readFile(filePath)
+    const minSize = (file.length / 1024).toFixed(2) + 'kb'
+    const [gzipped, compressed] = await Promise.all([
+      gzip(file),
+      compress(file),
+    ])
+    const gzippedSize = (gzipped.length / 1024).toFixed(2) + 'kb'
+    const compressedSize = (compressed.length / 1024).toFixed(2) + 'kb'
+    console.log(
+      `${chalk.gray(
+        chalk.bold(path.basename(filePath))
+      )} min:${minSize} / gzip:${gzippedSize} / brotli:${compressedSize}`
+    )
+  } catch (err) {
+    console.error(err)
   }
-  const file = fs.readFileSync(filePath)
-  const minSize = (file.length / 1024).toFixed(2) + 'kb'
-  const gzipped = gzipSync(file)
-  const gzippedSize = (gzipped.length / 1024).toFixed(2) + 'kb'
-  const compressed = compress(file)
-  const compressedSize = (compressed.length / 1024).toFixed(2) + 'kb'
-  console.log(
-    `${chalk.gray(
-      chalk.bold(path.basename(filePath))
-    )} min:${minSize} / gzip:${gzippedSize} / brotli:${compressedSize}`
-  )
 }
 
-checkFileSize(
-  path.resolve(__dirname, '../packages/router/size-checks/dist/webRouter.js')
-)
-checkFileSize(
-  path.resolve(__dirname, '../packages/router/dist/vue-router.global.prod.js')
-)
+;(async () => {
+  const files = [
+    path.resolve(__dirname, '../packages/router/size-checks/dist/webRouter.js'),
+    path.resolve(
+      __dirname,
+      '../packages/router/dist/vue-router.global.prod.js'
+    ),
+  ]
+  for (const file of files) {
+    await checkFileSize(file)
+  }
+})()

--- a/scripts/check-size.js
+++ b/scripts/check-size.js
@@ -5,23 +5,16 @@ const { gzip } = require('zlib')
 const { compress } = require('brotli')
 
 async function checkFileSize(filePath) {
-  try {
-    const file = await fs.readFile(filePath)
-    const minSize = (file.length / 1024).toFixed(2) + 'kb'
-    const [gzipped, compressed] = await Promise.all([
-      gzip(file),
-      compress(file),
-    ])
-    const gzippedSize = (gzipped.length / 1024).toFixed(2) + 'kb'
-    const compressedSize = (compressed.length / 1024).toFixed(2) + 'kb'
-    console.log(
-      `${chalk.gray(
-        chalk.bold(path.basename(filePath))
-      )} min:${minSize} / gzip:${gzippedSize} / brotli:${compressedSize}`
-    )
-  } catch (err) {
-    console.error(err)
-  }
+  const file = await fs.readFile(filePath)
+  const minSize = (file.length / 1024).toFixed(2) + 'kb'
+  const [gzipped, compressed] = await Promise.all([gzip(file), compress(file)])
+  const gzippedSize = (gzipped.length / 1024).toFixed(2) + 'kb'
+  const compressedSize = (compressed.length / 1024).toFixed(2) + 'kb'
+  console.log(
+    `${chalk.gray(
+      chalk.bold(path.basename(filePath))
+    )} min:${minSize} / gzip:${gzippedSize} / brotli:${compressedSize}`
+  )
 }
 
 ;(async () => {


### PR DESCRIPTION
Optimized the `checkFileSize` function in the `size-checks` script to improve its performance