### PR TITLE
fix: combining 'end' and 'strict'

### DIFF
--- a/packages/router/__tests__/matcher/pathParser.spec.ts
+++ b/packages/router/__tests__/matcher/pathParser.spec.ts
@@ -619,8 +619,59 @@ describe('Path parser', () => {
     })
 
     it('can not match the end', () => {
-      matchParams('/home', '/home/other', null, { end: true })
-      matchParams('/home', '/home/other', {}, { end: false })
+      const options = { end: false }
+
+      matchParams('/home', '/home', {}, options)
+      matchParams('/home', '/home/', {}, options)
+      matchParams('/home', '/home/other', {}, options)
+      matchParams('/home', '/homepage', {}, options)
+
+      matchParams('/home/:p', '/home', null, options)
+      matchParams('/home/:p', '/home/', null, options)
+      matchParams('/home/:p', '/home/a', { p: 'a' }, options)
+      matchParams('/home/:p', '/home/a/', { p: 'a' }, options)
+      matchParams('/home/:p', '/home/a/b', { p: 'a' }, options)
+      matchParams('/home/:p', '/homepage', null, options)
+
+      matchParams('/home/', '/home', {}, options)
+      matchParams('/home/', '/home/', {}, options)
+      matchParams('/home/', '/home/other', {}, options)
+      matchParams('/home/', '/homepage', {}, options)
+
+      matchParams('/home/:p/', '/home', null, options)
+      matchParams('/home/:p/', '/home/', null, options)
+      matchParams('/home/:p/', '/home/a', { p: 'a' }, options)
+      matchParams('/home/:p/', '/home/a/', { p: 'a' }, options)
+      matchParams('/home/:p/', '/home/a/b', { p: 'a' }, options)
+      matchParams('/home/:p/', '/homepage', null, options)
+    })
+
+    it('can not match the end when strict', () => {
+      const options = { end: false, strict: true }
+
+      matchParams('/home', '/home', {}, options)
+      matchParams('/home', '/home/', {}, options)
+      matchParams('/home', '/home/other', {}, options)
+      matchParams('/home', '/homepage', null, options)
+
+      matchParams('/home/:p', '/home', null, options)
+      matchParams('/home/:p', '/home/', null, options)
+      matchParams('/home/:p', '/home/a', { p: 'a' }, options)
+      matchParams('/home/:p', '/home/a/', { p: 'a' }, options)
+      matchParams('/home/:p', '/home/a/b', { p: 'a' }, options)
+      matchParams('/home/:p', '/homepage', null, options)
+
+      matchParams('/home/', '/home', null, options)
+      matchParams('/home/', '/home/', {}, options)
+      matchParams('/home/', '/home/other', {}, options)
+      matchParams('/home/', '/homepage', null, options)
+
+      matchParams('/home/:p/', '/home', null, options)
+      matchParams('/home/:p/', '/home/', null, options)
+      matchParams('/home/:p/', '/home/a', null, options)
+      matchParams('/home/:p/', '/home/a/', { p: 'a' }, options)
+      matchParams('/home/:p/', '/home/a/b', { p: 'a' }, options)
+      matchParams('/home/:p/', '/homepage', null, options)
     })
 
     it('should not match optional params + static without leading slash', () => {

--- a/packages/router/__tests__/matcher/pathParser.spec.ts
+++ b/packages/router/__tests__/matcher/pathParser.spec.ts
@@ -618,6 +618,23 @@ describe('Path parser', () => {
       matchParams('/home', '/other/home', {}, { start: false })
     })
 
+    it('defaults to matching the end', () => {
+      // The default should behave like `end: true`
+      const optionSets = [{}, { end: true }]
+
+      for (const options of optionSets) {
+        matchParams('/home', '/home', {}, options)
+        matchParams('/home', '/home/', {}, options)
+        matchParams('/home', '/home/other', null, options)
+        matchParams('/home', '/homepage', null, options)
+
+        matchParams('/home/', '/home', {}, options)
+        matchParams('/home/', '/home/', {}, options)
+        matchParams('/home/', '/home/other', null, options)
+        matchParams('/home/', '/homepage', null, options)
+      }
+    })
+
     it('can not match the end', () => {
       const options = { end: false }
 

--- a/packages/router/src/matcher/pathParserRanker.ts
+++ b/packages/router/src/matcher/pathParserRanker.ts
@@ -217,7 +217,7 @@ export function tokensToParser(
 
   if (options.end) pattern += '$'
   // allow paths like /dynamic to only match dynamic or dynamic/... but not dynamic_something_else
-  else if (options.strict) pattern += '(?:/|$)'
+  else if (options.strict && !pattern.endsWith('/')) pattern += '(?:/|$)'
 
   const re = new RegExp(pattern, options.sensitive ? '' : 'i')
 


### PR DESCRIPTION
This Playground illustrates the problem:

- [Playground](https://play.vuejs.org/#eNp9U8Fu2zAM/RVBFzdAbK1It4PhBtmGAtuAbkW3W7WDYzOxW1sSJDnN4PrfR0lN7G5pfTH1+Eg+klJPPyqV7DqgKc1MoWtliQHbqSUXdauktqQnhYbcwjW0Uv/5UhuLv/kzeCs7C5oMZKNlSyJMFGsPRVxwUUhhLAkAuXwRctZzQUgVsqWnSpzN5o7io01K7tyBEB/mPpG3kJLIu88jT3Wfym2FMOsMaDbCxuq6sCmxuoMjCKJMySZvzAgVEpsWIJDaDwH0v99cDLOxJVfFYEd3oVA0f66IQsbaB+s8wuiMheniXPFgoVUNNownQjKbrxsga6lL0B5x2MFydrW8wYIZQ2MKXue2qMBMcDQnGcgu3kh9yamTS2oRZHM6SVIuM6Vh2ffeR4YhY+6MecqTrLDLRIORzQ7OXNAscasgT08kiqNTGY6i0HCdoo3WYQJ0Tq3BqW7qbXJvpMCL6HfMqdtF3YD+oWyNU+cUdxIycpo3jXz85rHJSjGmguLhBH5v9g7j9Aalg94Bp0efzfUWbHBf/fwOe7SPzlaWXYPsN5y3bhid0xhonzpRouwJz6v96p9TLba/zNXegjCHppxQxxw8n1N8RJ/faH2Uu0gWPg7vJk4xPNe4zdU/cwyOl0nGhxo0V9YqkzLWCfWwTXDybGSsLpJF8o6V+CwnaAKmjddaPuI4seCk2xWSWAk7K2Vj4lzVr5X4j7j6kFwk71lTrxlmZ7UoYe9zH9sc/gJqEYgy)

The bottom row is the one that isn't working correctly. This combination of options:

```js
{
  path: '/user/',
  strict: true,
  end: false,
  component: ...
}
```

should match the location path `/user/1`, but it doesn't.

The reason why is the RegExp is checking for the `/` twice:

```
^/user/(?:/|$)
```

---

While I've added a lot of extra testing for `end: false`, only two of those assertions would have failed with the previous code. Specifically, this one on line 666:

```js
matchParams('/home/', '/home/other', {}, options)
```

and this one on line 673:

```js
matchParams('/home/:p/', '/home/a/b', { p: 'a' }, options)
```

In both cases they would previously have failed to resolve the route.