### PR TITLE
docs: correct become sponsor button text color when hovering

### DIFF
--- a/packages/docs/.vitepress/theme/styles/sponsors.css
+++ b/packages/docs/.vitepress/theme/styles/sponsors.css
@@ -15,7 +15,7 @@
   background-color: var(--vp-c-brand);
   text-decoration: none;
   border-color: var(--vp-c-brand);
-  color: var(--vp-button-brand-text);
+  color: var(--vp-button-brand-text) !important;
 }
 
 .sponsors-top .become-sponsor {


### PR DESCRIPTION
In this pull request, I am temporarily correcting the become sponsor button text color when hovering.

| Before      | Now      |
| ------------- | ------------- |
| ![become-sponsor-button-before-2024-05-25_22 21 39](https://github.com/vuejs/router/assets/31008635/faa22184-4b0f-43fc-9f17-827b934bd8ec) | ![become-sponsor-button-now-2024-05-25_22 23 06](https://github.com/vuejs/router/assets/31008635/a073d9d8-3bda-477d-81a5-94c269436400) |


