### PR TITLE
docs: adds Bun package manager option in Installation Guide

### DIFF
--- a/packages/docs/installation.md
+++ b/packages/docs/installation.md
@@ -20,6 +20,10 @@ yarn add vue-router@4
 pnpm add vue-router@4
 ```
 
+```bash [bun]
+bun add vue-router@4
+```
+
 :::
 
 If you're starting a new project, you might find it easier to use the [create-vue](https://github.com/vuejs/create-vue) scaffolding tool, which creates a Vite-based project with the option to include Vue Router:
@@ -36,6 +40,10 @@ yarn create vue
 
 ```bash [pnpm]
 pnpm create vue
+```
+
+```bash [bun]
+bun create vue
 ```
 
 :::

--- a/packages/docs/installation.md
+++ b/packages/docs/installation.md
@@ -35,15 +35,15 @@ npm create vue@latest
 ```
 
 ```bash [yarn]
-yarn create vue
+yarn create vue@latest
 ```
 
 ```bash [pnpm]
-pnpm create vue
+pnpm create vue@latest
 ```
 
 ```bash [bun]
-bun create vue
+bun create vue@latest
 ```
 
 :::

--- a/packages/docs/zh/installation.md
+++ b/packages/docs/zh/installation.md
@@ -45,15 +45,15 @@ npm create vue@latest
 ```
 
 ```bash [yarn]
-yarn create vue
+yarn create vue@latest
 ```
 
 ```bash [pnpm]
-pnpm create vue
+pnpm create vue@latest
 ```
 
 ```bash [bun]
-bun create vue
+bun create vue@latest
 ```
 
 :::

--- a/packages/docs/zh/installation.md
+++ b/packages/docs/zh/installation.md
@@ -30,6 +30,10 @@ yarn add vue-router@4
 pnpm add vue-router@4
 ```
 
+```bash [bun]
+bun add vue-router@4
+```
+
 :::
 
 如果你打算启动一个新项目，你可能会发现使用 [create-vue](https://github.com/vuejs/create-vue) 这个脚手架工具更容易，它能创建一个基于 Vite 的项目，并包含加入 Vue Router 的选项：
@@ -46,6 +50,10 @@ yarn create vue
 
 ```bash [pnpm]
 pnpm create vue
+```
+
+```bash [bun]
+bun create vue
 ```
 
 :::


### PR DESCRIPTION
While I was reading the documentation for creating a Vue 3 project using Vue Router, I realized that this option was missing and it was possible to default everything to the latest version, just like NPM. This PR adds the Bun package manager as an option as well as the Vuejs.org documentation

![image](https://github.com/vuejs/router/assets/79238503/2c3f0498-340a-4b8a-892a-52f75faf0ac6)
