### PR TITLE
docs(ko): add ko-KR translation

### DIFF
--- a/packages/docs/.vitepress/config/index.ts
+++ b/packages/docs/.vitepress/config/index.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   locales: {
     root: { label: 'English', lang: 'en-US', link: '/', ...enConfig },
     zh: { label: '简体中文', lang: 'zh-CN', link: '/zh/', ...zhConfig },
+    ko: { label: '한국어', lang: 'ko-KR', link: 'https://router.vuejs.kr/' },
   },
 })


### PR DESCRIPTION
I would appreciate it if you could approve this PR so that more Koreans can see it. (Though the translation for the API section is not yet completed.)

(I have activated both the VueSchool links and Carbon ads.)

Please let me know if there's anything lacking!
Thank you.