### PR TITLE
docs: update links to the core Vue docs

### DIFF
--- a/packages/docs/guide/advanced/composition-api.md
+++ b/packages/docs/guide/advanced/composition-api.md
@@ -5,7 +5,7 @@
   title="Learn how to use Vue Router with the composition API"
 />
 
-The introduction of `setup` and Vue's [Composition API](https://v3.vuejs.org/guide/composition-api-introduction.html), open up new possibilities but to be able to get the full potential out of Vue Router, we will need to use a few new functions to replace access to `this` and in-component navigation guards.
+The introduction of `setup` and Vue's [Composition API](https://vuejs.org/guide/extras/composition-api-faq.html), open up new possibilities but to be able to get the full potential out of Vue Router, we will need to use a few new functions to replace access to `this` and in-component navigation guards.
 
 ## Accessing the Router and current Route inside `setup`
 

--- a/packages/docs/guide/advanced/lazy-loading.md
+++ b/packages/docs/guide/advanced/lazy-loading.md
@@ -37,7 +37,7 @@ const UserDetails = () =>
 In general, it's a good idea **to always use dynamic imports** for all your routes.
 
 ::: tip Note
-Do **not** use [Async components](https://v3.vuejs.org/guide/component-dynamic-async.html#async-components) for routes. Async components can still be used inside route components but route component themselves are just dynamic imports.
+Do **not** use [Async components](https://vuejs.org/guide/components/async.html) for routes. Async components can still be used inside route components but route component themselves are just dynamic imports.
 :::
 
 When using a bundler like webpack, this will automatically benefit from [code splitting](https://webpack.js.org/guides/code-splitting/)

--- a/packages/docs/guide/advanced/navigation-guards.md
+++ b/packages/docs/guide/advanced/navigation-guards.md
@@ -264,7 +264,7 @@ beforeRouteLeave (to, from) {
 
 ### Using the composition API
 
-If you are writing your component using the [composition API and a `setup` function](https://v3.vuejs.org/guide/composition-api-setup.html#setup), you can add update and leave guards through `onBeforeRouteUpdate` and `onBeforeRouteLeave` respectively. Please refer to the [Composition API section](./composition-api.md#navigation-guards) for more details.
+If you are writing your component using the [composition API and a `setup` function](https://vuejs.org/api/composition-api-setup.html), you can add update and leave guards through `onBeforeRouteUpdate` and `onBeforeRouteLeave` respectively. Please refer to the [Composition API section](./composition-api.md#navigation-guards) for more details.
 
 ## The Full Navigation Resolution Flow
 

--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -15,7 +15,7 @@ In order to use transitions on your route components and animate navigations, yo
 </router-view>
 ```
 
-[All transition APIs](https://v3.vuejs.org/guide/transitions-enterleave.html) work the same here.
+[All transition APIs](https://vuejs.org/guide/built-ins/transition.html) work the same here.
 
 ## Per-Route Transition
 
@@ -70,7 +70,7 @@ router.afterEach((to, from) => {
 
 ## Forcing a transition between reused views
 
-Vue might automatically reuse components that look alike, avoiding any transition. Fortunately, it is possible [to add a `key` attribute](https://v3.vuejs.org/api/special-attributes.html#key) to force transitions. This also allows you to trigger transitions while staying on the same route with different params:
+Vue might automatically reuse components that look alike, avoiding any transition. Fortunately, it is possible [to add a `key` attribute](https://vuejs.org/api/built-in-special-attributes.html#key) to force transitions. This also allows you to trigger transitions while staying on the same route with different params:
 
 ```vue
 <router-view v-slot="{ Component, route }">

--- a/packages/docs/guide/essentials/history-mode.md
+++ b/packages/docs/guide/essentials/history-mode.md
@@ -214,4 +214,4 @@ const router = createRouter({
 })
 ```
 
-Alternatively, if you are using a Node.js server, you can implement the fallback by using the router on the server side to match the incoming URL and respond with 404 if no route is matched. Check out the [Vue server side rendering documentation](https://v3.vuejs.org/guide/ssr/introduction.html#what-is-server-side-rendering-ssr) for more information.
+Alternatively, if you are using a Node.js server, you can implement the fallback by using the router on the server side to match the incoming URL and respond with 404 if no route is matched. Check out the [Vue server side rendering documentation](https://vuejs.org/guide/scaling-up/ssr.html) for more information.

--- a/packages/docs/zh/guide/advanced/composition-api.md
+++ b/packages/docs/zh/guide/advanced/composition-api.md
@@ -5,7 +5,7 @@
   title="Learn how to use Vue Router with the composition API"
 />
 
-引入 `setup` 和 Vue 的[组合式 API](https://v3.vuejs.org/guide/composition-api-introduction.html)，开辟了新的可能性，但要想充分发挥 Vue Router 的潜力，我们需要使用一些新的函数来代替访问 `this` 和组件内导航守卫。
+引入 `setup` 和 Vue 的[组合式 API](https://cn.vuejs.org/guide/extras/composition-api-faq.html)，开辟了新的可能性，但要想充分发挥 Vue Router 的潜力，我们需要使用一些新的函数来代替访问 `this` 和组件内导航守卫。
 
 ## 在 `setup` 中访问路由和当前路由
 

--- a/packages/docs/zh/guide/advanced/lazy-loading.md
+++ b/packages/docs/zh/guide/advanced/lazy-loading.md
@@ -33,7 +33,7 @@ const UserDetails = () =>
 一般来说，对所有的路由**都使用动态导入**是个好主意。
 
 ::: tip 注意
-**不要**在路由中使用[异步组件](https://v3.vuejs.org/guide/component-dynamic-async.html#async-components)。异步组件仍然可以在路由组件中使用，但路由组件本身就是动态导入的。
+**不要**在路由中使用[异步组件](https://cn.vuejs.org/guide/components/async.html)。异步组件仍然可以在路由组件中使用，但路由组件本身就是动态导入的。
 :::
 
 如果你使用的是 webpack 之类的打包器，它将自动从[代码分割](https://webpack.js.org/guides/code-splitting/)中受益。

--- a/packages/docs/zh/guide/advanced/navigation-guards.md
+++ b/packages/docs/zh/guide/advanced/navigation-guards.md
@@ -246,7 +246,7 @@ beforeRouteLeave (to, from) {
 
 ### 使用组合 API
 
-如果你正在使用[组合 API 和 `setup` 函数](https://v3.vuejs.org/guide/composition-api-setup.html#setup)来编写组件，你可以通过 `onBeforeRouteUpdate` 和 `onBeforeRouteLeave` 分别添加 update 和 leave 守卫。 请参考[组合 API 部分](./composition-api.md#导航守卫)以获得更多细节。
+如果你正在使用[组合 API 和 `setup` 函数](https://cn.vuejs.org/api/composition-api-setup.html)来编写组件，你可以通过 `onBeforeRouteUpdate` 和 `onBeforeRouteLeave` 分别添加 update 和 leave 守卫。 请参考[组合 API 部分](./composition-api.md#导航守卫)以获得更多细节。
 
 ## 完整的导航解析流程
 

--- a/packages/docs/zh/guide/advanced/transitions.md
+++ b/packages/docs/zh/guide/advanced/transitions.md
@@ -15,7 +15,7 @@
 </router-view>
 ```
 
-[Transition 的 API](https://v3.vuejs.org/guide/transitions-enterleave.html) 在这里同样适用。
+[Transition 的 API](https://cn.vuejs.org/guide/built-ins/transition.html) 在这里同样适用。
 
 ## 单个路由的过渡
 
@@ -70,7 +70,7 @@ router.afterEach((to, from) => {
 
 ## 强制在复用的视图之间进行过渡
 
-Vue 可能会自动复用看起来相似的组件，从而忽略了任何过渡。幸运的是，可以[添加一个 `key` 属性](https://v3.vuejs.org/api/special-attributes.html#key)来强制过渡。这也允许你在相同路由上使用不同的参数触发过渡：
+Vue 可能会自动复用看起来相似的组件，从而忽略了任何过渡。幸运的是，可以[添加一个 `key` 属性](https://cn.vuejs.org/api/built-in-special-attributes.html#key)来强制过渡。这也允许你在相同路由上使用不同的参数触发过渡：
 
 ```vue
 <router-view v-slot="{ Component, route }">

--- a/packages/docs/zh/guide/essentials/history-mode.md
+++ b/packages/docs/zh/guide/essentials/history-mode.md
@@ -197,4 +197,4 @@ const router = createRouter({
 })
 ```
 
-另外，如果你使用的是 Node.js 服务器，你可以通过在服务器端使用路由器来匹配传入的 URL，如果没有匹配到路由，则用 404 来响应，从而实现回退。查看 [Vue 服务器端渲染文档](https://v3.cn.vuejs.org/guide/ssr/introduction.html#what-is-server-side-rendering-ssr)了解更多信息。
+另外，如果你使用的是 Node.js 服务器，你可以通过在服务器端使用路由器来匹配传入的 URL，如果没有匹配到路由，则用 404 来响应，从而实现回退。查看 [Vue 服务器端渲染文档](https://cn.vuejs.org/guide/scaling-up/ssr.html)了解更多信息。

--- a/packages/docs/zh/introduction.md
+++ b/packages/docs/zh/introduction.md
@@ -5,7 +5,7 @@
   title="Learn how to build powerful Single Page Applications with the Vue Router on Vue School"
 />
 
-Vue Router 是 [Vue.js](https://vuejs.org) 的官方路由。它与 Vue.js 核心深度集成，让用 Vue.js 构建单页应用变得轻而易举。功能包括：
+Vue Router 是 [Vue.js](https://cn.vuejs.org/) 的官方路由。它与 Vue.js 核心深度集成，让用 Vue.js 构建单页应用变得轻而易举。功能包括：
 
 - 嵌套路由映射
 - 动态路由选择


### PR DESCRIPTION
I've updated links to the docs for Vue core.

In most cases these were links to `v3.vuejs.org`. These had redirects configured and in most cases I just updated the link to reflect the location of the redirect.

For the Chinese translation I linked to `cn.vuejs.org` instead.

`history-mode.md` contained a link to `https://v3.vuejs.org/guide/ssr/introduction.html#what-is-server-side-rendering-ssr`. That link was broken and just led to the Vue homepage. I've updated it to point at the SSR guide, which is the closest match I could find. However, unlike the old SSR guide, the current SSR guide doesn't mention routing at all, so I'm not sure whether it's really equivalent.