### PR TITLE
test: earlier routes should have matching priority

### DIFF
--- a/packages/router/__tests__/matcher/addingRemoving.spec.ts
+++ b/packages/router/__tests__/matcher/addingRemoving.spec.ts
@@ -418,6 +418,64 @@ describe('Matcher: adding and removing records', () => {
     )
   })
 
+  it('should give priority to earlier routes', () => {
+    const matcher = createRouterMatcher([], {})
+    matcher.addRoute({ path: '/:id(123\\d*)', component, name: 'first' })
+    matcher.addRoute({ path: '/:id(12\\d*)', component, name: 'second' })
+    matcher.addRoute({ path: '/:id(1\\d*)', component, name: 'third' })
+    matcher.addRoute({ path: '/:id(\\d+)', component, name: 'fourth' })
+    expect(matcher.resolve({ path: '/1239' }, currentLocation)).toMatchObject({
+      name: 'first',
+    })
+    expect(matcher.resolve({ path: '/1299' }, currentLocation)).toMatchObject({
+      name: 'second',
+    })
+    expect(matcher.resolve({ path: '/1999' }, currentLocation)).toMatchObject({
+      name: 'third',
+    })
+    expect(matcher.resolve({ path: '/9999' }, currentLocation)).toMatchObject({
+      name: 'fourth',
+    })
+  })
+
+  it('should give priority to earlier child routes', () => {
+    const matcher = createRouterMatcher([], {})
+    matcher.addRoute({
+      path: '/user',
+      name: 'parent',
+      children: [
+        { path: '', component, name: 'root' },
+        { path: ':id(123\\d*)', component, name: 'first' },
+        { path: ':id(12\\d*)', component, name: 'second' },
+        { path: ':id(1\\d*)', component, name: 'third' },
+        { path: ':id(\\d+)', component, name: 'fourth' },
+      ],
+    })
+    expect(matcher.resolve({ path: '/user/' }, currentLocation)).toMatchObject({
+      name: 'root',
+    })
+    expect(
+      matcher.resolve({ path: '/user/1239' }, currentLocation)
+    ).toMatchObject({
+      name: 'first',
+    })
+    expect(
+      matcher.resolve({ path: '/user/1299' }, currentLocation)
+    ).toMatchObject({
+      name: 'second',
+    })
+    expect(
+      matcher.resolve({ path: '/user/1999' }, currentLocation)
+    ).toMatchObject({
+      name: 'third',
+    })
+    expect(
+      matcher.resolve({ path: '/user/9999' }, currentLocation)
+    ).toMatchObject({
+      name: 'fourth',
+    })
+  })
+
   describe('warnings', () => {
     mockWarn()
 


### PR DESCRIPTION
My initial attempt at #2137 passed all the existing unit tests, but with hindsight it fails to take account of various important cases.

This PR attempts to add test cases for one of those problem cases. e.g. Consider the following code:

```js
routes: [
  {
    path: '/user/:id(1\\d*)',
    component: {}
  }, {
    path: '/user/:id(\\d+)',
    component: {}
  }
]
```

The path ranking gives these routes the same score. For a path of `/user/1234`, both would be eligible to match, but we would want the first route to match. The ordering matters, the earlier route needs to be given priority.

I'm not clear whether this is documented anywhere, but I think it's a reasonable assumption and something that people are likely to be relying upon, even though they may not realise it.

My attempt at using a binary search in #2137 to sort the routes broke this assumption, leading to routes with equal scores being in an essentially random order. I believe that PR is fixable, but these extra tests can be merged independently.