### PR TITLE
feat: throw if parent and child routes have the same name

### DIFF
--- a/packages/router/__tests__/matcher/addingRemoving.spec.ts
+++ b/packages/router/__tests__/matcher/addingRemoving.spec.ts
@@ -388,6 +388,52 @@ describe('Matcher: adding and removing records', () => {
     })
   })
 
+  it('throws if a parent and child have the same name', () => {
+    expect(() => {
+      createRouterMatcher(
+        [
+          {
+            path: '/',
+            component,
+            name: 'home',
+            children: [{ path: '/home', component, name: 'home' }],
+          },
+        ],
+        {}
+      )
+    }).toThrowError(
+      'A route named "home" has been added as a child of a route with the same name'
+    )
+  })
+
+  it('throws if an ancestor and descendant have the same name', () => {
+    const name = Symbol('home')
+    const matcher = createRouterMatcher(
+      [
+        {
+          path: '/',
+          name,
+          children: [
+            {
+              path: 'home',
+              name: 'other',
+              component,
+            },
+          ],
+        },
+      ],
+      {}
+    )
+
+    const parent = matcher.getRecordMatcher('other')
+
+    expect(() => {
+      matcher.addRoute({ path: '', component, name }, parent)
+    }).toThrowError(
+      'A route named "Symbol(home)" has been added as a descendant of a route with the same name'
+    )
+  })
+
   it('adds empty paths as children', () => {
     const matcher = createRouterMatcher([], {})
     matcher.addRoute({ path: '/', component, name: 'parent' })

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -512,7 +512,7 @@ function checkSameNameAsAncestor(
       throw new Error(
         `A route named "${String(record.name)}" has been added as a ${
           parent === ancestor ? 'child' : 'descendant'
-        } of a route with the same name. This is not allowed, a nested route must not use the same name as an ancestor.`
+        } of a route with the same name. Route names must be unique and a nested route cannot use the same name as an ancestor.`
       )
     }
   }

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -154,8 +154,12 @@ export function createRouterMatcher(
 
         // remove the route if named and only for the top record (avoid in nested calls)
         // this works because the original record is the first one
-        if (isRootAdd && record.name && !isAliasRecord(matcher))
+        if (isRootAdd && record.name && !isAliasRecord(matcher)) {
+          if (__DEV__) {
+            checkSameNameAsAncestor(record, parent)
+          }
           removeRoute(record.name)
+        }
       }
 
       // Avoid adding a record that doesn't display anything. This allows passing through records without a component to
@@ -496,6 +500,21 @@ function checkChildMissingNameWithEmptyPath(
         parent.record.name
       )}" has a child without a name and an empty path. Using that name won't render the empty path child so you probably want to move the name to the child instead. If this is intentional, add a name to the child route to remove the warning.`
     )
+  }
+}
+
+function checkSameNameAsAncestor(
+  record: RouteRecordRaw,
+  parent?: RouteRecordMatcher
+) {
+  for (let ancestor = parent; ancestor; ancestor = ancestor.parent) {
+    if (ancestor.record.name === record.name) {
+      throw new Error(
+        `A route named "${String(record.name)}" has been added as a ${
+          parent === ancestor ? 'child' : 'descendant'
+        } of a route with the same name. This is not allowed, a nested route must not use the same name as an ancestor.`
+      )
+    }
   }
 }
 


### PR DESCRIPTION
#2266 demonstrated an edge case that can lead to inconsistent internal state in the matcher.

The problem arises when using nested routes. If the child (or deeper descendant) has the same `name` as its parent, the parent is removed at the same time that the child is added.

Removing a parent route should also remove its children, but in this case that removal happens just before the child is added to the matcher. The child still gets added to the matcher, and its `parent` property still points to the parent route, even though that has now been removed. The parent can no longer be resolved directly, but when resolving the child, the `matched` array will still contain the removed parent.

This problem can occur during the initial router creation:

```js
createRouter({
  // ...
  routes: [{
      name: 'abc',
      // ...
      children: [{
        name: 'abc',
        // ...      
      }]
  }]
})
```

It can also happen when adding a route dynamically:

```js
const router = createRouter({
  // ...
  routes: [{
      name: 'abc',
      // ...
  }]
})

router.addRoute('abc', {
  name: 'abc',
  // ...      
})
```

This PR introduces a dev-only check for ancestors with the same name and throws an error if a duplicate is found.