### PR TITLE
docs: delete useless import

### DIFF
--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -8,7 +8,6 @@ import './styles/vars.css'
 import './styles/sponsors.css'
 import VueSchoolLink from './components/VueSchoolLink.vue'
 import VueMasteryLogoLink from './components/VueMasteryLogoLink.vue'
-import VueMasteryBanner from './components/VueMasteryBanner.vue'
 
 const theme: Theme = {
   ...DefaultTheme,


### PR DESCRIPTION
I saw this commit (https://github.com/vuejs/router/commit/4e26035df5ee515e432167134835fb36f75fff71) and found that the corresponding import may be deleted.  So I casually submitted a PR.🤣