### PR TITLE
feat: router matcher sort cache

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,7 +1,7 @@
 export { createWebHistory } from './history/html5'
 export { createMemoryHistory } from './history/memory'
 export { createWebHashHistory } from './history/hash'
-export { createRouterMatcher } from './matcher'
+export { createRouterMatcher, createSortCache } from './matcher'
 export type { RouterMatcher } from './matcher'
 
 export { parseQuery, stringifyQuery } from './query'

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,7 +1,7 @@
 export { createWebHistory } from './history/html5'
 export { createMemoryHistory } from './history/memory'
 export { createWebHashHistory } from './history/hash'
-export { createRouterMatcher, createSortCache } from './matcher'
+export { createRouterMatcher, createRouterMatcherSortCache } from './matcher'
 export type { RouterMatcher } from './matcher'
 
 export { parseQuery, stringifyQuery } from './query'

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -394,11 +394,11 @@ export function createRouterMatcher(
 }
 
 /**
- * Creates matcher sort cache
+ * Creates a router matcher sort cache
  *
  * @internal
  */
-export function createSortCache(
+export function createRouterMatcherSortCache(
   records: RouteRecord[]
 ): Record<string, number> {
   const sortCache: Record<string, number> = {}

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -384,13 +384,7 @@ export function createRouterMatcher(
 
   restoreSort = false
 
-  return {
-    addRoute,
-    resolve,
-    removeRoute,
-    getRoutes,
-    getRecordMatcher,
-  }
+  return { addRoute, resolve, removeRoute, getRoutes, getRecordMatcher }
 }
 
 /**

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -366,17 +366,15 @@ export function createRouterMatcher(
   // restore matcher order from cache
   if (globalOptions.sortCache != null) {
     try {
-      const sorted = matchers.sort(
+      matchers.sort(
         (a, b) =>
           globalOptions!.sortCache![a.cacheKey!] -
           globalOptions!.sortCache![b.cacheKey!]
       )
 
-      for (const entry of sorted) {
+      for (const entry of matchers) {
         delete entry.cacheKey
       }
-
-      matchers.splice(0, matchers.length, ...sorted)
     } catch {
       console.log('Restore failure.')
     }

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -7,7 +7,11 @@ import {
   _RouteRecordProps,
 } from '../types'
 import { createRouterError, ErrorTypes, MatcherError } from '../errors'
-import { createRouteRecordMatcher, RouteRecordMatcher } from './pathMatcher'
+import {
+  createRouteRecordCacheKey,
+  createRouteRecordMatcher,
+  RouteRecordMatcher,
+} from './pathMatcher'
 import { RouteRecord, RouteRecordNormalized } from './types'
 
 import type {
@@ -394,11 +398,16 @@ export function createRouterMatcher(
  *
  * @internal
  */
-export function createSortCache(records: RouteRecord[]) {
-  return records.reduce((acc, cur, index) => {
-    acc[String(cur?.name) + '___' + cur.path] = index
-    return acc
-  }, {} as Record<string, number>)
+export function createSortCache(
+  records: RouteRecord[]
+): Record<string, number> {
+  const sortCache: Record<string, number> = {}
+
+  for (let i = 0; i < records.length; i++) {
+    sortCache[createRouteRecordCacheKey(records[i])] = i
+  }
+
+  return sortCache
 }
 
 function paramsFromLocation(

--- a/packages/router/src/matcher/pathMatcher.ts
+++ b/packages/router/src/matcher/pathMatcher.ts
@@ -18,6 +18,10 @@ export interface RouteRecordMatcher extends PathParser {
   cacheKey?: string
 }
 
+export function createRouteRecordCacheKey(record: Readonly<RouteRecord>) {
+  return String(record?.name) + '___' + record.path
+}
+
 export function createRouteRecordMatcher(
   record: Readonly<RouteRecord>,
   parent: RouteRecordMatcher | undefined,
@@ -46,7 +50,7 @@ export function createRouteRecordMatcher(
   })
 
   if (options?.sortCache) {
-    matcher.cacheKey = String(record?.name) + '___' + record.path
+    matcher.cacheKey = createRouteRecordCacheKey(record)
   }
 
   if (parent) {

--- a/packages/router/src/matcher/pathMatcher.ts
+++ b/packages/router/src/matcher/pathMatcher.ts
@@ -14,6 +14,8 @@ export interface RouteRecordMatcher extends PathParser {
   children: RouteRecordMatcher[]
   // aliases that must be removed when removing this record
   alias: RouteRecordMatcher[]
+  // defined when sort cache is present
+  cacheKey?: string
 }
 
 export function createRouteRecordMatcher(
@@ -42,6 +44,10 @@ export function createRouteRecordMatcher(
     children: [],
     alias: [],
   })
+
+  if (options?.sortCache) {
+    matcher.cacheKey = String(record?.name) + '___' + record.path
+  }
 
   if (parent) {
     // both are aliases or both are not aliases

--- a/packages/router/src/matcher/pathParserRanker.ts
+++ b/packages/router/src/matcher/pathParserRanker.ts
@@ -79,17 +79,28 @@ export interface _PathParserOptions {
    * @defaultValue `true`
    */
   end?: boolean
+
+  /**
+   * A precomputed object that maps matchers to its sorted index
+   *
+   * @internal
+   * @defaultValue `undefined`
+   */
+  sortCache?: Record<string, number>
 }
 
 export type PathParserOptions = Pick<
   _PathParserOptions,
-  'end' | 'sensitive' | 'strict'
+  'end' | 'sensitive' | 'strict' | 'sortCache'
 >
 
 // default pattern for a param: non-greedy everything but /
 const BASE_PARAM_PATTERN = '[^/]+?'
 
-const BASE_PATH_PARSER_OPTIONS: Required<_PathParserOptions> = {
+const BASE_PATH_PARSER_OPTIONS: Omit<
+  Required<_PathParserOptions>,
+  'sortCache'
+> = {
   sensitive: false,
   strict: false,
   start: true,


### PR DESCRIPTION
* Related #2132 

This PR adds the `createRouterMatcherSortCache` function which accepts a sorted `RouterRecord` array (returned from `router.getRoutes()` and returns a map of keys and sort index. This can be passed as `restoreCache` option to `createRouter`, if this cache is provided the path sorting is skipped when adding routes during matcher creation and the sort cache is used to restore the order after all initial routes have been added.

The sort cache and restoration is not perfect, it's more of a proof of concept, I tried to add this functionality without making any breaking changes. 

The usage would be as follows:

```ts
import { createRouter, createMemoryHistory, createRouterMatcherSortCache } from "vue-router";

// during build or startup
const initialRouter = createRouter({
  history: createMemoryHistory(),
  routes,
});
const sortCache = createRouterMatcherSortCache(initialRouter.getRoutes());

// store and retrieve `sortCache` however you like ...

// on following router creations
const router = createRouter({
  history: createMemoryHistory(),
  routes,
  sortCache,
});
```

So far with limited testing the cache may have issues with 'duplicate' routes, there may not be enough information from records returned from `getRoutes` to create a fully unique key, though so far these duplicates have the same score and I don't know if the order between these have any significance. I think if the router matcher were exposed, or the matchers array directly (something like `getMatchers`), it may be possible to more accurately create a sort cache, I opted not to this in this iteration to keep changes to a minimum.

I have added a branch to my performance comparison which also tests router creation with cached sort [here].(https://github.com/BobbieGoede/vue-router-perf-bench/tree/feature/sort-cache-comparison). Just caching the order of the matchers greatly reduces the creation time, results on my machine:

| version/routes| 11       | 110      | 550      | 1100      | 2200      |
|---------------|----------|----------|----------|-----------|-----------|
| RouterV3      | 5.88ms   | 21.90ms  | 100.11ms | 200.38ms  | 405.75ms  |
| RouterV4      | 10.72ms  | 40.35ms  | 601.14ms | 2386.12ms | 9649.10ms |
| RouterV4Cached| 5.26ms   | 32.52ms  | 141.46ms | 275.60ms  | 553.46ms  |

This is just one of the ways router performance could be improved, I will still look into what it would like to support custom matchers and perhaps more accurate ways of precompiling the matcher. Maybe there are obvious flaws in this implementation, I'm not attached to this implementation so please let me know 😄!