### PR TITLE
docs(zh): fix typo

### DIFF
--- a/packages/docs/zh/guide/advanced/navigation-failures.md
+++ b/packages/docs/zh/guide/advanced/navigation-failures.md
@@ -77,7 +77,7 @@ if (isNavigationFailure(failure, NavigationFailureType.aborted)) {
 ```js
 // 正在尝试访问 admin 页面
 router.push('/admin').then(failure => {
-  if (isNavigationFailure(failure, NavigationFailureType.redirected)) {
+  if (isNavigationFailure(failure, NavigationFailureType.aborted)) {
     failure.to.path // '/admin'
     failure.from.path // '/'
   }


### PR DESCRIPTION
above document and english docs, there should be `aborted`