### PR TITLE
docs: add a guide to the RouterView slot

### DIFF
--- a/packages/docs/.vitepress/config/en.ts
+++ b/packages/docs/.vitepress/config/en.ts
@@ -135,6 +135,10 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
               link: '/guide/advanced/composition-api.html',
             },
             {
+              text: 'RouterView slot',
+              link: '/guide/advanced/router-view-slot.html',
+            },
+            {
               text: 'Transitions',
               link: '/guide/advanced/transitions.html',
             },

--- a/packages/docs/guide/advanced/router-view-slot.md
+++ b/packages/docs/guide/advanced/router-view-slot.md
@@ -1,0 +1,75 @@
+# RouterView slot
+
+The RouterView component exposes a slot that can be used to render the route component:
+
+```vue-html
+<router-view v-slot="{ Component }"
+  <component :is="Component" />
+</router-view>
+```
+
+The code above is equivalent to using `<router-view />` without the slot, but the slot provides extra flexibility when we want to work with other features.
+
+## Passing props and slots
+
+We could use the slot to pass props or slots to the route component:
+
+```vue-html
+<router-view v-slot="{ Component }"
+  <component :is="Component" some-prop="a value">
+    <p>Some slotted content</p>
+  </component>
+</router-view>
+```
+
+In practice, this usually isn't something you would want to do, as the route components would all need to use the same props and slots. See [Passing Props to Route Components](/guide/essentials/passing-props) for other ways to pass props.
+
+## Template refs
+
+Using the slot also allows us to put a [template ref](https://vuejs.org/guide/essentials/template-refs.html) directly on the route component:
+
+```vue-html
+<router-view v-slot="{ Component }"
+  <component :is="Component" ref="mainContent" />
+</router-view>
+```
+
+If we put the ref on the `<router-view>` instead then the ref would be populated with the RouterView instance, rather than the route component.
+
+## KeepAlive
+
+The slot is also useful for working with the [KeepAlive](https://vuejs.org/guide/built-ins/keep-alive.html) component. We want the KeepAlive to apply to the route component, not the RouterView itself, so we can put the KeepAlive inside the slot:
+
+```vue-html
+<router-view v-slot="{ Component }">
+  <keep-alive>
+    <component :is="Component" />
+  </keep-alive>
+</router-view>
+```
+
+Similarly, we can also combine both KeepAlive and Transition:
+
+```vue-html
+<router-view v-slot="{ Component }">
+  <transition>
+    <keep-alive>
+      <component :is="Component" />
+    </keep-alive>
+  </transition>
+</router-view>
+```
+
+For more information about using RouterView with the Transition component, see the [Transitions](/guide/advanced/transitions) guide.
+
+## Slot props
+
+In addition to the `Component`, the RouterView also exposes the current route via the `route` slot prop:
+
+```vue-html
+<router-view v-slot="{ Component, route }">
+  ...
+</router-view>
+```
+
+While `route` is equivalent to the global `$route`, it can be more convenient when working with [render functions](https://vuejs.org/guide/extras/render-function.html).

--- a/packages/docs/guide/advanced/router-view-slot.md
+++ b/packages/docs/guide/advanced/router-view-slot.md
@@ -3,42 +3,16 @@
 The RouterView component exposes a slot that can be used to render the route component:
 
 ```vue-html
-<router-view v-slot="{ Component }"
+<router-view v-slot="{ Component }">
   <component :is="Component" />
 </router-view>
 ```
 
 The code above is equivalent to using `<router-view />` without the slot, but the slot provides extra flexibility when we want to work with other features.
 
-## Passing props and slots
+## KeepAlive & Transition
 
-We could use the slot to pass props or slots to the route component:
-
-```vue-html
-<router-view v-slot="{ Component }"
-  <component :is="Component" some-prop="a value">
-    <p>Some slotted content</p>
-  </component>
-</router-view>
-```
-
-In practice, this usually isn't something you would want to do, as the route components would all need to use the same props and slots. See [Passing Props to Route Components](/guide/essentials/passing-props) for other ways to pass props.
-
-## Template refs
-
-Using the slot also allows us to put a [template ref](https://vuejs.org/guide/essentials/template-refs.html) directly on the route component:
-
-```vue-html
-<router-view v-slot="{ Component }"
-  <component :is="Component" ref="mainContent" />
-</router-view>
-```
-
-If we put the ref on the `<router-view>` instead then the ref would be populated with the RouterView instance, rather than the route component.
-
-## KeepAlive
-
-The slot is also useful for working with the [KeepAlive](https://vuejs.org/guide/built-ins/keep-alive.html) component. We want the KeepAlive to apply to the route component, not the RouterView itself, so we can put the KeepAlive inside the slot:
+When working with the [KeepAlive](https://vuejs.org/guide/built-ins/keep-alive.html) component, we would usually want it to keep the route components alive, not the RouterView itself. We can achieve that by putting the KeepAlive inside the slot:
 
 ```vue-html
 <router-view v-slot="{ Component }">
@@ -48,7 +22,17 @@ The slot is also useful for working with the [KeepAlive](https://vuejs.org/guide
 </router-view>
 ```
 
-Similarly, we can also combine both KeepAlive and Transition:
+Similarly, the slot allows us to use a [Transition](https://vuejs.org/guide/built-ins/transition.html) component to transition between route components:
+
+```vue-html
+<router-view v-slot="{ Component }">
+  <transition>
+    <component :is="Component" />
+  </transition>
+</router-view>
+```
+
+We can also use KeepAlive inside a Transition:
 
 ```vue-html
 <router-view v-slot="{ Component }">
@@ -60,16 +44,30 @@ Similarly, we can also combine both KeepAlive and Transition:
 </router-view>
 ```
 
-For more information about using RouterView with the Transition component, see the [Transitions](/guide/advanced/transitions) guide.
+For more information about using RouterView with the Transition component, see the [Transitions](./transitions) guide.
 
-## Slot props
+## Passing props and slots
 
-In addition to the `Component`, the RouterView also exposes the current route via the `route` slot prop:
+We can use the slot to pass props or slots to the route component:
 
 ```vue-html
-<router-view v-slot="{ Component, route }">
-  ...
+<router-view v-slot="{ Component }">
+  <component :is="Component" some-prop="a value">
+    <p>Some slotted content</p>
+  </component>
 </router-view>
 ```
 
-While `route` is equivalent to the global `$route`, it can be more convenient when working with [render functions](https://vuejs.org/guide/extras/render-function.html).
+In practice, this usually isn't something you would want to do, as the route components would **all need to use the same props and slots**. See [Passing Props to Route Components](../essentials/passing-props) for other ways to pass props.
+
+## Template refs
+
+Using the slot allows us to put a [template ref](https://vuejs.org/guide/essentials/template-refs.html) directly on the route component:
+
+```vue-html
+<router-view v-slot="{ Component }">
+  <component :is="Component" ref="mainContent" />
+</router-view>
+```
+
+If we put the ref on the `<router-view>` instead then the ref would be populated with the RouterView instance, rather than the route component.

--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -5,7 +5,7 @@
   title="Learn about route transitions"
 />
 
-In order to use transitions on your route components and animate navigations, you need to use the [`<RouterView>` slot](/guide/advanced/router-view-slot):
+In order to use transitions on your route components and animate navigations, you need to use the [`<RouterView>` slot](./router-view-slot):
 
 ```html
 <router-view v-slot="{ Component }">

--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -5,7 +5,7 @@
   title="Learn about route transitions"
 />
 
-In order to use transitions on your route components and animate navigations, you need to use the v-slot API:
+In order to use transitions on your route components and animate navigations, you need to use the [`<RouterView>` slot](/guide/advanced/router-view-slot):
 
 ```html
 <router-view v-slot="{ Component }">

--- a/packages/docs/guide/essentials/passing-props.md
+++ b/packages/docs/guide/essentials/passing-props.md
@@ -81,7 +81,7 @@ Try to keep the `props` function stateless, as it's only evaluated on route chan
 
 ## Via RouterView
 
-You can also pass any props directly via `<RouterView>`:
+You can also pass any props via the [`<RouterView>` slot](/guide/advanced/router-view-slot):
 
 ```vue-html
 <RouterView v-slot="{ Component }">

--- a/packages/docs/guide/essentials/passing-props.md
+++ b/packages/docs/guide/essentials/passing-props.md
@@ -81,7 +81,7 @@ Try to keep the `props` function stateless, as it's only evaluated on route chan
 
 ## Via RouterView
 
-You can also pass any props via the [`<RouterView>` slot](/guide/advanced/router-view-slot):
+You can also pass any props via the [`<RouterView>` slot](../advanced/router-view-slot):
 
 ```vue-html
 <RouterView v-slot="{ Component }">


### PR DESCRIPTION
The slot for `RouterView` is mentioned in a few places within the docs, but it isn't directly explained anywhere. This PR adds a new page to the advanced guides covering that topic.

Perhaps this isn't the best way to introduce the topic, but maybe it'll be useful as a starting point to discuss it further.

I've put this guide just before the guide to transitions, as that guide heavily relies on using the slot. The slot is also used in the earlier guide to passing props, but I didn't think it made sense to have this new page in the **Essentials** section. Instead, I've just linked to the new page from that earlier page.

There are a few things I would like any reviewers to consider:

- Any suggestions for improvements to the file name and page title? `router-view-slot.md` and `RouterView slot` make sense, but it seems a little inconsistent with some of the other page titles. The page is a bit of a mash up of various different problems solved by the same feature. Does it actually make sense to put these different cases together like this?
- Are there other or better uses of the slot that should be covered?
- I haven't mentioned that the `Component` slot prop is actually a VNode.
- I've glossed over the detail that the `Component` slot prop will initially be `undefined`. In general, this aspect of the timing of route resolution doesn't seem to be covered in the documentation, but I decided this probably wasn't the right place to go down that rabbit hole.
- I'm not entirely sure what the use case for the `route` slot prop is, rather than using `$route`. I figured it makes it easier when working with render functions, but I couldn't come up with a specific example that wasn't mind-melting complicated, so I didn't go into details. I did check the RFC, which mentioned working with JSX, but I figured that just saying 'render functions' covered that case too.