### PR TITLE
docs(zh): fix the comment format in packages/docs/zh/guide/index.md

### DIFF
--- a/packages/docs/zh/guide/index.md
+++ b/packages/docs/zh/guide/index.md
@@ -16,9 +16,9 @@
 <div id="app">
   <h1>Hello App!</h1>
   <p>
-    <!--使用 router-link 组件进行导航 -->
-    <!--通过传递 `to` 来指定链接 -->
-    <!--`<router-link>` 将呈现一个带有正确 `href` 属性的 `<a>` 标签-->
+    <!-- 使用 router-link 组件进行导航 -->
+    <!-- 通过传递 `to` 来指定链接 -->
+    <!-- `<router-link>` 将呈现一个带有正确 `href` 属性的 `<a>` 标签 -->
     <router-link to="/">Go to Home</router-link>
     <router-link to="/about">Go to About</router-link>
   </p>
@@ -63,8 +63,8 @@ const router = VueRouter.createRouter({
 
 // 5. 创建并挂载根实例
 const app = Vue.createApp({})
-//确保 _use_ 路由实例使
-//整个应用支持路由。
+// 确保 _use_ 路由实例使
+// 整个应用支持路由。
 app.use(router)
 
 app.mount('#app')


### PR DESCRIPTION
missing space between comment symbols and text.
![image](https://github.com/vuejs/router/assets/47178158/e846e171-71bf-404a-b2c7-a65ca3f33b7b)
![image](https://github.com/vuejs/router/assets/47178158/0fc086be-faa7-4a25-a26e-9303c45726b1)
