### PR TITLE
docs(zh): update typed routes sidebar

### DIFF
--- a/packages/docs/.vitepress/config/zh.ts
+++ b/packages/docs/.vitepress/config/zh.ts
@@ -152,6 +152,10 @@ export const zhConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
               link: '/zh/guide/advanced/lazy-loading.html',
             },
             {
+              text: '类型化路由',
+              link: '/zh/guide/advanced/typed-routes.html'
+            },
+            {
               text: '扩展 RouterLink',
               link: '/zh/guide/advanced/extending-router-link.html',
             },


### PR DESCRIPTION
Currently, zh docs have no Typed Routes entry in the sidebar.

![image](https://user-images.githubusercontent.com/54026110/232196438-0f856d0a-4cea-48b5-91a6-6064bb84f7ee.png) ![image](https://user-images.githubusercontent.com/54026110/232196443-874a072d-ea34-4ccb-ad58-b2410c42a723.png)
