### PR TITLE
docs: Add link to Russian docs

### DIFF
--- a/packages/docs/.vitepress/config/index.ts
+++ b/packages/docs/.vitepress/config/index.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     zh: { label: '简体中文', lang: 'zh-CN', link: '/zh/', ...zhConfig },
     ko: { label: '한국어', lang: 'ko-KR', link: 'https://router.vuejs.kr/' },
     pt: { label: 'Português', lang: 'pt-PT', link: 'https://vue-router-docs-pt.netlify.app/' },
+    ru: { label: 'Русский', lang: 'ru-RU', link: 'https://vue-router-ru.netlify.app' },
   },
 })


### PR DESCRIPTION
After translating the documentation of the Pinia library into Russian (the link has been added to the official documentation, [repository with translations](https://github.com/translation-ru/pinia)), I have started working on translating the documentation for Vue Router. All translations are being done within the scope of the organization https://github.com/translation-ru.

The current status of the documentation translation for Vue Router can be found [here](https://github.com/translation-ru/vue-router/issues/1).
Sync with the head repo is done through https://github.com/vuejs-translations/ryu-cho.

After adding a link to the Russian version of the Vue Router documentation, I plan to gather more people from the community to work on translations for Vue Router documentation and other libraries (the next planned project is Vue Test Utils).

Thank.