### PR TITLE
feat(dx): warn when `addRoute` cannot find the parent

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -1076,5 +1076,22 @@ describe('Router', () => {
         name: 'Param',
       })
     })
+
+    it('warns when the parent route is missing', async () => {
+      const { router } = await newRouter()
+      router.addRoute('parent-route', {
+        path: '/p',
+        component: components.Foo,
+      })
+      expect(
+        'Parent route "parent-route" not found when adding child route'
+      ).toHaveBeenWarned()
+    })
+
+    it('warns when removing a missing route', async () => {
+      const { router } = await newRouter()
+      router.removeRoute('route-name')
+      expect('Cannot remove non-existent route "route-name"').toHaveBeenWarned()
+    })
   })
 })

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -397,6 +397,14 @@ export function createRouter(options: RouterOptions): Router {
     let record: RouteRecordRaw
     if (isRouteName(parentOrRoute)) {
       parent = matcher.getRecordMatcher(parentOrRoute)
+      if (__DEV__ && !parent) {
+        warn(
+          `Parent route "${String(
+            parentOrRoute
+          )}" not found when adding child route`,
+          route
+        )
+      }
       record = route!
     } else {
       record = parentOrRoute


### PR DESCRIPTION
This adds a warning when calling `router.addRoute('foo', { ... })` if the parent route isn't found.

Without this warning, it can be difficult to tell why `addRoute` isn't working correctly. With an absolute path, beginning with `/`, the addition seems to succeed, but the new route won't be a child of the intended parent. With a relative path, it'll fail to add the new route, but with a confusing error about the `path` being invalid.

I've also added a test for the similar warning in `removeRoute`, though the warning itself already existed.