### PR TITLE
Correct language to reflect pre-fetching

### DIFF
--- a/packages/docs/guide/advanced/lazy-loading.md
+++ b/packages/docs/guide/advanced/lazy-loading.md
@@ -21,7 +21,7 @@ const router = createRouter({
 })
 ```
 
-The `component` (and `components`) option accepts a function that returns a Promise of a component and Vue Router **will only fetch it when entering the page for the first time**, then use the cached version. Which means you can also have more complex functions as long as they return a Promise:
+The `component` (and `components`) option accepts a function that returns a Promise of a component and Vue Router **will not initially load the component. Instead, by default it will pre-fetch the component after the inital app loads**, then use the cached version. Which means you can also have more complex functions as long as they return a Promise:
 
 ```js
 const UserDetails = () =>


### PR DESCRIPTION
The original statement that `Vue Router will only fetch [a lazily-loaded route/component] when entering the page for the first time` seems misleading since it does pre-fetch the route/component. My understanding is that the component chunks are actually pre-fetched by default.