### PR TITLE
docs: rewrite the Named Routes page

### DIFF
--- a/packages/docs/.vitepress/config/en.ts
+++ b/packages/docs/.vitepress/config/en.ts
@@ -85,16 +85,16 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
               link: '/guide/essentials/route-matching-syntax.html',
             },
             {
+              text: 'Named Routes',
+              link: '/guide/essentials/named-routes.html',
+            },
+            {
               text: 'Nested Routes',
               link: '/guide/essentials/nested-routes.html',
             },
             {
               text: 'Programmatic Navigation',
               link: '/guide/essentials/navigation.html',
-            },
-            {
-              text: 'Named Routes',
-              link: '/guide/essentials/named-routes.html',
             },
             {
               text: 'Named Views',

--- a/packages/docs/guide/essentials/named-routes.md
+++ b/packages/docs/guide/essentials/named-routes.md
@@ -5,39 +5,41 @@
   title="Learn about the named routes"
 />
 
-Alongside the `path`, you can provide a `name` to any route. This has the following advantages:
-
-- No hardcoded URLs
-- Automatic encoding/decoding of `params`
-- Prevents you from having a typo in the url
-- Bypassing path ranking (e.g. to display a )
+When creating a route, we can optionally give the route a `name`:
 
 ```js
 const routes = [
   {
     path: '/user/:username',
-    name: 'user',
+    name: 'profile', // [!code highlight]
     component: User
   }
 ]
 ```
 
-To link to a named route, you can pass an object to the `router-link` component's `to` prop:
+We can then use the `name` instead of the `path` when passing the `to` prop to `<router-link>`:
 
 ```vue-html
-<router-link :to="{ name: 'user', params: { username: 'erina' }}">
-  User
+<router-link :to="{ name: 'profile', params: { username: 'erina' } }">
+  User profile
 </router-link>
 ```
 
-This is the exact same object used programmatically with `router.push()`:
+The example above would create a link to `/user/erina`.
+
+- [See it in the Playground](https://play.vuejs.org/#eNqtVVtP2zAU/itWNqlFauNNIB6iUMEQEps0NjH2tOzBtKY1JLZlO6VTlP++4+PcelnFwyRofe7fubaKCiZk/GyjJBKFVsaRiswNZ45faU1q8mRUQUbrko8yuaPwlRfK/LkV1sHXpGHeq9JxMzScGmT19t5xkMaUaR1vOb9VBe+kntgWXz2Cs06O1LbCTwvRW7knGnEm50paRwIYcrEFd1xlkpBVyCQ5lN74ZOJV0Nom5JcnCFRCM7dKyIiOJkSygsNzBZiBmivAI7l0SUipRvuhCfPge7uWHBiGZPctS0iLJv7T2/YutFFPIt+JjgUJPn7DZ32CtWg7PIZ/4BASg7txKE6gC1VKNx69gw6NTqJJ1HQK5iR1vNA52M+8Yrr6OLuD+AuCtbQpBQYK9Oy6NAZAhLI1KKuKvEc69jSp65Tqw/oh3V7f00P9MsdveOWiecE75DDNhXwhiVMXWVRttYbUWdRpE2xOZ0sHxq1v2jl/a5jQyZ042Mv/HKjvt2aGFTCXFWmnAsTcCMkAxw4SHIjG9E2AUtpUusWyFvyVUGCltBsFmJB2W/dHZCHWswdYLwJ/XiulnrNr323zcQeodthDuAHTgmm4aEqCH1zsrBHYLIISheyyqD9Nnp1FK+e0TSgtpX5ZxrBBtNe4PItP4w8Q07oBN+a2mD4a9erPzDN4bzY1iy5BiS742imV2ynT4l8h9hQvz+Pz+COU/pGCdyrkgm/Qt3ddw/5Cms7CLXsSy50k/dJDT8037QTcuq1kWZ6r1y/Ic6bkHdD5is9fDvCf7SZA/m44ZLfmg+QcM0vugvjmxx3fwLsTFmpRwlwdE95zq/LSYwxqn0q5ANgDPUT7GXsm5PLB3mwcl7ZNygPFaqA+NvL6SOo93NP4bFDF9sfh+LThtgxvkF80fyxxy/Ac7U9i/RcYNWrd).
+
+Using a `name` has various advantages:
+
+- No hardcoded URLs.
+- Automatic encoding of `params`.
+- Prevents you from having a typo in the url.
+- Bypassing path ranking, e.g. to display a lower-ranked route that matches the same path.
+
+Each name **must be unique** across all routes. If you add the same name to multiple routes, the router will only keep the last one. You can read more about this [in the Dynamic Routing](../advanced/dynamic-routing#Removing-routes) section.
+
+There are various other parts of Vue Router that can be passed a location, e.g. the methods `router.push()` and `router.replace()`. We'll go into more detail about those methods in the guide to [programmatic navigation](./navigation). Just like the `to` prop, these methods also support passing a location by `name`:
 
 ```js
-router.push({ name: 'user', params: { username: 'erina' } })
+router.push({ name: 'profile', params: { username: 'erina' } })
 ```
-
-In both cases, the router will navigate to the path `/user/erina`.
-
-Full example [here](https://github.com/vuejs/vue-router/blob/dev/examples/named-routes/app.js).
-
-Each name **must be unique** across all routes. If you add the same name to multiple routes, the router will only keep the last one. You can read more about this [in the Dynamic Routing](../advanced/dynamic-routing.md#Removing-routes) section.

--- a/packages/docs/guide/essentials/named-routes.md
+++ b/packages/docs/guide/essentials/named-routes.md
@@ -33,7 +33,7 @@ Using a `name` has various advantages:
 
 - No hardcoded URLs.
 - Automatic encoding of `params`.
-- Prevents you from having a typo in the url.
+- Avoids URL typos.
 - Bypassing path ranking, e.g. to display a lower-ranked route that matches the same path.
 
 Each name **must be unique** across all routes. If you add the same name to multiple routes, the router will only keep the last one. You can read more about this [in the Dynamic Routing](../advanced/dynamic-routing#Removing-routes) section.


### PR DESCRIPTION
There are several problems I was trying to address:

1. Named routes are used in earlier pages, particularly the **Nested Routes** and **Programmatic Navigation** pages, which use them quite heavily.
2. The list of advantages comes too soon. A reader will struggle to understand that list until they have seen the example.
3. Advantage 2 on the list mentions `encoding/decoding`. As far as I can tell, that should just be `encoding`, as named routes don't impact decoding.
4. Advantage 4 stops mid-sentence. `Bypassing path ranking (e.g. to display a )`.
5. The linked example is for Vue 2.

While I've reworded and reordered much of the page, the material covered should be the same.

I've tweaked the example to use `name: 'profile'`, rather than `name: 'user'`. This was to avoid the `name` coinciding with the `/user/` prefix on the `path`. These kinds of naming coincidences can (in general) lead to beginners misunderstanding what is significant and what isn't, and it seemed unnecessary to risk any confusion here.