### PR TITLE
docs: omitting parent components for nested routes

### DIFF
--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -15,7 +15,7 @@ const i18nLabels = {
 }
 
 const theme: Theme = {
-  ...DefaultTheme,
+  extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
       // 'home-features-after': () => h(HomeSponsors),

--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -148,4 +148,4 @@ const routes = [
 ]
 ```
 
-As the parent doesn't specify a route component, the top-level `router-view` will skip over the parent and just use the component from the relevant child instead.
+As the parent doesn't specify a route component, the top-level `<router-view>` will skip over the parent and just use the component from the relevant child instead.

--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -128,3 +128,24 @@ const routes = [
   },
 ]
 ```
+
+## Omitting parent components <Badge text="4.1+" />
+
+We can also take advantage of the parent-child relationship between routes without needing to nest route components. This can be useful for grouping together routes with a common path prefix, or when working with [route meta fields](../advanced/meta).
+
+To achieve this, we omit the `component` and `components` options from the parent route:
+
+```js
+const routes = [
+  {
+    path: '/admin',
+    children: [
+      { path: '', component: AdminOverview },
+      { path: 'users', component: AdminUserList },
+      { path: 'users/:id', component: AdminUserDetails },
+    ], 
+  },
+]
+```
+
+As the parent doesn't specify a route component, the top-level `router-view` will skip over the parent and just use the component from the relevant child instead.


### PR DESCRIPTION
close #1810

The change to `index.ts` is intentional. Extending a theme in VitePress is now done using `extends` rather than `...`. The main difference is that `extends` will ensure `enhanceApp` is called on `DefaultTheme`. This is needed for the `<Badge>` to work.

The example is based on a similar example given at <https://github.com/vuejs/router/pull/1397>.