### PR TITLE
feat(dx): warn when passing undefined/null locations

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -330,7 +330,7 @@ describe('Router', () => {
     expect(route1.params).toEqual({ p: 'a' })
   })
 
-  it('handles an undefined location', async () => {
+  it('warns on undefined location during dev', async () => {
     const { router } = await newRouter()
 
     const route1 = router.resolve(undefined as any)
@@ -338,7 +338,7 @@ describe('Router', () => {
     expect(route1.path).toBe('/')
   })
 
-  it('handles a null location', async () => {
+  it('warns on null location during dev', async () => {
     const { router } = await newRouter()
 
     const route1 = router.resolve(null as any)

--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -330,6 +330,22 @@ describe('Router', () => {
     expect(route1.params).toEqual({ p: 'a' })
   })
 
+  it('handles an undefined location', async () => {
+    const { router } = await newRouter()
+
+    const route1 = router.resolve(undefined as any)
+    expect('router.resolve() was passed an invalid location').toHaveBeenWarned()
+    expect(route1.path).toBe('/')
+  })
+
+  it('handles a null location', async () => {
+    const { router } = await newRouter()
+
+    const route1 = router.resolve(null as any)
+    expect('router.resolve() was passed an invalid location').toHaveBeenWarned()
+    expect(route1.path).toBe('/')
+  })
+
   it('removes null/undefined optional params when current location has it', async () => {
     const { router } = await newRouter()
 

--- a/packages/router/__tests__/useLink.spec.ts
+++ b/packages/router/__tests__/useLink.spec.ts
@@ -7,9 +7,7 @@ import { mockWarn } from 'jest-mock-warn'
 import {
   createMemoryHistory,
   createRouter,
-  routeLocationKey,
   RouteLocationRaw,
-  routerKey,
   useLink,
   UseLinkOptions,
 } from '../src'
@@ -50,10 +48,7 @@ async function callUseLink(args: UseLinkOptions) {
     },
     {
       global: {
-        provide: {
-          [routerKey as any]: router,
-          [routeLocationKey as any]: router.currentRoute.value,
-        },
+        plugins: [router],
       },
     }
   )

--- a/packages/router/__tests__/useLink.spec.ts
+++ b/packages/router/__tests__/useLink.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+import { nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { mockWarn } from 'jest-mock-warn'
+import {
+  createMemoryHistory,
+  createRouter,
+  routeLocationKey,
+  RouteLocationRaw,
+  routerKey,
+  useLink,
+  UseLinkOptions,
+} from '../src'
+
+async function callUseLink(args: UseLinkOptions) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path: '/',
+        component: {},
+        name: 'root',
+      },
+      {
+        path: '/a',
+        component: {},
+        name: 'a',
+      },
+      {
+        path: '/b',
+        component: {},
+        name: 'b',
+      },
+    ],
+  })
+
+  await router.push('/')
+
+  let link: ReturnType<typeof useLink>
+
+  mount(
+    {
+      setup() {
+        link = useLink(args)
+
+        return () => ''
+      },
+    },
+    {
+      global: {
+        provide: {
+          [routerKey as any]: router,
+          [routeLocationKey as any]: router.currentRoute.value,
+        },
+      },
+    }
+  )
+
+  return link!
+}
+
+describe('useLink', () => {
+  describe('basic usage', () => {
+    it('supports a string for "to"', async () => {
+      const { href, route } = await callUseLink({
+        to: '/a',
+      })
+
+      expect(href.value).toBe('/a')
+      expect(route.value).toMatchObject({ name: 'a' })
+    })
+
+    it('supports an object for "to"', async () => {
+      const { href, route } = await callUseLink({
+        to: { path: '/a' },
+      })
+
+      expect(href.value).toBe('/a')
+      expect(route.value).toMatchObject({ name: 'a' })
+    })
+
+    it('supports a ref for "to"', async () => {
+      const to = ref<RouteLocationRaw>('/a')
+
+      const { href, route } = await callUseLink({
+        to,
+      })
+
+      expect(href.value).toBe('/a')
+      expect(route.value).toMatchObject({ name: 'a' })
+
+      to.value = { path: '/b' }
+
+      await nextTick()
+
+      expect(href.value).toBe('/b')
+      expect(route.value).toMatchObject({ name: 'b' })
+    })
+  })
+
+  describe('warnings', () => {
+    mockWarn()
+
+    it('should warn when "to" is undefined', async () => {
+      await callUseLink({
+        to: undefined as any,
+      })
+
+      expect('Invalid value for prop "to" in useLink()').toHaveBeenWarned()
+      expect(
+        'router.resolve() was passed an invalid location'
+      ).toHaveBeenWarned()
+    })
+
+    it('should warn when "to" is an undefined ref', async () => {
+      await callUseLink({
+        to: ref(undefined as any),
+      })
+
+      expect('Invalid value for prop "to" in useLink()').toHaveBeenWarned()
+      expect(
+        'router.resolve() was passed an invalid location'
+      ).toHaveBeenWarned()
+    })
+
+    it('should warn when "to" changes to a null ref', async () => {
+      const to = ref('/a')
+
+      const { href, route } = await callUseLink({
+        to,
+      })
+
+      expect(href.value).toBe('/a')
+      expect(route.value).toMatchObject({ name: 'a' })
+
+      to.value = null as any
+
+      await nextTick()
+
+      expect('Invalid value for prop "to" in useLink()').toHaveBeenWarned()
+      expect(
+        'router.resolve() was passed an invalid location'
+      ).toHaveBeenWarned()
+    })
+  })
+})

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -36,7 +36,8 @@ import { isSameRouteLocationParams, isSameRouteRecord } from './location'
 import { routerKey, routeLocationKey } from './injectionSymbols'
 import { RouteRecord } from './matcher/types'
 import { NavigationFailure } from './errors'
-import { isArray, isBrowser, noop } from './utils'
+import { isArray, isBrowser, isObject, noop } from './utils'
+import { warn } from './warning'
 
 export interface RouterLinkOptions {
   /**
@@ -83,6 +84,7 @@ export interface UseLinkDevtoolsContext {
   route: RouteLocationNormalized & { href: string }
   isActive: boolean
   isExactActive: boolean
+  error: string
 }
 
 export type UseLinkOptions = VueUseOptions<RouterLinkOptions>
@@ -93,7 +95,40 @@ export function useLink(props: UseLinkOptions) {
   const router = inject(routerKey)!
   const currentRoute = inject(routeLocationKey)!
 
-  const route = computed(() => router.resolve(unref(props.to)))
+  const isValidTo = (to: unknown) => typeof to === 'string' || isObject(to)
+  let hasPrevious = false
+  let previousTo: unknown = null
+
+  const route = computed(() => {
+    const to = unref(props.to)
+
+    if (__DEV__ && (!hasPrevious || to !== previousTo)) {
+      if (!isValidTo(to)) {
+        if (hasPrevious) {
+          warn(
+            `Invalid value for prop "to" in useLink()\n- to:`,
+            to,
+            `\n- previous to:`,
+            previousTo,
+            `\n- props:`,
+            props
+          )
+        } else {
+          warn(
+            `Invalid value for prop "to" in useLink()\n- to:`,
+            to,
+            `\n- props:`,
+            props
+          )
+        }
+      }
+
+      previousTo = to
+      hasPrevious = true
+    }
+
+    return router.resolve(to)
+  })
 
   const activeRecordIndex = computed<number>(() => {
     const { matched } = route.value
@@ -157,6 +192,7 @@ export function useLink(props: UseLinkOptions) {
         route: route.value,
         isActive: isActive.value,
         isExactActive: isExactActive.value,
+        error: '',
       }
 
       // @ts-expect-error: this is internal
@@ -168,6 +204,9 @@ export function useLink(props: UseLinkOptions) {
           linkContextDevtools.route = route.value
           linkContextDevtools.isActive = isActive.value
           linkContextDevtools.isExactActive = isExactActive.value
+          linkContextDevtools.error = isValidTo(unref(props.to))
+            ? ''
+            : 'Invalid "to" value'
         },
         { flush: 'post' }
       )

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -27,6 +27,7 @@ import {
   ComponentOptionsMixin,
 } from 'vue'
 import {
+  isRouteLocation,
   RouteLocationRaw,
   VueUseOptions,
   RouteLocation,
@@ -36,7 +37,7 @@ import { isSameRouteLocationParams, isSameRouteRecord } from './location'
 import { routerKey, routeLocationKey } from './injectionSymbols'
 import { RouteRecord } from './matcher/types'
 import { NavigationFailure } from './errors'
-import { isArray, isBrowser, isObject, noop } from './utils'
+import { isArray, isBrowser, noop } from './utils'
 import { warn } from './warning'
 
 export interface RouterLinkOptions {
@@ -95,7 +96,6 @@ export function useLink(props: UseLinkOptions) {
   const router = inject(routerKey)!
   const currentRoute = inject(routeLocationKey)!
 
-  const isValidTo = (to: unknown) => typeof to === 'string' || isObject(to)
   let hasPrevious = false
   let previousTo: unknown = null
 
@@ -103,7 +103,7 @@ export function useLink(props: UseLinkOptions) {
     const to = unref(props.to)
 
     if (__DEV__ && (!hasPrevious || to !== previousTo)) {
-      if (!isValidTo(to)) {
+      if (!isRouteLocation(to)) {
         if (hasPrevious) {
           warn(
             `Invalid value for prop "to" in useLink()\n- to:`,
@@ -204,7 +204,7 @@ export function useLink(props: UseLinkOptions) {
           linkContextDevtools.route = route.value
           linkContextDevtools.isActive = isActive.value
           linkContextDevtools.isExactActive = isExactActive.value
-          linkContextDevtools.error = isValidTo(unref(props.to))
+          linkContextDevtools.error = isRouteLocation(unref(props.to))
             ? null
             : 'Invalid "to" value'
         },

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -84,7 +84,7 @@ export interface UseLinkDevtoolsContext {
   route: RouteLocationNormalized & { href: string }
   isActive: boolean
   isExactActive: boolean
-  error: string
+  error: string | null
 }
 
 export type UseLinkOptions = VueUseOptions<RouterLinkOptions>
@@ -192,7 +192,7 @@ export function useLink(props: UseLinkOptions) {
         route: route.value,
         isActive: isActive.value,
         isExactActive: isExactActive.value,
-        error: '',
+        error: null,
       }
 
       // @ts-expect-error: this is internal
@@ -205,7 +205,7 @@ export function useLink(props: UseLinkOptions) {
           linkContextDevtools.isActive = isActive.value
           linkContextDevtools.isExactActive = isExactActive.value
           linkContextDevtools.error = isValidTo(unref(props.to))
-            ? ''
+            ? null
             : 'Invalid "to" value'
         },
         { flush: 'post' }

--- a/packages/router/src/devtools.ts
+++ b/packages/router/src/devtools.ts
@@ -119,10 +119,16 @@ export function addDevtools(app: App, router: Router, matcher: RouterMatcher) {
           ;(
             componentInstance.__vrl_devtools as UseLinkDevtoolsContext[]
           ).forEach(devtoolsData => {
+            let label = devtoolsData.route.path
             let backgroundColor = ORANGE_400
             let tooltip: string = ''
+            let textColor = 0
 
-            if (devtoolsData.isExactActive) {
+            if (devtoolsData.error) {
+              label = devtoolsData.error
+              backgroundColor = RED_100
+              textColor = RED_700
+            } else if (devtoolsData.isExactActive) {
               backgroundColor = LIME_500
               tooltip = 'This is exactly active'
             } else if (devtoolsData.isActive) {
@@ -131,8 +137,8 @@ export function addDevtools(app: App, router: Router, matcher: RouterMatcher) {
             }
 
             node.tags.push({
-              label: devtoolsData.route.path,
-              textColor: 0,
+              label,
+              textColor,
               tooltip,
               backgroundColor,
             })
@@ -419,6 +425,8 @@ const CYAN_400 = 0x22d3ee
 const ORANGE_400 = 0xfb923c
 // const GRAY_100 = 0xf4f4f5
 const DARK = 0x666666
+const RED_100 = 0xfee2e2
+const RED_700 = 0xb91c1c
 
 function formatRouteRecordForInspector(
   route: RouteRecordMatcher

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -8,6 +8,7 @@ import {
   RouteLocationNormalizedLoaded,
   RouteLocation,
   RouteRecordName,
+  isRouteLocation,
   isRouteName,
   NavigationGuardWithThis,
   RouteLocationOptions,
@@ -32,14 +33,7 @@ import {
   NavigationRedirectError,
   isNavigationFailure,
 } from './errors'
-import {
-  applyToParams,
-  isBrowser,
-  assign,
-  noop,
-  isArray,
-  isObject,
-} from './utils'
+import { applyToParams, isBrowser, assign, noop, isArray } from './utils'
 import { useCallbacks } from './utils/callbacks'
 import { encodeParam, decode, encodeHash } from './encoding'
 import {
@@ -467,7 +461,7 @@ export function createRouter(options: RouterOptions): Router {
       })
     }
 
-    if (__DEV__ && !isObject(rawLocation)) {
+    if (__DEV__ && !isRouteLocation(rawLocation)) {
       warn(
         `router.resolve() was passed an invalid location. This will fail in production.\n- Location:`,
         rawLocation

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -32,7 +32,14 @@ import {
   NavigationRedirectError,
   isNavigationFailure,
 } from './errors'
-import { applyToParams, isBrowser, assign, noop, isArray } from './utils'
+import {
+  applyToParams,
+  isBrowser,
+  assign,
+  noop,
+  isArray,
+  isObject,
+} from './utils'
 import { useCallbacks } from './utils/callbacks'
 import { encodeParam, decode, encodeHash } from './encoding'
 import {
@@ -458,6 +465,14 @@ export function createRouter(options: RouterOptions): Router {
         redirectedFrom: undefined,
         href,
       })
+    }
+
+    if (__DEV__ && !isObject(rawLocation)) {
+      warn(
+        `router.resolve() was passed an invalid location. This will fail in production.\n- Location:`,
+        rawLocation
+      )
+      rawLocation = {}
     }
 
     let matcherLocation: MatcherLocationRaw

--- a/packages/router/src/utils/index.ts
+++ b/packages/router/src/utils/index.ts
@@ -37,3 +37,6 @@ export const noop = () => {}
  */
 export const isArray: (arg: ArrayLike<any> | any) => arg is ReadonlyArray<any> =
   Array.isArray
+
+export const isObject = (val: unknown): val is Record<any, any> =>
+  val !== null && typeof val === 'object'

--- a/packages/router/src/utils/index.ts
+++ b/packages/router/src/utils/index.ts
@@ -37,6 +37,3 @@ export const noop = () => {}
  */
 export const isArray: (arg: ArrayLike<any> | any) => arg is ReadonlyArray<any> =
   Array.isArray
-
-export const isObject = (val: unknown): val is Record<any, any> =>
-  val !== null && typeof val === 'object'


### PR DESCRIPTION
This PR attempts to improve the warnings and error handling for a common problem encountered during development.

## Background

There's an error message I've encountered several times on Vue Land:

> TypeError: Cannot use 'in' operator to search for 'path' in undefined
 
This comes from `router.resolve()`, e.g.:

- [Playground](https://play.vuejs.org/#eNp9UV1PgzAU/SsNL2zJgESnDyQmi2aJmviR6Zv1gcEddIOWtIVhCP/d24L70DleWs49Pfece1uniBj318oJHVaUQmrSklhCpOEJCiG/7pnSeEwGcCEqDZJ0ZCVFQdy6Ak9ayKWc8lhwpUkPkJujJ6OWckKyXi081WI0nhiKfa1C8mF+CLHPzFdGOguJG7iWZb5YoGEOXIek7XrQHp+Ud2NjpzfiS1Air2FU8QRWjEMydiZDWK+ISgwvOMa3nehQUNRB1V6UOvuYBqZOpnWpwiCoeLlJffQR7BmzqX/hXwUJhjpAfVCFt5Riq/C+RvUhBXVmSAoSqLUQufKikv3X4g9xdu1PsVPOlgGqBwzjNVbbSOMkOoypFe5kxdJfIc3oWA7ypdQMd3YUNspzsX20mJYV7IzGGcSbE/haNb3lVxw0yBoOwulIpqD78vztGRq874qFSKoc2WeKC7O6ynjsabe4Q7R9wLNuH+zOGE/f1bzRwNVPKGPUTsPy7SLvzkTf2730p7spdt+TZA3R)

That's a silly example, it's rarely quite so obvious when someone is having this problem in a real application.

These two issues are both hitting the same problem (the first one is in the wrong repo):
- https://github.com/vuejs/vue-router/issues/3735
- https://github.com/vuejs/router/issues/992

You get something similar with `null` instead of `undefined`.

`router.push(undefined)` gives the same error, as that uses `router.resolve()`.

Most commonly this is hit via `useLink()`. Here's a simple example of that:

- [Playground](https://play.vuejs.org/#eNp9Uk2P0zAQ/SujcEgqtYkEhUOkRQW0EiC+tHAjHLLJtHGb2JY97hZV/e+M7fRjl931Je7M85v33nSfDLWQ+domZSIGrQzBHhqDNeE7reEAS6MGSLcO00o+AHzFQZm/H4Ul/kzH4o1yhGYKzuIXITeXDDMTekxUyUZJSxALcHXvbbavJEAXacvHZmWTqYeE17aE3/4HQHjmj66pKyEt0oDyp1GsXKKkEvaHWAyfP5U8TM5yanZ81MLuoxCL5HQ2OdKPvmLPH1IlONniUkhsR+7A6W+GHxsJ/PzqLaQd9r1i+2F6BPHInCmzmMSpNCgnKUtf8D2dJNNxNbOh1rwqJXlZYX41NmyVsLM4skrOUftylXRE2pZF4aTerHLOojgjFvP8Zf66aDnYi2qOdpjdGnVn+b5m9jHJKlkwqGhxS0r1dlZr8dSI/4CLN/mcJ/XitmD2QnBku8B9zINtkuVFLMXqgUm/PtGj+a5J8KLuma050rvPoUbG4Ulo02GzeaS+trso+YdBdrfFC3NUmxVSbF///IY7vp+ag2pdz+hnmjdoVe+8xgh7z/8Lln2BC2o/hZ0Jufplr3eE0h5NeaEhjYAPi/zwjPWz3Ff5/JTi4R/NvkZT)

Again, I've made it obvious what the problem is with `to: undefined`, but real code is rarely so blatant.

It is possible to hit this same error via `RouterLink`, but in that case we get a prop validation warning, making it a bit easier to figure out what the problem is:

- [Playground](https://play.vuejs.org/#eNqFVNuO0zAQ/ZUhPCSV2ljAwkPURbuglRbETQuCB8JDtnFb7ya2ZTvdoir/zviS21LKQxt75oznjOeMD1FdMJ7e6SiLWC2FMnCAlaKFoZdSQgtrJWqIdw2Ncx4ASjSGquBJid8ObhvX+QopUx+b8/7UBH+znAOkjaaJD/f7WjTcJPFTDItn0TwK4chtqVeKSQOamka+7nMd4MaFf2D8fh7W3xl9GBNf9ASRg+DaQIVoDefw0yY92D8AQ/cmg/ha1DSee5MszBZNBCMB2vkj5OUtHjuCcgstnNHhc/4r50vieSNj3BhaywrvAHcAS17s3AKXnQN2i7VQ53mUWIpzYLyk+xl+POU8CgEYomXBEc7WiHYwdMICMCE6BthwPZAZgVh7UGorQ/zh4M5NbUXQtksyoDtmZMqZdKSXVjYdaHTvJOCCexSP7fSNOCq2j7QW6vc10wY/82D05x7vZYi3/XKJO8V1hiC7TpO2LxNcb+n1SfcOWtJ10VRmQiFxrd96dtkxysnMKcHR05lXVq+tkZSCXgBWAplxylFKHWXvGoQ2hHlZHYvtywjB9oO6a+30jK/i1Agpun406N2g1HqDY4L+JL6mVSXgh1BV+STGaT2l7O0zKy0bbEWFO2dlXDYGJVuLklaoRPQ7QU81MunLEdaE/De3vwp3EDTa69GZp5l8/Yu6kKhIwTGXu3ccJ+fAacu6TuTRoD1rzqOtMVJnhDRc3m9SbAgZEBdn6fP0JSlRGSNrSnW9uFXiQbsRyKPQzjy6QBAp6c4IUelFIdm/UvwFvHiVnmGmit0SPJ24d8CdHV6gFss0Gnu5ZptHRVoNsYqqz9Iw7PWk2AJb/fDe2YxqaE90taWr+yP2O42vj6X8RVGsbkdHxZlCbajx7quvn/ClGTlRCk2F6BPOG6pF1ViOHvam4SXSHuEc23euZ4xvvumrvaFcd0VZov799nXjFb49UfpA90V61t9i+wfNoGNa)

The mistake in that example is a typo in `patn: '/about'`.

But even with the prop validation warning, it can be difficult to identify exactly which component has the problem. If we could inspect the components using Vue Devtools it'd be much easier, but that isn't currently an option because rendering bombs out.

## The Vuetify problem

Someone on Vue Land was hitting this error, but without any warnings to indicate what they were doing wrong. They weren't using `RouterLink`, they were using Vuetify's breadcrumb component.

The ultimate cause of the problem was an `undefined` in their data that they hadn't taken into account. But this isn't quite as simple as it sounds.

There's this problematic line in Vuetify:

- https://github.com/vuetifyjs/vuetify/blob/c8503b1e0d9669bfc384ba563d5211922ea33e80/packages/vuetify/src/composables/router.tsx#L68

The problem here is that `props.to` can be `undefined`. While the Vuetify composable does check that, it only checks the initial value. In the application we encountered on Vue Land, the `to` prop was populated initially, only becoming `undefined` after some new data loaded.

It isn't obvious to me how Vuetify could fix this problem in their own code. There doesn't seem to be a way to disable the `useLink()` composable when the prop is `undefined` and re-enable it when the value is defined.

This PR doesn't attempt to address that problem directly, it just aims to improve the warnings/errors to ease debugging.

## What's changed

- `router.resolve()` no longer throws an error in dev. It logs a warning instead. This allows Vue Devtools to be used to debug the problem.
- `useLink()` logs warnings. This is usually a bit more helpful than the warning in `router.resolve()`, as it has more context to work with.
- Vue Devtools will show an error label if `props.to` is invalid, making it much easier to find a rogue `RouterLink` in a long list:
  ![Vue Devtools](https://github.com/vuejs/router/assets/65301168/70f32889-cce1-490b-8273-0d2da35a77d2)

In cases where `RouterLink` has an `undefined` or `null` value for `to`, this will lead to 3 warnings being shown: one for prop validation, one for `useLink()` and one for `router.resolve()`. I couldn't see an easy way to avoid that, but I think that's much better than not having the warnings.