### PR TITLE
fix: decode hash when parsing urls

### DIFF
--- a/packages/router/__tests__/urlEncoding.spec.ts
+++ b/packages/router/__tests__/urlEncoding.spec.ts
@@ -68,17 +68,17 @@ describe('URL Encoding', () => {
     const router = createRouter()
     await router.push('/p/foo')
     // one extra time for hash
-    expect(encoding.decode).toHaveBeenCalledTimes(2)
-    expect(encoding.decode).toHaveBeenNthCalledWith(1, 'foo')
+    expect(encoding.decode).toHaveBeenCalledTimes(3)
+    expect(encoding.decode).toHaveBeenNthCalledWith(2, 'foo')
   })
 
   it('calls decode with a path with repeatable params', async () => {
     const router = createRouter()
     await router.push('/p/foo/bar')
     // one extra time for hash
-    expect(encoding.decode).toHaveBeenCalledTimes(3)
-    expect(encoding.decode).toHaveBeenNthCalledWith(1, 'foo', 0, ['foo', 'bar'])
-    expect(encoding.decode).toHaveBeenNthCalledWith(2, 'bar', 1, ['foo', 'bar'])
+    expect(encoding.decode).toHaveBeenCalledTimes(4)
+    expect(encoding.decode).toHaveBeenNthCalledWith(2, 'foo', 0, ['foo', 'bar'])
+    expect(encoding.decode).toHaveBeenNthCalledWith(3, 'bar', 1, ['foo', 'bar'])
   })
 
   it('decodes values in params', async () => {
@@ -108,7 +108,7 @@ describe('URL Encoding', () => {
     const router = createRouter()
     await router.push('/?p=foo')
     // one extra time for hash
-    expect(encoding.decode).toHaveBeenCalledTimes(3)
+    expect(encoding.decode).toHaveBeenCalledTimes(4)
     expect(encoding.decode).toHaveBeenNthCalledWith(1, 'p')
     expect(encoding.decode).toHaveBeenNthCalledWith(2, 'foo')
   })

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -7,6 +7,7 @@ import {
 import { RouteRecord } from './matcher/types'
 import { warn } from './warning'
 import { isArray } from './utils'
+import { decode } from './encoding'
 
 /**
  * Location object returned by {@link `parseURL`}.
@@ -85,7 +86,7 @@ export function parseURL(
     fullPath: path + (searchString && '?') + searchString + hash,
     path,
     query,
-    hash,
+    hash: decode(hash),
   }
 }
 


### PR DESCRIPTION
Fix #2060