### PR TITLE
docs: explain per-route guards on nested routes

### DIFF
--- a/packages/docs/guide/advanced/navigation-guards.md
+++ b/packages/docs/guide/advanced/navigation-guards.md
@@ -197,7 +197,28 @@ const routes = [
 ]
 ```
 
-Note it is possible to achieve a similar behavior by using [route meta fields](./meta.md) and global navigation guards.
+When working with [nested routes](../essentials/nested-routes), both parent and child routes can use `beforeEnter`. When placed on a parent route, it won't be triggered when moving between children with that same parent. For example:
+
+```js
+const routes = [
+  {
+    path: '/user',
+    beforeEnter() {
+      // ...
+    },
+    children: [
+      { path: 'list', component: UserList },
+      { path: 'details', component: UserDetails },
+    ],
+  },
+]
+```
+
+The `beforeEnter` in the example above won't be called when moving between `/user/list` and `/user/details`, as they share the same parent. If we put the `beforeEnter` guard directly on the `details` route instead, that would be called when moving between those two routes.
+
+::: tip
+It is possible to achieve similar behavior to per-route guards by using [route meta fields](./meta) and global navigation guards.
+:::
 
 ## In-Component Guards
 

--- a/packages/docs/guide/essentials/nested-routes.md
+++ b/packages/docs/guide/essentials/nested-routes.md
@@ -131,7 +131,7 @@ const routes = [
 
 ## Omitting parent components <Badge text="4.1+" />
 
-We can also take advantage of the parent-child relationship between routes without needing to nest route components. This can be useful for grouping together routes with a common path prefix, or when working with [route meta fields](../advanced/meta).
+We can also take advantage of the parent-child relationship between routes without needing to nest route components. This can be useful for grouping together routes with a common path prefix, or when working with more advanced features, such as [per-route navigation guards](../advanced/navigation-guards#Per-Route-Guard) or [route meta fields](../advanced/meta).
 
 To achieve this, we omit the `component` and `components` options from the parent route:
 


### PR DESCRIPTION
While working on #2127, I had originally intended to include a note about per-route guards, but the specific functionality I was trying to reference doesn't appear to be documented, so I left it out.

This PR attempts to address that.

Specifically, when using nested routes, the `beforeEnter` per-route guard can be placed on either the parent or the child route. There is some subtlety to exactly when those guards will be called, which I believe is intentional and worth documenting.

I've also moved the final paragraph of that section into a `tip`. The new content about nested routes left that final paragraph feeling like a strange jump to a separate topic, and I think the `tip` box makes that less confusing.