### PR TITLE
fix: parseQuery -> pre decode the + into space #2253

### DIFF
--- a/packages/router/src/query.ts
+++ b/packages/router/src/query.ts
@@ -60,7 +60,7 @@ export function parseQuery(search: string): LocationQuery {
   const searchParams = (hasLeadingIM ? search.slice(1) : search).split('&')
   for (let i = 0; i < searchParams.length; ++i) {
     // pre decode the + into space
-    const searchParam = searchParams[i].replace(PLUS_RE, ' ')
+    const searchParam = searchParams[i].replace(PLUS_RE, '%2B')
     // allow the = character
     const eqPos = searchParam.indexOf('=')
     const key = decode(eqPos < 0 ? searchParam : searchParam.slice(0, eqPos))


### PR DESCRIPTION
Maybe what you want to do this，Because in Params of Date String, this will result in formatting errors.
Otherwise, the decode operation on key and value will replace all + with spaces.