### PR TITLE
docs: Add correct type-aliases links for API interfaces

### DIFF
--- a/packages/docs/api/enums/NavigationFailureType.md
+++ b/packages/docs/api/enums/NavigationFailureType.md
@@ -7,31 +7,31 @@ editLink: false
 # Enumeration: NavigationFailureType
 
 Enumeration with all possible types for navigation failures. Can be passed to
-[isNavigationFailure](../index.md#isnavigationfailure) to check for specific failures.
+[isNavigationFailure](../index.md#Functions-isNavigationFailure) to check for specific failures.
 
 ## Enumeration Members %{#Enumeration-Members}%
 
 ### aborted %{#Enumeration-Members-aborted}%
 
-• **aborted** = ``4``
+• **aborted** = `4`
 
 An aborted navigation is a navigation that failed because a navigation
 guard returned `false` or called `next(false)`
 
-___
+---
 
 ### cancelled %{#Enumeration-Members-cancelled}%
 
-• **cancelled** = ``8``
+• **cancelled** = `8`
 
 A cancelled navigation is a navigation that failed because a more recent
 navigation finished started (not necessarily finished).
 
-___
+---
 
 ### duplicated %{#Enumeration-Members-duplicated}%
 
-• **duplicated** = ``16``
+• **duplicated** = `16`
 
 A duplicated navigation is a navigation that failed because it was
 initiated while already being at the exact same location.

--- a/packages/docs/api/index.md
+++ b/packages/docs/api/index.md
@@ -36,23 +36,23 @@ API Documentation
 
 Normalized query object that appears in [RouteLocationNormalized](interfaces/RouteLocationNormalized.md)
 
-___
+---
 
 ### LocationQueryRaw %{#Type-Aliases-LocationQueryRaw}%
 
 Ƭ **LocationQueryRaw**: `Record`<`string` \| `number`, `LocationQueryValueRaw` \| `LocationQueryValueRaw`[]\>
 
-Loose [LocationQuery](index.md#locationquery) object that can be passed to functions like
+Loose [LocationQuery](index.md#Type-Aliases-LocationQuery) object that can be passed to functions like
 [push](interfaces/Router.md#push) and [replace](interfaces/Router.md#replace) or anywhere when creating a
-[RouteLocationRaw](index.md#routelocationraw)
+[RouteLocationRaw](index.md#Type-Aliases-RouteLocationRaw)
 
-___
+---
 
 ### PathParserOptions %{#Type-Aliases-PathParserOptions}%
 
-Ƭ **PathParserOptions**: `Pick`<`_PathParserOptions`, ``"end"`` \| ``"sensitive"`` \| ``"strict"``\>
+Ƭ **PathParserOptions**: `Pick`<`_PathParserOptions`, `"end"` \| `"sensitive"` \| `"strict"`\>
 
-___
+---
 
 ### RouteComponent %{#Type-Aliases-RouteComponent}%
 
@@ -60,7 +60,7 @@ ___
 
 Allowed Component in [RouteLocationMatched](interfaces/RouteLocationMatched.md)
 
-___
+---
 
 ### RouteLocationRaw %{#Type-Aliases-RouteLocationRaw}%
 
@@ -68,27 +68,27 @@ ___
 
 User-level route location
 
-___
+---
 
 ### RouteParams %{#Type-Aliases-RouteParams}%
 
 Ƭ **RouteParams**: `Record`<`string`, `RouteParamValue` \| `RouteParamValue`[]\>
 
-___
+---
 
 ### RouteParamsRaw %{#Type-Aliases-RouteParamsRaw}%
 
-Ƭ **RouteParamsRaw**: `Record`<`string`, `RouteParamValueRaw` \| `Exclude`<`RouteParamValueRaw`, ``null`` \| `undefined`\>[]\>
+Ƭ **RouteParamsRaw**: `Record`<`string`, `RouteParamValueRaw` \| `Exclude`<`RouteParamValueRaw`, `null` \| `undefined`\>[]\>
 
-___
+---
 
 ### RouteRecord %{#Type-Aliases-RouteRecord}%
 
 Ƭ **RouteRecord**: [`RouteRecordNormalized`](interfaces/RouteRecordNormalized.md)
 
-Normalized version of a [route record](index.md#routerecord).
+Normalized version of a [route record](index.md#Type-Aliases-RouteRecord).
 
-___
+---
 
 ### RouteRecordName %{#Type-Aliases-RouteRecordName}%
 
@@ -96,13 +96,13 @@ ___
 
 Possible values for a user-defined route record's name
 
-___
+---
 
 ### RouteRecordRaw %{#Type-Aliases-RouteRecordRaw}%
 
 Ƭ **RouteRecordRaw**: `RouteRecordSingleView` \| `RouteRecordSingleViewWithChildren` \| `RouteRecordMultipleViews` \| `RouteRecordMultipleViewsWithChildren` \| `RouteRecordRedirect`
 
-___
+---
 
 ### UseLinkOptions %{#Type-Aliases-UseLinkOptions}%
 
@@ -116,11 +116,11 @@ ___
 
 Component to render a link that triggers a navigation on click.
 
-___
+---
 
 ### RouterView %{#Variables-RouterView}%
 
-• `Const` **RouterView**: () => { `$props`: `AllowedComponentProps` & `ComponentCustomProps` & `VNodeProps` & [`RouterViewProps`](interfaces/RouterViewProps.md) ; `$slots`: { `default?`: (`__namedParameters`: { `Component`: `VNode`<`RendererNode`, `RendererElement`, { `[key: string]`: `any`;  }\> ; `route`: [`RouteLocationNormalizedLoaded`](interfaces/RouteLocationNormalizedLoaded.md)  }) => `VNode`<`RendererNode`, `RendererElement`, { `[key: string]`: `any`;  }\>[]  }  }
+• `Const` **RouterView**: () => { `$props`: `AllowedComponentProps` & `ComponentCustomProps` & `VNodeProps` & [`RouterViewProps`](interfaces/RouterViewProps.md) ; `$slots`: { `default?`: (`__namedParameters`: { `Component`: `VNode`<`RendererNode`, `RendererElement`, { `[key: string]`: `any`; }\> ; `route`: [`RouteLocationNormalizedLoaded`](interfaces/RouteLocationNormalizedLoaded.md) }) => `VNode`<`RendererNode`, `RendererElement`, { `[key: string]`: `any`; }\>[] } }
 
 #### Type declaration %{#Variables-RouterView-Type-declaration}%
 
@@ -128,11 +128,11 @@ ___
 
 Component to display the current route the user is at.
 
-___
+---
 
-### START\_LOCATION %{#Variables-START_LOCATION}%
+### START_LOCATION %{#Variables-START_LOCATION}%
 
-• `Const` **START\_LOCATION**: [`RouteLocationNormalizedLoaded`](interfaces/RouteLocationNormalizedLoaded.md)
+• `Const` **START_LOCATION**: [`RouteLocationNormalizedLoaded`](interfaces/RouteLocationNormalizedLoaded.md)
 
 Initial route location where the router is. Can be used in navigation guards
 to differentiate the initial navigation.
@@ -160,9 +160,9 @@ It's up to the user to replace that location with the starter location by either
 
 #### Parameters %{#Functions-createMemoryHistory-Parameters}%
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `base` | `string` | `''` | Base applied to all urls, defaults to '/' |
+| Name   | Type     | Default value | Description                               |
+| :----- | :------- | :------------ | :---------------------------------------- |
+| `base` | `string` | `''`          | Base applied to all urls, defaults to '/' |
 
 #### Returns %{#Functions-createMemoryHistory-Returns}%
 
@@ -170,7 +170,7 @@ It's up to the user to replace that location with the starter location by either
 
 a history object that can be passed to the router constructor
 
-___
+---
 
 ### createRouter %{#Functions-createRouter}%
 
@@ -180,15 +180,15 @@ Creates a Router instance that can be used by a Vue app.
 
 #### Parameters %{#Functions-createRouter-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type                                           | Description                                  |
+| :-------- | :--------------------------------------------- | :------------------------------------------- |
 | `options` | [`RouterOptions`](interfaces/RouterOptions.md) | [RouterOptions](interfaces/RouterOptions.md) |
 
 #### Returns %{#Functions-createRouter-Returns}%
 
 [`Router`](interfaces/Router.md)
 
-___
+---
 
 ### createWebHashHistory %{#Functions-createWebHashHistory}%
 
@@ -215,15 +215,15 @@ createWebHashHistory('/iAmIgnored') // gives a url of `file:///usr/etc/folder/in
 
 #### Parameters %{#Functions-createWebHashHistory-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type     | Description                                                                                                                                                                                                                                                                                                                                                        |
+| :------ | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `base?` | `string` | optional base to provide. Defaults to `location.pathname + location.search` If there is a `<base>` tag in the `head`, its value will be ignored in favor of this parameter **but note it affects all the history.pushState() calls**, meaning that if you use a `<base>` tag, it's `href` value **has to match this parameter** (ignoring anything after the `#`). |
 
 #### Returns %{#Functions-createWebHashHistory-Returns}%
 
 [`RouterHistory`](interfaces/RouterHistory.md)
 
-___
+---
 
 ### createWebHistory %{#Functions-createWebHistory}%
 
@@ -233,15 +233,15 @@ Creates an HTML5 history. Most common history for single page applications.
 
 #### Parameters %{#Functions-createWebHistory-Parameters}%
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type     |
+| :------ | :------- |
 | `base?` | `string` |
 
 #### Returns %{#Functions-createWebHistory-Returns}%
 
 [`RouterHistory`](interfaces/RouterHistory.md)
 
-___
+---
 
 ### isNavigationFailure %{#Functions-isNavigationFailure}%
 
@@ -264,7 +264,12 @@ router.afterEach((to, from, failure) => {
     // ...
   }
   // Aborted or canceled navigations
-  if (isNavigationFailure(failure, NavigationFailureType.aborted | NavigationFailureType.canceled)) {
+  if (
+    isNavigationFailure(
+      failure,
+      NavigationFailureType.aborted | NavigationFailureType.canceled
+    )
+  ) {
     // ...
   }
 })
@@ -272,10 +277,10 @@ router.afterEach((to, from, failure) => {
 
 #### Parameters %{#Functions-isNavigationFailure-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `error` | `any` | possible [NavigationFailure](interfaces/NavigationFailure.md) |
-| `type?` | `NAVIGATION_GUARD_REDIRECT` | optional types to check for |
+| Name    | Type                        | Description                                                   |
+| :------ | :-------------------------- | :------------------------------------------------------------ |
+| `error` | `any`                       | possible [NavigationFailure](interfaces/NavigationFailure.md) |
+| `type?` | `NAVIGATION_GUARD_REDIRECT` | optional types to check for                                   |
 
 #### Returns %{#Functions-isNavigationFailure-Returns}%
 
@@ -285,16 +290,16 @@ error is NavigationRedirectError
 
 #### Parameters %{#Functions-isNavigationFailure-Parameters_1}%
 
-| Name | Type |
-| :------ | :------ |
-| `error` | `any` |
+| Name    | Type                                                                      |
+| :------ | :------------------------------------------------------------------------ |
+| `error` | `any`                                                                     |
 | `type?` | `ErrorTypes` \| [`NavigationFailureType`](enums/NavigationFailureType.md) |
 
 #### Returns %{#Functions-isNavigationFailure-Returns_1}%
 
 error is NavigationFailure
 
-___
+---
 
 ### loadRouteLocation %{#Functions-loadRouteLocation}%
 
@@ -304,15 +309,15 @@ Ensures a route is loaded, so it can be passed as o prop to `<RouterView>`.
 
 #### Parameters %{#Functions-loadRouteLocation-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                                               | Description            |
+| :------ | :----------------------------------------------------------------- | :--------------------- |
 | `route` | [`RouteLocationNormalized`](interfaces/RouteLocationNormalized.md) | resolved route to load |
 
 #### Returns %{#Functions-loadRouteLocation-Returns}%
 
 `Promise`<[`RouteLocationNormalizedLoaded`](interfaces/RouteLocationNormalizedLoaded.md)\>
 
-___
+---
 
 ### onBeforeRouteLeave %{#Functions-onBeforeRouteLeave}%
 
@@ -324,15 +329,15 @@ used in any component. The guard is removed when the component is unmounted.
 
 #### Parameters %{#Functions-onBeforeRouteLeave-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name         | Type                                               | Description                                      |
+| :----------- | :------------------------------------------------- | :----------------------------------------------- |
 | `leaveGuard` | [`NavigationGuard`](interfaces/NavigationGuard.md) | [NavigationGuard](interfaces/NavigationGuard.md) |
 
 #### Returns %{#Functions-onBeforeRouteLeave-Returns}%
 
 `void`
 
-___
+---
 
 ### onBeforeRouteUpdate %{#Functions-onBeforeRouteUpdate}%
 
@@ -344,15 +349,15 @@ component. The guard is removed when the component is unmounted.
 
 #### Parameters %{#Functions-onBeforeRouteUpdate-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name          | Type                                               | Description                                      |
+| :------------ | :------------------------------------------------- | :----------------------------------------------- |
 | `updateGuard` | [`NavigationGuard`](interfaces/NavigationGuard.md) | [NavigationGuard](interfaces/NavigationGuard.md) |
 
 #### Returns %{#Functions-onBeforeRouteUpdate-Returns}%
 
 `void`
 
-___
+---
 
 ### useLink %{#Functions-useLink}%
 
@@ -360,23 +365,23 @@ ___
 
 #### Parameters %{#Functions-useLink-Parameters}%
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type                                  |
+| :------ | :------------------------------------ |
 | `props` | `VueUseOptions`<`RouterLinkOptions`\> |
 
 #### Returns %{#Functions-useLink-Returns}%
 
 `Object`
 
-| Name | Type |
-| :------ | :------ |
-| `href` | `ComputedRef`<`string`\> |
-| `isActive` | `ComputedRef`<`boolean`\> |
-| `isExactActive` | `ComputedRef`<`boolean`\> |
-| `navigate` | (`e`: `MouseEvent`) => `Promise`<`void` \| [`NavigationFailure`](interfaces/NavigationFailure.md)\> |
-| `route` | `ComputedRef`<[`RouteLocation`](interfaces/RouteLocation.md) & { `href`: `string`  }\> |
+| Name            | Type                                                                                                |
+| :-------------- | :-------------------------------------------------------------------------------------------------- |
+| `href`          | `ComputedRef`<`string`\>                                                                            |
+| `isActive`      | `ComputedRef`<`boolean`\>                                                                           |
+| `isExactActive` | `ComputedRef`<`boolean`\>                                                                           |
+| `navigate`      | (`e`: `MouseEvent`) => `Promise`<`void` \| [`NavigationFailure`](interfaces/NavigationFailure.md)\> |
+| `route`         | `ComputedRef`<[`RouteLocation`](interfaces/RouteLocation.md) & { `href`: `string` }\>               |
 
-___
+---
 
 ### useRoute %{#Functions-useRoute}%
 
@@ -389,7 +394,7 @@ templates.
 
 [`RouteLocationNormalizedLoaded`](interfaces/RouteLocationNormalizedLoaded.md)
 
-___
+---
 
 ### useRouter %{#Functions-useRouter}%
 

--- a/packages/docs/api/interfaces/NavigationGuardNext.md
+++ b/packages/docs/api/interfaces/NavigationGuardNext.md
@@ -22,7 +22,7 @@ editLink: false
 
 #### Parameters %{#Callable-NavigationGuardNext-Parameters}%
 
-| Name | Type |
+| Name    | Type    |
 | :------ | :------ |
 | `error` | `Error` |
 
@@ -36,9 +36,9 @@ editLink: false
 
 #### Parameters %{#Callable-NavigationGuardNext-Parameters_1}%
 
-| Name | Type |
-| :------ | :------ |
-| `location` | [`RouteLocationRaw`](../index.md#routelocationraw) |
+| Name       | Type                                                            |
+| :--------- | :-------------------------------------------------------------- |
+| `location` | [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw) |
 
 #### Returns %{#Callable-NavigationGuardNext-Returns_2}%
 
@@ -50,8 +50,8 @@ editLink: false
 
 #### Parameters %{#Callable-NavigationGuardNext-Parameters_2}%
 
-| Name | Type |
-| :------ | :------ |
+| Name    | Type                     |
+| :------ | :----------------------- |
 | `valid` | `undefined` \| `boolean` |
 
 #### Returns %{#Callable-NavigationGuardNext-Returns_3}%
@@ -64,8 +64,8 @@ editLink: false
 
 #### Parameters %{#Callable-NavigationGuardNext-Parameters_3}%
 
-| Name | Type |
-| :------ | :------ |
+| Name | Type                          |
+| :--- | :---------------------------- |
 | `cb` | `NavigationGuardNextCallback` |
 
 #### Returns %{#Callable-NavigationGuardNext-Returns_4}%

--- a/packages/docs/api/interfaces/RouteLocation.md
+++ b/packages/docs/api/interfaces/RouteLocation.md
@@ -6,7 +6,7 @@ editLink: false
 
 # Interface: RouteLocation
 
-[RouteLocationRaw](../index.md#routelocationraw) resolved using the matcher
+[RouteLocationRaw](../index.md#Type-Aliases-RouteLocationRaw) resolved using the matcher
 
 ## Hierarchy %{#Hierarchy}%
 
@@ -27,7 +27,7 @@ percentage encoded.
 
 \_RouteLocationBase.fullPath
 
-___
+---
 
 ### hash %{#Properties-hash}%
 
@@ -39,17 +39,17 @@ Hash of the current location. If present, starts with a `#`.
 
 \_RouteLocationBase.hash
 
-___
+---
 
 ### matched %{#Properties-matched}%
 
 • **matched**: [`RouteRecordNormalized`](RouteRecordNormalized.md)[]
 
-Array of [RouteRecord](../index.md#routerecord) containing components as they were
+Array of [RouteRecord](../index.md#Type-Aliases-RouteRecord) containing components as they were
 passed when adding records. It can also contain redirect records. This
 can't be used directly
 
-___
+---
 
 ### meta %{#Properties-meta}%
 
@@ -61,11 +61,11 @@ Merged `meta` properties from all the matched route records.
 
 \_RouteLocationBase.meta
 
-___
+---
 
 ### name %{#Properties-name}%
 
-• **name**: `undefined` \| ``null`` \| [`RouteRecordName`](../index.md#routerecordname)
+• **name**: `undefined` \| `null` \| [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName)
 
 Name of the matched record
 
@@ -73,11 +73,11 @@ Name of the matched record
 
 \_RouteLocationBase.name
 
-___
+---
 
 ### params %{#Properties-params}%
 
-• **params**: [`RouteParams`](../index.md#routeparams)
+• **params**: [`RouteParams`](../index.md#Type-Aliases-RouteParams)
 
 Object of decoded params extracted from the `path`.
 
@@ -85,7 +85,7 @@ Object of decoded params extracted from the `path`.
 
 \_RouteLocationBase.params
 
-___
+---
 
 ### path %{#Properties-path}%
 
@@ -97,11 +97,11 @@ Percentage encoded pathname section of the URL.
 
 \_RouteLocationBase.path
 
-___
+---
 
 ### query %{#Properties-query}%
 
-• **query**: [`LocationQuery`](../index.md#locationquery)
+• **query**: [`LocationQuery`](../index.md#Type-Aliases-LocationQuery)
 
 Object representation of the `search` property of the current location.
 
@@ -109,7 +109,7 @@ Object representation of the `search` property of the current location.
 
 \_RouteLocationBase.query
 
-___
+---
 
 ### redirectedFrom %{#Properties-redirectedFrom}%
 

--- a/packages/docs/api/interfaces/RouteLocationMatched.md
+++ b/packages/docs/api/interfaces/RouteLocationMatched.md
@@ -6,7 +6,7 @@ editLink: false
 
 # Interface: RouteLocationMatched
 
-Normalized version of a [route record](../index.md#routerecord).
+Normalized version of a [route record](../index.md#Type-Aliases-RouteRecord).
 
 ## Hierarchy %{#Hierarchy}%
 
@@ -27,7 +27,7 @@ Defines if this record is the alias of another one. This property is
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[aliasOf](RouteRecordNormalized.md#aliasof)
 
-___
+---
 
 ### beforeEnter %{#Properties-beforeEnter}%
 
@@ -39,11 +39,11 @@ Registered beforeEnter guards
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[beforeEnter](RouteRecordNormalized.md#beforeenter)
 
-___
+---
 
 ### children %{#Properties-children}%
 
-• **children**: [`RouteRecordRaw`](../index.md#routerecordraw)[]
+• **children**: [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw)[]
 
 Nested route records.
 
@@ -51,11 +51,11 @@ Nested route records.
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[children](RouteRecordNormalized.md#children)
 
-___
+---
 
 ### components %{#Properties-components}%
 
-• **components**: `undefined` \| ``null`` \| `Record`<`string`, [`RouteComponent`](../index.md#routecomponent)\>
+• **components**: `undefined` \| `null` \| `Record`<`string`, [`RouteComponent`](../index.md#Type-Aliases-RouteComponent)\>
 
 {@inheritDoc RouteRecordMultipleViews.components}
 
@@ -63,11 +63,11 @@ ___
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[components](RouteRecordNormalized.md#components)
 
-___
+---
 
 ### instances %{#Properties-instances}%
 
-• **instances**: `Record`<`string`, `undefined` \| ``null`` \| `ComponentPublicInstance`<{}, {}, {}, {}, {}, {}, {}, {}, ``false``, `ComponentOptionsBase`<`any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, {}, {}, `string`, {}\>, {}, {}\>\>
+• **instances**: `Record`<`string`, `undefined` \| `null` \| `ComponentPublicInstance`<{}, {}, {}, {}, {}, {}, {}, {}, `false`, `ComponentOptionsBase`<`any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, {}, {}, `string`, {}\>, {}, {}\>\>
 
 Mounted route component instances
 Having the instances on the record mean beforeRouteUpdate and
@@ -81,43 +81,43 @@ views.
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[instances](RouteRecordNormalized.md#instances)
 
-___
+---
 
 ### meta %{#Properties-meta}%
 
 • **meta**: [`RouteMeta`](RouteMeta.md)
 
-{@inheritDoc _RouteRecordBase.meta}
+{@inheritDoc \_RouteRecordBase.meta}
 
 #### Inherited from %{#Properties-meta-Inherited-from}%
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[meta](RouteRecordNormalized.md#meta)
 
-___
+---
 
 ### name %{#Properties-name}%
 
-• **name**: `undefined` \| [`RouteRecordName`](../index.md#routerecordname)
+• **name**: `undefined` \| [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName)
 
-{@inheritDoc _RouteRecordBase.name}
+{@inheritDoc \_RouteRecordBase.name}
 
 #### Inherited from %{#Properties-name-Inherited-from}%
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[name](RouteRecordNormalized.md#name)
 
-___
+---
 
 ### path %{#Properties-path}%
 
 • **path**: `string`
 
-{@inheritDoc _RouteRecordBase.path}
+{@inheritDoc \_RouteRecordBase.path}
 
 #### Inherited from %{#Properties-path-Inherited-from}%
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[path](RouteRecordNormalized.md#path)
 
-___
+---
 
 ### props %{#Properties-props}%
 
@@ -129,13 +129,13 @@ ___
 
 [RouteRecordNormalized](RouteRecordNormalized.md).[props](RouteRecordNormalized.md#props)
 
-___
+---
 
 ### redirect %{#Properties-redirect}%
 
 • **redirect**: `undefined` \| `RouteRecordRedirectOption`
 
-{@inheritDoc _RouteRecordBase.redirect}
+{@inheritDoc \_RouteRecordBase.redirect}
 
 #### Inherited from %{#Properties-redirect-Inherited-from}%
 

--- a/packages/docs/api/interfaces/RouteLocationNormalized.md
+++ b/packages/docs/api/interfaces/RouteLocationNormalized.md
@@ -28,7 +28,7 @@ percentage encoded.
 
 \_RouteLocationBase.fullPath
 
-___
+---
 
 ### hash %{#Properties-hash}%
 
@@ -40,7 +40,7 @@ Hash of the current location. If present, starts with a `#`.
 
 \_RouteLocationBase.hash
 
-___
+---
 
 ### matched %{#Properties-matched}%
 
@@ -48,7 +48,7 @@ ___
 
 Array of [RouteRecordNormalized](RouteRecordNormalized.md)
 
-___
+---
 
 ### meta %{#Properties-meta}%
 
@@ -60,11 +60,11 @@ Merged `meta` properties from all the matched route records.
 
 \_RouteLocationBase.meta
 
-___
+---
 
 ### name %{#Properties-name}%
 
-• **name**: `undefined` \| ``null`` \| [`RouteRecordName`](../index.md#routerecordname)
+• **name**: `undefined` \| `null` \| [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName)
 
 Name of the matched record
 
@@ -72,11 +72,11 @@ Name of the matched record
 
 \_RouteLocationBase.name
 
-___
+---
 
 ### params %{#Properties-params}%
 
-• **params**: [`RouteParams`](../index.md#routeparams)
+• **params**: [`RouteParams`](../index.md#Type-Aliases-RouteParams)
 
 Object of decoded params extracted from the `path`.
 
@@ -84,7 +84,7 @@ Object of decoded params extracted from the `path`.
 
 \_RouteLocationBase.params
 
-___
+---
 
 ### path %{#Properties-path}%
 
@@ -96,11 +96,11 @@ Percentage encoded pathname section of the URL.
 
 \_RouteLocationBase.path
 
-___
+---
 
 ### query %{#Properties-query}%
 
-• **query**: [`LocationQuery`](../index.md#locationquery)
+• **query**: [`LocationQuery`](../index.md#Type-Aliases-LocationQuery)
 
 Object representation of the `search` property of the current location.
 
@@ -108,7 +108,7 @@ Object representation of the `search` property of the current location.
 
 \_RouteLocationBase.query
 
-___
+---
 
 ### redirectedFrom %{#Properties-redirectedFrom}%
 

--- a/packages/docs/api/interfaces/RouteLocationNormalizedLoaded.md
+++ b/packages/docs/api/interfaces/RouteLocationNormalizedLoaded.md
@@ -6,7 +6,7 @@ editLink: false
 
 # Interface: RouteLocationNormalizedLoaded
 
-[RouteLocationRaw](../index.md#routelocationraw) with
+[RouteLocationRaw](../index.md#Type-Aliases-RouteLocationRaw) with
 
 ## Hierarchy %{#Hierarchy}%
 
@@ -27,7 +27,7 @@ percentage encoded.
 
 \_RouteLocationBase.fullPath
 
-___
+---
 
 ### hash %{#Properties-hash}%
 
@@ -39,7 +39,7 @@ Hash of the current location. If present, starts with a `#`.
 
 \_RouteLocationBase.hash
 
-___
+---
 
 ### matched %{#Properties-matched}%
 
@@ -50,7 +50,7 @@ lazy-loaded components have been loaded and were replaced inside the
 `components` object) so it can be directly used to display routes. It
 cannot contain redirect records either
 
-___
+---
 
 ### meta %{#Properties-meta}%
 
@@ -62,11 +62,11 @@ Merged `meta` properties from all the matched route records.
 
 \_RouteLocationBase.meta
 
-___
+---
 
 ### name %{#Properties-name}%
 
-• **name**: `undefined` \| ``null`` \| [`RouteRecordName`](../index.md#routerecordname)
+• **name**: `undefined` \| `null` \| [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName)
 
 Name of the matched record
 
@@ -74,11 +74,11 @@ Name of the matched record
 
 \_RouteLocationBase.name
 
-___
+---
 
 ### params %{#Properties-params}%
 
-• **params**: [`RouteParams`](../index.md#routeparams)
+• **params**: [`RouteParams`](../index.md#Type-Aliases-RouteParams)
 
 Object of decoded params extracted from the `path`.
 
@@ -86,7 +86,7 @@ Object of decoded params extracted from the `path`.
 
 \_RouteLocationBase.params
 
-___
+---
 
 ### path %{#Properties-path}%
 
@@ -98,11 +98,11 @@ Percentage encoded pathname section of the URL.
 
 \_RouteLocationBase.path
 
-___
+---
 
 ### query %{#Properties-query}%
 
-• **query**: [`LocationQuery`](../index.md#locationquery)
+• **query**: [`LocationQuery`](../index.md#Type-Aliases-LocationQuery)
 
 Object representation of the `search` property of the current location.
 
@@ -110,7 +110,7 @@ Object representation of the `search` property of the current location.
 
 \_RouteLocationBase.query
 
-___
+---
 
 ### redirectedFrom %{#Properties-redirectedFrom}%
 

--- a/packages/docs/api/interfaces/RouteRecordNormalized.md
+++ b/packages/docs/api/interfaces/RouteRecordNormalized.md
@@ -6,7 +6,7 @@ editLink: false
 
 # Interface: RouteRecordNormalized
 
-Normalized version of a [route record](../index.md#routerecord).
+Normalized version of a [route record](../index.md#Type-Aliases-RouteRecord).
 
 ## Hierarchy %{#Hierarchy}%
 
@@ -23,7 +23,7 @@ Normalized version of a [route record](../index.md#routerecord).
 Defines if this record is the alias of another one. This property is
 `undefined` if the record is the original one.
 
-___
+---
 
 ### beforeEnter %{#Properties-beforeEnter}%
 
@@ -31,27 +31,27 @@ ___
 
 Registered beforeEnter guards
 
-___
+---
 
 ### children %{#Properties-children}%
 
-• **children**: [`RouteRecordRaw`](../index.md#routerecordraw)[]
+• **children**: [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw)[]
 
 Nested route records.
 
-___
+---
 
 ### components %{#Properties-components}%
 
-• **components**: `undefined` \| ``null`` \| `Record`<`string`, `RawRouteComponent`\>
+• **components**: `undefined` \| `null` \| `Record`<`string`, `RawRouteComponent`\>
 
 {@inheritDoc RouteRecordMultipleViews.components}
 
-___
+---
 
 ### instances %{#Properties-instances}%
 
-• **instances**: `Record`<`string`, `undefined` \| ``null`` \| `ComponentPublicInstance`<{}, {}, {}, {}, {}, {}, {}, {}, ``false``, `ComponentOptionsBase`<`any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, {}, {}, `string`, {}\>, {}, {}\>\>
+• **instances**: `Record`<`string`, `undefined` \| `null` \| `ComponentPublicInstance`<{}, {}, {}, {}, {}, {}, {}, {}, `false`, `ComponentOptionsBase`<`any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, `any`, {}, {}, `string`, {}\>, {}, {}\>\>
 
 Mounted route component instances
 Having the instances on the record mean beforeRouteUpdate and
@@ -61,31 +61,31 @@ view, basically duplicating the content on the page, which shouldn't happen
 in practice. It will work if multiple apps are rendering different named
 views.
 
-___
+---
 
 ### meta %{#Properties-meta}%
 
 • **meta**: [`RouteMeta`](RouteMeta.md)
 
-{@inheritDoc _RouteRecordBase.meta}
+{@inheritDoc \_RouteRecordBase.meta}
 
-___
+---
 
 ### name %{#Properties-name}%
 
-• **name**: `undefined` \| [`RouteRecordName`](../index.md#routerecordname)
+• **name**: `undefined` \| [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName)
 
-{@inheritDoc _RouteRecordBase.name}
+{@inheritDoc \_RouteRecordBase.name}
 
-___
+---
 
 ### path %{#Properties-path}%
 
 • **path**: `string`
 
-{@inheritDoc _RouteRecordBase.path}
+{@inheritDoc \_RouteRecordBase.path}
 
-___
+---
 
 ### props %{#Properties-props}%
 
@@ -93,10 +93,10 @@ ___
 
 {@inheritDoc RouteRecordMultipleViews.props}
 
-___
+---
 
 ### redirect %{#Properties-redirect}%
 
 • **redirect**: `undefined` \| `RouteRecordRedirectOption`
 
-{@inheritDoc _RouteRecordBase.redirect}
+{@inheritDoc \_RouteRecordBase.redirect}

--- a/packages/docs/api/interfaces/Router.md
+++ b/packages/docs/api/interfaces/Router.md
@@ -16,7 +16,7 @@ Router instance.
 
 Current [RouteLocationNormalized](RouteLocationNormalized.md)
 
-___
+---
 
 ### listening %{#Properties-listening}%
 
@@ -24,7 +24,7 @@ ___
 
 Allows turning off the listening of history events. This is a low level api for micro-frontends.
 
-___
+---
 
 ### options %{#Properties-options}%
 
@@ -38,14 +38,14 @@ Original options object passed to create the Router
 
 ▸ **addRoute**(`parentName`, `route`): () => `void`
 
-Add a new [route record](../index.md#routerecordraw) as the child of an existing route.
+Add a new [route record](../index.md#Type-Aliases-RouteRecord) as the child of an existing route.
 
 #### Parameters %{#Methods-addRoute-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `parentName` | [`RouteRecordName`](../index.md#routerecordname) | Parent Route Record where `route` should be appended at |
-| `route` | [`RouteRecordRaw`](../index.md#routerecordraw) | Route Record to add |
+| Name         | Type                                                          | Description                                             |
+| :----------- | :------------------------------------------------------------ | :------------------------------------------------------ |
+| `parentName` | [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName) | Parent Route Record where `route` should be appended at |
+| `route`      | [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw)   | Route Record to add                                     |
 
 #### Returns %{#Methods-addRoute-Returns}%
 
@@ -53,7 +53,7 @@ Add a new [route record](../index.md#routerecordraw) as the child of an existing
 
 ▸ (): `void`
 
-Add a new [route record](../index.md#routerecordraw) as the child of an existing route.
+Add a new [route record](../index.md#Type-Aliases-RouteRecord) as the child of an existing route.
 
 ##### Returns %{#Methods-addRoute-Returns-Returns}%
 
@@ -61,13 +61,13 @@ Add a new [route record](../index.md#routerecordraw) as the child of an existing
 
 ▸ **addRoute**(`route`): () => `void`
 
-Add a new [route record](../index.md#routerecordraw) to the router.
+Add a new [route record](../index.md#Type-Aliases-RouteRecord) to the router.
 
 #### Parameters %{#Methods-addRoute-Parameters_1}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `route` | [`RouteRecordRaw`](../index.md#routerecordraw) | Route Record to add |
+| Name    | Type                                                        | Description         |
+| :------ | :---------------------------------------------------------- | :------------------ |
+| `route` | [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw) | Route Record to add |
 
 #### Returns %{#Methods-addRoute-Returns_1}%
 
@@ -75,13 +75,13 @@ Add a new [route record](../index.md#routerecordraw) to the router.
 
 ▸ (): `void`
 
-Add a new [route record](../index.md#routerecordraw) to the router.
+Add a new [route record](../index.md#Type-Aliases-RouteRecord) to the router.
 
 ##### Returns %{#Methods-addRoute-Returns-Returns_1}%
 
 `void`
 
-___
+---
 
 ### afterEach %{#Methods-afterEach}%
 
@@ -102,8 +102,8 @@ router.afterEach((to, from, failure) => {
 
 #### Parameters %{#Methods-afterEach-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                            | Description            |
+| :------ | :---------------------------------------------- | :--------------------- |
 | `guard` | [`NavigationHookAfter`](NavigationHookAfter.md) | navigation hook to add |
 
 #### Returns %{#Methods-afterEach-Returns}%
@@ -129,7 +129,7 @@ router.afterEach((to, from, failure) => {
 
 `void`
 
-___
+---
 
 ### back %{#Methods-back}%
 
@@ -142,7 +142,7 @@ Go back in history if possible by calling `history.back()`. Equivalent to
 
 `void`
 
-___
+---
 
 ### beforeEach %{#Methods-beforeEach}%
 
@@ -153,8 +153,8 @@ function that removes the registered guard.
 
 #### Parameters %{#Methods-beforeEach-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                                                  | Description             |
+| :------ | :-------------------------------------------------------------------- | :---------------------- |
 | `guard` | [`NavigationGuardWithThis`](NavigationGuardWithThis.md)<`undefined`\> | navigation guard to add |
 
 #### Returns %{#Methods-beforeEach-Returns}%
@@ -170,7 +170,7 @@ function that removes the registered guard.
 
 `void`
 
-___
+---
 
 ### beforeResolve %{#Methods-beforeResolve}%
 
@@ -191,8 +191,8 @@ router.beforeResolve(to => {
 
 #### Parameters %{#Methods-beforeResolve-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type                                                                  | Description             |
+| :------ | :-------------------------------------------------------------------- | :---------------------- |
 | `guard` | [`NavigationGuardWithThis`](NavigationGuardWithThis.md)<`undefined`\> | navigation guard to add |
 
 #### Returns %{#Methods-beforeResolve-Returns}%
@@ -218,7 +218,7 @@ router.beforeResolve(to => {
 
 `void`
 
-___
+---
 
 ### forward %{#Methods-forward}%
 
@@ -231,19 +231,19 @@ Equivalent to `router.go(1)`.
 
 `void`
 
-___
+---
 
 ### getRoutes %{#Methods-getRoutes}%
 
 ▸ **getRoutes**(): [`RouteRecordNormalized`](RouteRecordNormalized.md)[]
 
-Get a full list of all the [route records](../index.md#routerecord).
+Get a full list of all the [route records](../index.md#Type-Aliases-RouteRecord).
 
 #### Returns %{#Methods-getRoutes-Returns}%
 
 [`RouteRecordNormalized`](RouteRecordNormalized.md)[]
 
-___
+---
 
 ### go %{#Methods-go}%
 
@@ -254,15 +254,15 @@ Allows you to move forward or backward through the history. Calls
 
 #### Parameters %{#Methods-go-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name    | Type     | Description                                                                         |
+| :------ | :------- | :---------------------------------------------------------------------------------- |
 | `delta` | `number` | The position in the history to which you want to move, relative to the current page |
 
 #### Returns %{#Methods-go-Returns}%
 
 `void`
 
-___
+---
 
 ### hasRoute %{#Methods-hasRoute}%
 
@@ -272,15 +272,15 @@ Checks if a route with a given name exists
 
 #### Parameters %{#Methods-hasRoute-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | [`RouteRecordName`](../index.md#routerecordname) | Name of the route to check |
+| Name   | Type                                                          | Description                |
+| :----- | :------------------------------------------------------------ | :------------------------- |
+| `name` | [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName) | Name of the route to check |
 
 #### Returns %{#Methods-hasRoute-Returns}%
 
 `boolean`
 
-___
+---
 
 ### isReady %{#Methods-isReady}%
 
@@ -300,7 +300,7 @@ picks it up from the URL.
 
 `Promise`<`void`\>
 
-___
+---
 
 ### onError %{#Methods-onError}%
 
@@ -314,8 +314,8 @@ is required to render a route.
 
 #### Parameters %{#Methods-onError-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
+| Name      | Type            | Description               |
+| :-------- | :-------------- | :------------------------ |
 | `handler` | `_ErrorHandler` | error handler to register |
 
 #### Returns %{#Methods-onError-Returns}%
@@ -334,7 +334,7 @@ is required to render a route.
 
 `void`
 
-___
+---
 
 ### push %{#Methods-push}%
 
@@ -345,15 +345,15 @@ stack.
 
 #### Parameters %{#Methods-push-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `to` | [`RouteLocationRaw`](../index.md#routelocationraw) | Route location to navigate to |
+| Name | Type                                                            | Description                   |
+| :--- | :-------------------------------------------------------------- | :---------------------------- |
+| `to` | [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw) | Route location to navigate to |
 
 #### Returns %{#Methods-push-Returns}%
 
 `Promise`<`undefined` \| `void` \| [`NavigationFailure`](NavigationFailure.md)\>
 
-___
+---
 
 ### removeRoute %{#Methods-removeRoute}%
 
@@ -363,15 +363,15 @@ Remove an existing route by its name.
 
 #### Parameters %{#Methods-removeRoute-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `name` | [`RouteRecordName`](../index.md#routerecordname) | Name of the route to remove |
+| Name   | Type                                                          | Description                 |
+| :----- | :------------------------------------------------------------ | :-------------------------- |
+| `name` | [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName) | Name of the route to remove |
 
 #### Returns %{#Methods-removeRoute-Returns}%
 
 `void`
 
-___
+---
 
 ### replace %{#Methods-replace}%
 
@@ -382,32 +382,32 @@ the history stack.
 
 #### Parameters %{#Methods-replace-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `to` | [`RouteLocationRaw`](../index.md#routelocationraw) | Route location to navigate to |
+| Name | Type                                                            | Description                   |
+| :--- | :-------------------------------------------------------------- | :---------------------------- |
+| `to` | [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw) | Route location to navigate to |
 
 #### Returns %{#Methods-replace-Returns}%
 
 `Promise`<`undefined` \| `void` \| [`NavigationFailure`](NavigationFailure.md)\>
 
-___
+---
 
 ### resolve %{#Methods-resolve}%
 
-▸ **resolve**(`to`, `currentLocation?`): [`RouteLocation`](RouteLocation.md) & { `href`: `string`  }
+▸ **resolve**(`to`, `currentLocation?`): [`RouteLocation`](RouteLocation.md) & { `href`: `string` }
 
 Returns the [normalized version](RouteLocation.md) of a
-[route location](../index.md#routelocationraw). Also includes an `href` property
+[route location](../index.md#Type-Aliases-RouteLocation). Also includes an `href` property
 that includes any existing `base`. By default, the `currentLocation` used is
 `router.currentRoute` and should only be overridden in advanced use cases.
 
 #### Parameters %{#Methods-resolve-Parameters}%
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `to` | [`RouteLocationRaw`](../index.md#routelocationraw) | Raw route location to resolve |
+| Name               | Type                                                                | Description                                  |
+| :----------------- | :------------------------------------------------------------------ | :------------------------------------------- |
+| `to`               | [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw)     | Raw route location to resolve                |
 | `currentLocation?` | [`RouteLocationNormalizedLoaded`](RouteLocationNormalizedLoaded.md) | Optional current location to resolve against |
 
 #### Returns %{#Methods-resolve-Returns}%
 
-[`RouteLocation`](RouteLocation.md) & { `href`: `string`  }
+[`RouteLocation`](RouteLocation.md) & { `href`: `string` }

--- a/packages/docs/api/interfaces/RouterLinkProps.md
+++ b/packages/docs/api/interfaces/RouterLinkProps.md
@@ -20,11 +20,11 @@ editLink: false
 
 Class to apply when the link is active
 
-___
+---
 
 ### ariaCurrentValue %{#Properties-ariaCurrentValue}%
 
-• `Optional` **ariaCurrentValue**: ``"location"`` \| ``"time"`` \| ``"page"`` \| ``"step"`` \| ``"date"`` \| ``"true"`` \| ``"false"``
+• `Optional` **ariaCurrentValue**: `"location"` \| `"time"` \| `"page"` \| `"step"` \| `"date"` \| `"true"` \| `"false"`
 
 Value passed to the attribute `aria-current` when the link is exact active.
 
@@ -32,7 +32,7 @@ Value passed to the attribute `aria-current` when the link is exact active.
 
 `'page'`
 
-___
+---
 
 ### custom %{#Properties-custom}%
 
@@ -41,7 +41,7 @@ ___
 Whether RouterLink should not wrap its content in an `a` tag. Useful when
 using `v-slot` to create a custom RouterLink
 
-___
+---
 
 ### exactActiveClass %{#Properties-exactActiveClass}%
 
@@ -49,7 +49,7 @@ ___
 
 Class to apply when the link is exact active
 
-___
+---
 
 ### replace %{#Properties-replace}%
 
@@ -61,11 +61,11 @@ Calls `router.replace` instead of `router.push`.
 
 RouterLinkOptions.replace
 
-___
+---
 
 ### to %{#Properties-to}%
 
-• **to**: [`RouteLocationRaw`](../index.md#routelocationraw)
+• **to**: [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw)
 
 Route Location the link should navigate to when clicked on.
 

--- a/packages/docs/api/interfaces/RouterOptions.md
+++ b/packages/docs/api/interfaces/RouterOptions.md
@@ -10,7 +10,7 @@ Options to initialize a [Router](Router.md) instance.
 
 ## Hierarchy %{#Hierarchy}%
 
-- [`PathParserOptions`](../index.md#pathparseroptions)
+- [`PathParserOptions`](../index.md#Type-Aliases-PathParserOptions)
 
   ↳ **`RouterOptions`**
 
@@ -30,7 +30,7 @@ Should the RegExp match until the end by appending a `$` to it.
 
 PathParserOptions.end
 
-___
+---
 
 ### history %{#Properties-history}%
 
@@ -51,33 +51,33 @@ createRouter({
 })
 ```
 
-___
+---
 
 ### linkActiveClass %{#Properties-linkActiveClass}%
 
 • `Optional` **linkActiveClass**: `string`
 
-Default class applied to active [RouterLink](../index.md#routerlink). If none is provided,
+Default class applied to active [RouterLink](../index.md#Type-Aliases-RouterLink). If none is provided,
 `router-link-active` will be applied.
 
-___
+---
 
 ### linkExactActiveClass %{#Properties-linkExactActiveClass}%
 
 • `Optional` **linkExactActiveClass**: `string`
 
-Default class applied to exact active [RouterLink](../index.md#routerlink). If none is provided,
+Default class applied to exact active [RouterLink](../index.md#Type-Aliases-RouterLink). If none is provided,
 `router-link-exact-active` will be applied.
 
-___
+---
 
 ### parseQuery %{#Properties-parseQuery}%
 
-• `Optional` **parseQuery**: (`search`: `string`) => [`LocationQuery`](../index.md#locationquery)
+• `Optional` **parseQuery**: (`search`: `string`) => [`LocationQuery`](../index.md#Type-Aliases-LocationQuery)
 
 #### Type declaration %{#Properties-parseQuery-Type-declaration}%
 
-▸ (`search`): [`LocationQuery`](../index.md#locationquery)
+▸ (`search`): [`LocationQuery`](../index.md#Type-Aliases-LocationQuery)
 
 Custom implementation to parse a query. See its counterpart,
 [stringifyQuery](RouterOptions.md#stringifyquery).
@@ -86,6 +86,7 @@ Custom implementation to parse a query. See its counterpart,
 
 Let's say you want to use the [qs package](https://github.com/ljharb/qs)
 to parse queries, you can provide both `parseQuery` and `stringifyQuery`:
+
 ```js
 import qs from 'qs'
 
@@ -98,23 +99,23 @@ createRouter({
 
 ##### Parameters %{#Properties-parseQuery-Type-declaration-Parameters}%
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type     |
+| :------- | :------- |
 | `search` | `string` |
 
 ##### Returns %{#Properties-parseQuery-Type-declaration-Returns}%
 
-[`LocationQuery`](../index.md#locationquery)
+[`LocationQuery`](../index.md#Type-Aliases-LocationQuery)
 
-___
+---
 
 ### routes %{#Properties-routes}%
 
-• **routes**: readonly [`RouteRecordRaw`](../index.md#routerecordraw)[]
+• **routes**: readonly [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw)[]
 
 Initial list of routes that should be added to the router.
 
-___
+---
 
 ### scrollBehavior %{#Properties-scrollBehavior}%
 
@@ -132,7 +133,7 @@ function scrollBehavior(to, from, savedPosition) {
 }
 ```
 
-___
+---
 
 ### sensitive %{#Properties-sensitive}%
 
@@ -148,7 +149,7 @@ Makes the RegExp case-sensitive.
 
 PathParserOptions.sensitive
 
-___
+---
 
 ### strict %{#Properties-strict}%
 
@@ -164,11 +165,11 @@ Whether to disallow a trailing slash or not.
 
 PathParserOptions.strict
 
-___
+---
 
 ### stringifyQuery %{#Properties-stringifyQuery}%
 
-• `Optional` **stringifyQuery**: (`query`: [`LocationQueryRaw`](../index.md#locationqueryraw)) => `string`
+• `Optional` **stringifyQuery**: (`query`: [`LocationQueryRaw`](../index.md#Type-Aliases-LocationQueryRaw)) => `string`
 
 #### Type declaration %{#Properties-stringifyQuery-Type-declaration}%
 
@@ -179,9 +180,9 @@ Custom implementation to stringify a query object. Should not prepend a leading 
 
 ##### Parameters %{#Properties-stringifyQuery-Type-declaration-Parameters}%
 
-| Name | Type |
-| :------ | :------ |
-| `query` | [`LocationQueryRaw`](../index.md#locationqueryraw) |
+| Name    | Type                                                            |
+| :------ | :-------------------------------------------------------------- |
+| `query` | [`LocationQueryRaw`](../index.md#Type-Aliases-LocationQueryRaw) |
 
 ##### Returns %{#Properties-stringifyQuery-Type-declaration-Returns}%
 


### PR DESCRIPTION
Fix for #1846