### PR TITLE
chore: remove unnecessary await keyword 

### DIFF
--- a/packages/router/__tests__/guards/extractComponentsGuards.spec.ts
+++ b/packages/router/__tests__/guards/extractComponentsGuards.spec.ts
@@ -50,7 +50,7 @@ async function checkGuards(
   guardsLength: number = n
 ) {
   beforeRouteEnter.mockClear()
-  const guards = await extractComponentsGuards(
+  const guards = extractComponentsGuards(
     // type is fine as we excluded RouteRecordRedirect in components argument
     components.map(normalizeRouteRecord) as RouteRecordNormalized[],
     'beforeRouteEnter',

--- a/packages/router/__tests__/utils.ts
+++ b/packages/router/__tests__/utils.ts
@@ -4,7 +4,6 @@ import {
   RouteRecordMultipleViews,
   MatcherLocation,
   RouteLocationNormalized,
-  _RouteRecordBase,
   RouteComponent,
   RouteRecordRaw,
   RouteRecordName,

--- a/packages/router/e2e/guards-instances/index.ts
+++ b/packages/router/e2e/guards-instances/index.ts
@@ -45,7 +45,8 @@ const state = reactive({
 
 /**
  * creates a component that logs the guards
- * @param name
+ * @param key {string} - a unique identifier for the component
+ * @returns {object} - a Vue component object with beforeRouteEnter, beforeRouteUpdate, and beforeRouteLeave navigation guards implemented
  */
 function createTestComponent(key: string) {
   return defineComponent({

--- a/packages/router/e2e/modal/index.ts
+++ b/packages/router/e2e/modal/index.ts
@@ -12,7 +12,6 @@ import {
   ref,
   watchEffect,
   computed,
-  toRefs,
   defineComponent,
 } from 'vue'
 

--- a/packages/router/e2e/suspense/index.ts
+++ b/packages/router/e2e/suspense/index.ts
@@ -35,8 +35,13 @@ const state = reactive({
 const delay = (t: number) => new Promise(r => setTimeout(r, t))
 
 /**
- * creates a component that logs the guards
- * @param name
+ * Creates a test component with the given key, optionally specifying whether it should be async and whether creation should be logged.
+ *
+ * @param {string} key - The key of the component.
+ * @param {boolean} [isAsync=false] - Whether the component should be async.
+ * @param {boolean} [logCreation=false] - Whether creation should be logged.
+ * @returns {object} The component object.
+ *
  */
 function createTestComponent(
   key: string,

--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -32,7 +32,8 @@ interface StateEntry extends HistoryState {
 
 /**
  * Creates a normalized history location from a window.location object
- * @param location -
+ * @param base - The base path
+ * @param location - The window.location object
  */
 function createCurrentLocation(
   base: string,

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -121,6 +121,7 @@ export function stripBase(pathname: string, base: string): string {
  * pointing towards the same {@link RouteRecord} and that all `params`, `query`
  * parameters and `hash` are the same
  *
+ * @param stringifyQuery - A function that takes a query object of type LocationQueryRaw and returns a string representation of it.
  * @param a - first {@link RouteLocation}
  * @param b - second {@link RouteLocation}
  */


### PR DESCRIPTION
Summary
This PR removes the unnecessary await keyword from extractComponentsGuards and makes some minor adjustments.