### PR TITLE
fix: handle undefined path in router resolve

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -319,6 +319,17 @@ describe('Router', () => {
     await router.push({ name: 'optional', params: {} })
   })
 
+  it('handles undefined path', async () => {
+    const { router } = await newRouter()
+
+    const route1 = router.resolve({
+      path: undefined,
+      params: { p: 'a' },
+    })
+    expect(route1.path).toBe('/')
+    expect(route1.params).toEqual({ p: 'a' })
+  })
+
   it('removes null/undefined optional params when current location has it', async () => {
     const { router } = await newRouter()
 

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -290,7 +290,7 @@ export function createRouterMatcher(
       )
       // throws if cannot be stringified
       path = matcher.stringify(params)
-    } else if ('path' in location) {
+    } else if ('path' in location && location.path != null) {
       // no need to resolve the path with the matcher as it was provided
       // this also allows the user to control the encoding
       path = location.path

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -466,7 +466,7 @@ export function createRouter(options: RouterOptions): Router {
     let matcherLocation: MatcherLocationRaw
 
     // path could be relative in object as well
-    if ('path' in rawLocation) {
+    if ('path' in rawLocation && rawLocation.path != null) {
       if (
         __DEV__ &&
         'params' in rawLocation &&


### PR DESCRIPTION
Suppose we execute for example:
```
router.replace({
    path: undefined,
    params: { foo: 'bar' }
);
```

Error would be thrown during `route.resolve` as we only check if `location` has property `path` but not if the path is defined and non null. 