### PR TITLE
fix: remove nullish params when resolving

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -297,20 +297,25 @@ describe('Router', () => {
     expect(router.currentRoute.value).toMatchObject({ params: { p: '0' } })
   })
 
-  it('casts null/undefined params to empty strings', async () => {
+  it('removes null/undefined params', async () => {
     const { router } = await newRouter()
-    expect(
-      router.resolve({ name: 'optional', params: { p: undefined } })
-    ).toMatchObject({
-      params: {},
+
+    const route1 = router.resolve({
+      name: 'optional',
+      params: { p: undefined },
     })
-    expect(
-      router.resolve({ name: 'optional', params: { p: null } })
-    ).toMatchObject({
-      params: {},
+    expect(route1.path).toBe('/optional')
+    expect(route1.params).toEqual({})
+
+    const route2 = router.resolve({
+      name: 'optional',
+      params: { p: null },
     })
+    expect(route2.path).toBe('/optional')
+    expect(route2.params).toEqual({})
+
     await router.push({ name: 'optional', params: { p: null } })
-    expect(router.currentRoute.value).toMatchObject({ params: {} })
+    expect(router.currentRoute.value.params).toEqual({})
     await router.push({ name: 'optional', params: {} })
   })
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -491,7 +491,7 @@ export function createRouter(options: RouterOptions): Router {
       }
       // pass encoded values to the matcher, so it can produce encoded path and fullPath
       matcherLocation = assign({}, rawLocation, {
-        params: encodeParams(rawLocation.params),
+        params: encodeParams(targetParams),
       })
       // current location params are decoded, we need to encode them in case the
       // matcher merges the params


### PR DESCRIPTION
### Introduction

This line appears in `router.ts`:

```js
const targetParams = assign({}, rawLocation.params)
```

The lines that follow update the contents of `targetParams` to remove nullish values, but that object is never actually used anywhere.

### Background

That code was introduced in change ebca15a0140453c6671fdae7a9864badc650531e. From what I can tell, `targetParams` was supposed to be used to build `matcherLocation` on the lines that follow, but instead it is using the original `rawLocation.params`.

The accompanying test also contains a problem. It is using `toMatchObject()` to verify that the `params` object is empty. Unfortunately, `toMatchObject()` only checks properties that are present in the expectation, it won't fail for any extra properties that are present. So even though it appears to be verifying that the `params` is empty, that isn't really what it's doing. The `params` object still contains the `null` and `undefined` property values.

### Proposed Solution

I've assumed the intention is for the `null` and `undefined` values to be removed, so I've adjusted the code accordingly.

However, if the current behaviour is deemed correct then the alternative 'fix' would be to remove this section of the code, as it currently isn't doing anything.