### PR TITLE
docs: fix typo

### DIFF
--- a/packages/docs/api/interfaces/RouteRecordNormalized.md
+++ b/packages/docs/api/interfaces/RouteRecordNormalized.md
@@ -53,7 +53,7 @@ ___
 
 • **instances**: `Record`\<`string`, `undefined` \| ``null`` \| `ComponentPublicInstance`\>
 
-Mounted route component instances
+Mounted route component instances.
 Having the instances on the record mean beforeRouteUpdate and
 beforeRouteLeave guards can only be invoked with the latest mounted app
 instance if there are multiple application instances rendering the same


### PR DESCRIPTION
### Fix typo

**Description:** A period is missing between `instances` and `Having`, click [here](https://router.vuejs.org/zh/api/interfaces/RouteRecordNormalized.html#Properties-instances) for details.

**Snapshot:**
![图片](https://github.com/vuejs/router/assets/45524718/251836b0-1a34-4d26-85e2-88f20e2f6e46)