### PR TITLE
fix:enable vue-router to operate normally in the micro-front project with react-router instance

### DIFF
--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -265,7 +265,7 @@ function useHistoryStateNavigation(base: string) {
     // Add to current entry the information of where we are going
     // as well as saving the current position
     const currentState = assign(
-      {},
+      {current: location.pathname},
       // use current history state to gracefully handle a wrong call to
       // history.replaceState
       // https://github.com/vuejs/router/issues/366


### PR DESCRIPTION
When we create a front-end project with a microfront-end architecture like qiankun, the main application uses vue-router, and the sub app uses react-router, which causes value of history.state.current is undefined