### PR TITLE
Added example for passing custom props

### DIFF
--- a/packages/docs/guide/essentials/passing-props.md
+++ b/packages/docs/guide/essentials/passing-props.md
@@ -78,3 +78,16 @@ const routes = [
 The URL `/search?q=vue` would pass `{query: 'vue'}` as props to the `SearchUser` component.
 
 Try to keep the `props` function stateless, as it's only evaluated on route changes. Use a wrapper component if you need state to define the props, that way vue can react to state changes.
+
+## Programmatically via RouterView
+
+You can also pass down state from a parent component to nested route component via RouterView.
+
+```html
+<RouterView v-slot="{ Component }">
+  <component
+    :is="Component"
+    yourProp="your-value"
+   />
+</RouterView
+```


### PR DESCRIPTION
I ended using the method described at https://github.com/vuejs/router/pull/1375 which was never merged into docs.

I think it's useful for cases where you derive some state in a parent (that might be reactive) that nested route components are dependent on.

I hope it's a supported case and that it deserves a more prominent place in the docs.

Thanks to @MilosPaunovic for the original snippet.