### PR TITLE
fix: router typescript definations related to vue package

### DIFF
--- a/packages/router/src/globalExtensions.ts
+++ b/packages/router/src/globalExtensions.ts
@@ -8,8 +8,7 @@ import type { RouterLink } from './RouterLink'
 import type { Router } from './router'
 import type { TypesConfig } from './config'
 
-// TODO: figure out why it cannot be 'vue' like said in docs
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomOptions {
     /**
      * Guard called when the router is navigating to the route that is rendering


### PR DESCRIPTION
![image](https://github.com/vuejs/router/assets/7310471/a5f6da79-2bb6-46e9-9f8e-5a2222fc1320)
![image](https://github.com/vuejs/router/assets/7310471/abeed6f0-50eb-474c-92bc-3b9f8f377b26)

after

![image](https://github.com/vuejs/router/assets/7310471/14b77ce1-0e93-448b-8dda-c6a2d0552dae)
![image](https://github.com/vuejs/router/assets/7310471/64056833-b0c6-4934-9c15-a1821429b42d)

I noticed the comment : `// TODO: figure out why it cannot be 'vue' like said in docs`, actullay, it works in the latest version of vue(3.4.31) 
