### PR TITLE
docs: update custom transition example

### DIFF
--- a/packages/docs/guide/advanced/transitions.md
+++ b/packages/docs/guide/advanced/transitions.md
@@ -38,7 +38,7 @@ const routes = [
 
 ```vue-html
 <router-view v-slot="{ Component, route }">
-  <!-- Use any custom transition and  to `fade` -->
+  <!-- Use a custom transition or fallback to `fade` -->
   <transition :name="route.meta.transition || 'fade'">
     <component :is="Component" />
   </transition>


### PR DESCRIPTION
The word `fallback` was removed by this change: https://github.com/vuejs/router/commit/950681aac7428cd91b47fd0b7a6aecb2b51c016f. This seems to have been unintentional.

I've reintroduced the word `fallback`. I also didn't think that `any` was quite the right word here, so I've made a couple of other tweaks to the wording.