### PR TITLE
docs: mention useRouter for programmatic navigation

### DIFF
--- a/packages/docs/guide/essentials/navigation.md
+++ b/packages/docs/guide/essentials/navigation.md
@@ -13,7 +13,7 @@ Aside from using `<router-link>` to create anchor tags for declarative navigatio
 
 ## Navigate to a different location
 
-**Note: Inside of a Vue instance, you have access to the router instance as `$router`. You can therefore call `this.$router.push`.**
+**Note: The examples below refer to the router instance as `router`. Inside a component, you can access the router using the `$router` property, e.g. `this.$router.push(...)`. If you're using the Composition API, the router is accessible by calling [`useRouter()`](../advanced/composition-api).**
 
 To navigate to a different URL, use `router.push`. This method pushes a new entry into the history stack, so when the user clicks the browser back button they will be taken to the previous URL.
 


### PR DESCRIPTION
This note has been carried across from the v3 docs, but it has a couple of problems in the context of Vue Router 4.

It uses the term 'Vue instance', which is Vue 2 terminology. That term is no longer used in the core Vue 3 docs and it's likely that the reader won't have encountered it before.

The mention of `this.$router` is fine, but I think it'll derail newcomers who are using the Composition API. `useRouter()` is briefly mentioned a couple of pages earlier, but I doubt most readers would have that fresh in their mind when they reach this page.

I think having the note makes sense. This page (Programmatic Navigation) is one of the few pages where the router is accessed in components. I've reworded it to try to make it a better reflection of using Vue Router with Vue 3. Arguably it still places too much emphasis on the Options API, but I think that keeps it consistent with the rest of the router docs.