### PR TITLE
docs(zh): translate the warning part of passing_props to Chinese

### DIFF
--- a/packages/docs/zh/guide/essentials/passing-props.md
+++ b/packages/docs/zh/guide/essentials/passing-props.md
@@ -79,11 +79,9 @@ URL `/search?q=vue` 将传递 `{query: 'vue'}` 作为 props 传给 `SearchUser` 
 
 请尽可能保持 `props` 函数为无状态的，因为它只会在路由发生变化时起作用。如果你需要状态来定义 props，请使用包装组件，这样 vue 才可以对状态变化做出反应。
 
-<!-- TODO: translation -->
+## 通过 RouterView
 
-## Via RouterView
-
-You can also pass any props via the [`<RouterView>` slot](../advanced/router-view-slot):
+你还可以通过 [`<RouterView>` 插槽](../advanced/router-view-slot) 传递任意参数：
 
 ```vue-html
 <RouterView v-slot="{ Component }">
@@ -95,5 +93,5 @@ You can also pass any props via the [`<RouterView>` slot](../advanced/router-vie
 ```
 
 ::: warning
-In this case, **all view components** will receive `view-prop`. This is usually not a good idea as  it means that all of the view components have declared a `view-prop` prop, which is not necessarily true. If possible, use any of the options above.
+在这种情况下，**所有视图组件**都会接收到 `view-prop`。通常这并不是一个好主意，因为这意味着所有的视图组件都声明了一个 `view-prop` prop，但这未必需要。所以请尽可能使用上述的其他选项。
 :::


### PR DESCRIPTION
### Finished the translation of Passing Props to Route Components

[2024.03.06] UPDATE: 
![图片](https://github.com/vuejs/router/assets/45524718/9831b764-a59f-4689-bf11-7f9b192abcd6)

Before: 
![图片](https://github.com/vuejs/router/assets/45524718/87b6f783-22da-4714-982c-2c01e630d458)

After: 
![图片](https://github.com/vuejs/router/assets/45524718/c9958d23-36c0-46ee-b193-e17df15cfc3a)