### PR TITLE
fix(router): allow duplicated navigation on back + redirect

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -978,7 +978,7 @@ export function createRouter(options: RouterOptions): Router {
       const shouldRedirect = handleRedirectRecord(toLocation)
       if (shouldRedirect) {
         pushWithRedirect(
-          assign(shouldRedirect, { replace: true }),
+          assign(shouldRedirect, { replace: true, force: true }),
           toLocation
         ).catch(noop)
         return
@@ -1019,7 +1019,9 @@ export function createRouter(options: RouterOptions): Router {
             // the error is already handled by router.push we just want to avoid
             // logging the error
             pushWithRedirect(
-              (error as NavigationRedirectError).to,
+              assign(locationAsObject((error as NavigationRedirectError).to), {
+                force: true,
+              }),
               toLocation
               // avoid an uncaught rejection, let push call triggerError
             )


### PR DESCRIPTION
Fix #1850

I need to test this more as it could have other consequences. For the moment a workaround is to avoid the navigation duplication:

```js
router.beforeEach((to, from) => {
  if (!localStorage.getItem("JWT") && to.name !== "Home") {
    console.log("intercepting, no token, URL should be: ", from.fullPath);
	if (from.name === 'Home') return false // avoid duplicated navigation
    return { name: "Home" };
  }
});
```