### PR TITLE
fix: broken play icon on vue school links

### DIFF
--- a/packages/docs/.vitepress/theme/components/VueSchoolLink.vue
+++ b/packages/docs/.vitepress/theme/components/VueSchoolLink.vue
@@ -5,6 +5,7 @@
       target="_blank"
       rel="sponsored noopener"
       :title="title"
+      class="no-icon"
     >
       <slot>{{ translations[site.lang] }}</slot>
     </a>


### PR DESCRIPTION
The play button icon on the Vue School links is broken:
<img width="382" alt="Screenshot 2023-08-18 at 8 59 08 AM" src="https://github.com/vuejs/router/assets/7635209/38674f8d-0d1e-4cb0-bde7-658147825476">

This fixes:
<img width="405" alt="Screenshot 2023-08-18 at 8 59 23 AM" src="https://github.com/vuejs/router/assets/7635209/0295b40b-6df0-4b98-b061-96061f372416">
