### PR TITLE
docs(migration): provide guidance on using the new reactive currentRoute

### DIFF
--- a/packages/docs/guide/migration/index.md
+++ b/packages/docs/guide/migration/index.md
@@ -113,18 +113,17 @@ You don't need to add the `*` for repeated params if you don't plan to directly 
 
 **Reason**: Vue Router doesn't use `path-to-regexp` anymore, instead it implements its own parsing system that allows route ranking and enables dynamic routing. Since we usually add one single catch-all route per project, there is no big benefit in supporting a special syntax for `*`. The encoding of params is encoding across routes, without exception to make things easier to predict.
 
-### The `currentRoute` property is now a ref() (ie. reactive) property
+### The `currentRoute` property is now a `ref()`
 
 Previously the properties of the [`currentRoute`](https://v3.router.vuejs.org/api/#router-currentroute) object on a router instance could be accessed directly. 
 
 With the introduction of vue-router v4, the underlying type of the `currentRoute` object on the router instance has changed to `Ref<RouteLocationNormalizedLoaded>`, which comes from the newer [reactivity fundamentals](https://vuejs.org/guide/essentials/reactivity-fundamentals.html) introduced in Vue 3.
 
-While this doesn't change anything if you're using these objects from the Vue templates, if you're accessing them from outside the Vue templates you'll need to tweak your `currentRoute` usage to use the [`.value`](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#why-refs) property, in order to drill down to the underlying properties like `query`, `params` or `fullPath` etc.
+While this doesn't change anything if you're reading the route with `useRoute()` or `this.$route`, if you're accessing it directly on the router instance, you will need to access the actual route object via `currentRoute.value`:
 
-```diff
--const myQueryProperty = router.currentRoute.query.customProperty;
-+const myQueryProperty = router.currentRoute.value.query.customProperty
-```
+```ts
+const { page } = router.currentRoute.query  // [!code  --]
+const { page } = router.currentRoute.value.query  // [!code  ++]
 
 ### Replaced `onReady` with `isReady`
 

--- a/packages/docs/guide/migration/index.md
+++ b/packages/docs/guide/migration/index.md
@@ -122,8 +122,8 @@ With the introduction of vue-router v4, the underlying type of the `currentRoute
 While this doesn't change anything if you're reading the route with `useRoute()` or `this.$route`, if you're accessing it directly on the router instance, you will need to access the actual route object via `currentRoute.value`:
 
 ```ts
-const { page } = router.currentRoute.query // [!code  --]
-const { page } = router.currentRoute.value.query // [!code  ++]
+const { page } = router.currentRoute.query // [!code --]
+const { page } = router.currentRoute.value.query // [!code ++]
 ```
 
 ### Replaced `onReady` with `isReady`

--- a/packages/docs/guide/migration/index.md
+++ b/packages/docs/guide/migration/index.md
@@ -115,15 +115,16 @@ You don't need to add the `*` for repeated params if you don't plan to directly 
 
 ### The `currentRoute` property is now a `ref()`
 
-Previously the properties of the [`currentRoute`](https://v3.router.vuejs.org/api/#router-currentroute) object on a router instance could be accessed directly. 
+Previously the properties of the [`currentRoute`](https://v3.router.vuejs.org/api/#router-currentroute) object on a router instance could be accessed directly.
 
 With the introduction of vue-router v4, the underlying type of the `currentRoute` object on the router instance has changed to `Ref<RouteLocationNormalizedLoaded>`, which comes from the newer [reactivity fundamentals](https://vuejs.org/guide/essentials/reactivity-fundamentals.html) introduced in Vue 3.
 
 While this doesn't change anything if you're reading the route with `useRoute()` or `this.$route`, if you're accessing it directly on the router instance, you will need to access the actual route object via `currentRoute.value`:
 
 ```ts
-const { page } = router.currentRoute.query  // [!code  --]
-const { page } = router.currentRoute.value.query  // [!code  ++]
+const { page } = router.currentRoute.query // [!code  --]
+const { page } = router.currentRoute.value.query // [!code  ++]
+```
 
 ### Replaced `onReady` with `isReady`
 

--- a/packages/docs/guide/migration/index.md
+++ b/packages/docs/guide/migration/index.md
@@ -113,6 +113,19 @@ You don't need to add the `*` for repeated params if you don't plan to directly 
 
 **Reason**: Vue Router doesn't use `path-to-regexp` anymore, instead it implements its own parsing system that allows route ranking and enables dynamic routing. Since we usually add one single catch-all route per project, there is no big benefit in supporting a special syntax for `*`. The encoding of params is encoding across routes, without exception to make things easier to predict.
 
+### The `currentRoute` property is now a ref() (ie. reactive) property
+
+Previously the properties of the [`currentRoute`](https://v3.router.vuejs.org/api/#router-currentroute) object on a router instance could be accessed directly. 
+
+With the introduction of vue-router v4, the underlying type of the `currentRoute` object on the router instance has changed to `Ref<RouteLocationNormalizedLoaded>`, which comes from the newer [reactivity fundamentals](https://vuejs.org/guide/essentials/reactivity-fundamentals.html) introduced in Vue 3.
+
+While this doesn't change anything if you're using these objects from the Vue templates, if you're accessing them from outside the Vue templates you'll need to tweak your `currentRoute` usage to use the [`.value`](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#why-refs) property, in order to drill down to the underlying properties like `query`, `params` or `fullPath` etc.
+
+```diff
+-const myQueryProperty = router.currentRoute.query.customProperty;
++const myQueryProperty = router.currentRoute.value.query.customProperty
+```
+
 ### Replaced `onReady` with `isReady`
 
 The existing `router.onReady()` function has been replaced with `router.isReady()` which doesn't take any argument and returns a Promise:


### PR DESCRIPTION
Howdy folks,

Just raising this PR to add some extra guidance on the `currentRoute` object being changed to a reactive object in vue-router v4. We got a little tripped up on this during our migration to Vue 3/Vue-Router 4 as I couldn't find any docs that explicitly mentioned this change, and how it may impact code accessing router information from outside a Vue template.

I'm hoping the place I've put it in is ok, but if its not, let me know and I'm happy to change it :)

Cheers,
Adam
