### PR TITLE
feat: pluggable matcher

### DIFF
--- a/packages/router/src/devtools.ts
+++ b/packages/router/src/devtools.ts
@@ -10,10 +10,10 @@ import {
 import { watch } from 'vue'
 import { decode } from './encoding'
 import { isSameRouteRecord } from './location'
-import { RouterMatcher } from './matcher'
+import { GenericRouterMatcher } from './matcher'
 import { RouteRecordMatcher } from './matcher/pathMatcher'
 import { PathParser } from './matcher/pathParserRanker'
-import { Router } from './router'
+import { GenericRouter } from './router'
 import { UseLinkDevtoolsContext } from './RouterLink'
 import { RouterViewDevtoolsContext } from './RouterView'
 import { RouteLocationNormalized } from './types'
@@ -59,7 +59,11 @@ function formatDisplay(display: string) {
 // to support multiple router instances
 let routerId = 0
 
-export function addDevtools(app: App, router: Router, matcher: RouterMatcher) {
+export function addDevtools<RC>(
+  app: App,
+  router: GenericRouter<RC>,
+  matcher: GenericRouterMatcher<RC>
+) {
   // Take over router.beforeEach and afterEach
 
   // make sure we are not registering the devtool twice

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -2,7 +2,7 @@ export { createWebHistory } from './history/html5'
 export { createMemoryHistory } from './history/memory'
 export { createWebHashHistory } from './history/hash'
 export { createRouterMatcher } from './matcher'
-export type { RouterMatcher } from './matcher'
+export type { GenericRouterMatcher, RouterMatcher } from './matcher'
 
 export { parseQuery, stringifyQuery } from './query'
 export type {
@@ -67,8 +67,18 @@ export type {
   NavigationHookAfter,
 } from './types'
 
-export { createRouter } from './router'
-export type { Router, RouterOptions, RouterScrollBehavior } from './router'
+export {
+  createRouter,
+  createRouterWithMatcher,
+  createDefaultMatcher,
+} from './router'
+export type {
+  Router,
+  RouterWithMatcher,
+  RouterOptions,
+  RouterWithMatcherOptions,
+  RouterScrollBehavior,
+} from './router'
 
 export { NavigationFailureType, isNavigationFailure } from './errors'
 export type {


### PR DESCRIPTION
## Background

Original issue: #2132. In short, the performance of adding a large number of routes is slow, and is particularly problematic with SSR.

This PR explores the idea of a 'pluggable matcher'. This allows the matcher to be passed into the router, rather than being created internally. The potential benefits are twofold:

1. In an SSR scenario, the matcher can be created upfront, rather than processing the individual routes for each request.
2. Custom matchers can be used, potentially supporting different features or faster implementations.

The code presented here is a long way from being merged, but hopefully it'll work as a starting point to discuss how to proceed.

## SSR usage

To get the benefits with SSR, we'd need to replace this:

```js
const router = createRouter({
  history,
  routes: [/* ... */],
  strict,
  sensitive
})
```

with this:

```js
// Do this once
const matcher = createDefaultMatcher({
  routes: [/* ... */],
  strict,
  sensitive
})

// Do this for each request
const router = createRouterWithMatcher({
  history,
  matcher: matcher.clone()
})
```

The `clone()` call creates a copy of the matcher, allowing for more routes to be added or removed without impacting the original matcher.

The performance of this is really good. Calling `clone()` is very fast and we skip all the overhead of processing the individual routes.

## Custom matchers

This is trickier.

The usage is similar to the previous example, but with a custom implementation of `matcher`.

TypeScript isn't my strong suit, so perhaps this isn't as difficult as it seemed, but I found trying to get the types working as I wanted really difficult. The code in this PR is much less ambitious than some of my other attempts, but hopefully it'll still illustrate the difficulties.

For example, I tried writing a custom matcher that only supported the options `path`, `name`, `component` and `components`. You can see that at:

- [SimpleRouterMatcher](https://gist.github.com/skirtles-code/6c253e201d4ec1da1b32fafbce21c6cb)

If you search through the code for `Pain point`, you'll find various points where I had to do things that didn't really make sense in the context of that matcher implementation. Some of those may be necessary for other reasons, but in many cases I was adding things just to appease TS. For example, the `score` and `re` properties are completely redundant, but the types force them to be included.

I did experiment with changing those types, adding generics all over the place, but it got a bit out of hand and I decided to aim a little lower for this initial PR. Instead, I chose to focus just on the route config.

As `SimpleRouterMatcher` only supports 4 options for the route, I wanted the types to reflect that. So `SimpleRoute` is a type that defines that format, with the matcher having type:

```ts
interface SimpleRouterMatcher extends GenericRouterMatcher<SimpleRoute> {}
```

You'll find `RC` used a generic in various places in the code. `RC` stands for 'route config'.

This then has an impact on the type of the `addRoute()` method of the router itself. New routes need to be added using the `SimpleRoute` format. e.g.:

```ts
const matcher = createSimpleRouterMatcher({
  routes: [
    {
      path: '/',
      component: HomeView
    }
  ]
})

const router = createRouterWithMatcher({ history, matcher })

// The type here is 'SimpleRoute', so options like 'strict' aren't available
router.addRoute({
  path: '/about',
  component: AboutView
})
```

This almost works. The major problem is `$router` and `useRouter()`, neither of which take account of the generic.

## Other problems

The `options` property of the `Router` type is a bit fiddly. It needs to take account of the options passed to `createRouterWithMatcher()`, which aren't the same as `createRouter()`.

## Next steps

If we just want the performance benefits for SSR usage, we don't need support for custom matchers. That would dodge most of the type problems.

The custom matcher feature may tie into #2148. That PR is currently implemented as changes to the default matcher, but it could instead be implemented as a separate matcher implementation.

If the type problems can be overcome, I think we'd also need to consider adding helpers to make custom matchers easier to write. I found myself duplicating a lot of logic from the default matcher when I was writing `SimpleRouterMatcher`. If we do choose to pursue this further, I recommend anyone wanting to give feedback to attempt writing a custom matcher. I found going through that process quite enlightening.

Depending on what direction we choose to go in, we should also consider an RFC. At the very least we'd need some feedback from the SSR meta-frameworks about whether this is workable for them.