### PR TITLE
fix: check document for browser instead of window

### DIFF
--- a/packages/router/src/utils/env.ts
+++ b/packages/router/src/utils/env.ts
@@ -1,1 +1,1 @@
-export const isBrowser = typeof window !== 'undefined'
+export const isBrowser = typeof document !== 'undefined'


### PR DESCRIPTION
Deno has `window` object in its runtime. Thus, when trying to deploy a typical vue SSR project, the server output fails to run.

So, replaced the browser check with `document` instead.
[VitePress is also doing the same.](https://github.com/vuejs/vitepress/blob/main/src/shared/shared.ts#L22)