### PR TITLE
Fix in docs for target incorrect type-aliases links #1846

### DIFF
--- a/packages/docs/api/interfaces/NavigationGuardNext.md
+++ b/packages/docs/api/interfaces/NavigationGuardNext.md
@@ -38,7 +38,7 @@ editLink: false
 
 | Name | Type |
 | :------ | :------ |
-| `location` | [`RouteLocationRaw`](../index.md#routelocationraw) |
+| `location` | [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw) |
 
 #### Returns %{#Callable-NavigationGuardNext-Returns_2}%
 

--- a/packages/docs/api/interfaces/RouteLocation.md
+++ b/packages/docs/api/interfaces/RouteLocation.md
@@ -65,7 +65,7 @@ ___
 
 ### name %{#Properties-name}%
 
-• **name**: `undefined` \| ``null`` \| [`RouteRecordName`](../index.md#routerecordname)
+• **name**: `undefined` \| ``null`` \| [`RouteRecordName`](../index.md#Type-Aliases-RouteRecordName)
 
 Name of the matched record
 

--- a/packages/docs/api/interfaces/RouteLocationMatched.md
+++ b/packages/docs/api/interfaces/RouteLocationMatched.md
@@ -43,7 +43,7 @@ ___
 
 ### children %{#Properties-children}%
 
-• **children**: [`RouteRecordRaw`](../index.md#routerecordraw)[]
+• **children**: [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw)[]
 
 Nested route records.
 

--- a/packages/docs/api/interfaces/Router.md
+++ b/packages/docs/api/interfaces/Router.md
@@ -45,7 +45,7 @@ Add a new [route record](../index.md#routerecordraw) as the child of an existing
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `parentName` | [`RouteRecordName`](../index.md#routerecordname) | Parent Route Record where `route` should be appended at |
-| `route` | [`RouteRecordRaw`](../index.md#routerecordraw) | Route Record to add |
+| `route` | [`RouteRecordRaw`](../index.md#Type-Aliases-RouteRecordRaw) | Route Record to add |
 
 #### Returns %{#Methods-addRoute-Returns}%
 
@@ -53,7 +53,7 @@ Add a new [route record](../index.md#routerecordraw) as the child of an existing
 
 ▸ (): `void`
 
-Add a new [route record](../index.md#routerecordraw) as the child of an existing route.
+Add a new [route record](../index.md#Type-Aliases-RouteRecordRaw) as the child of an existing route.
 
 ##### Returns %{#Methods-addRoute-Returns-Returns}%
 
@@ -347,7 +347,7 @@ stack.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `to` | [`RouteLocationRaw`](../index.md#routelocationraw) | Route location to navigate to |
+| `to` | [`RouteLocationRaw`](../index.md#Type-Aliases-RouteLocationRaw) | Route location to navigate to |
 
 #### Returns %{#Methods-push-Returns}%
 


### PR DESCRIPTION
Fix for Docs for API interfaces target incorrect type-aliases links #1846