### PR TITLE
docs: fix example in passing-props.md

### DIFF
--- a/packages/docs/guide/essentials/passing-props.md
+++ b/packages/docs/guide/essentials/passing-props.md
@@ -36,14 +36,14 @@ We can remove the direct dependency on `$route` in `User.vue` by declaring a pro
 ```vue [Composition API]
 <!-- User.vue -->
 <script setup>
-defineProps({
+const props = defineProps({
   id: String
 })
 </script>
 
 <template>
   <div>
-    User {{ id }}
+    User {{ props.id }}
   </div>
 </template>
 ```
@@ -60,7 +60,7 @@ export default {
 
 <template>
   <div>
-    User {{ id }}
+    User {{ props.id }}
   </div>
 </template>
 ```


### PR DESCRIPTION
I think the example given for passing in `id` through props is incorrect. I needed to assign the return value of `defineProps` and then reference that in order to get the right behavior.

Vue 3.4.29, Vue-Router 4.3.3