### PR TITLE
docs: expand installation.md

### DIFF
--- a/packages/docs/installation.md
+++ b/packages/docs/installation.md
@@ -12,14 +12,46 @@
 
 <!--/email_off-->
 
-## npm
+This will expose Vue Router via a global `VueRouter` object, e.g. `VueRouter.createRouter(...)`.
 
-```bash
+## Package managers
+
+If you have an existing project that uses a JavaScript package manager, you can install Vue Router from the npm registry:
+
+::: code-group
+
+```bash [npm]
 npm install vue-router@4
 ```
 
-## yarn
-
-```bash
+```bash [yarn]
 yarn add vue-router@4
 ```
+
+```bash [pnpm]
+pnpm add vue-router@4
+```
+
+:::
+
+If you're starting a new project, you might find it easier to use the [create-vue](https://github.com/vuejs/create-vue) scaffolding tool, which creates a Vite-based project with the option to include Vue Router:
+
+::: code-group
+
+```bash [npm]
+npm create vue@latest
+```
+
+```bash [yarn]
+yarn create vue
+```
+
+```bash [pnpm]
+pnpm create vue
+```
+
+:::
+
+You'll be prompted with some questions about the kind of project you want to create. If you choose to install Vue Router, the example application will also demonstrate some of Vue Router's core features.
+
+Projects using package managers will typically use ES modules to access Vue Router, e.g. `import { createRouter } from 'vue-router'`.


### PR DESCRIPTION
There were a few preliminaries that I felt were missing from the **Installation** page. I'm not sure how many people actually read that page, but at least the extra information will be explicitly stated for anyone who does.

I imagine this page will undergo significant changes when the docs are rewritten next year, but I thought it was worth making these additions now.

1. I've explicitly noted that `VueRouter` is exposed as a global object when using the global build.
2. I've added installation instructions for `pnpm`, alongside `npm` and `yarn`. To keep things concise, this is wrapped in a VitePress code group, similar to how commands like these are presented in the Vite docs.
3. I've tried to encourage newcomers to use `create-vue` instead.
4. I've added a note about how to access Vue Router via ES modules. I know this seems super obvious to anyone with JS experience, but the early docs examples are currently using the CDN approach and we get a steady stream of confused people on Vue Land who don't seem to understand the relationship between the global and ESM builds.