### PR TITLE
chore(router): reorder exports in `package.json`

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -7,6 +7,26 @@
   "module": "dist/vue-router.mjs",
   "types": "dist/vue-router.d.ts",
   "exports": {
+    ".": {
+      "types": "./dist/vue-router.d.ts",
+      "node": {
+        "import": {
+          "production": "./dist/vue-router.node.mjs",
+          "development": "./dist/vue-router.node.mjs",
+          "default": "./dist/vue-router.node.mjs"
+        },
+        "require": {
+          "production": "./dist/vue-router.prod.cjs",
+          "development": "./dist/vue-router.cjs",
+          "default": "./index.js"
+        }
+      },
+      "import": "./dist/vue-router.mjs",
+      "require": "./index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./vetur/*": "./vetur/*",
+    "./package.json": "./package.json",
     "./auto-routes": {
       "types": "./vue-router-auto-routes.d.ts",
       "node": {
@@ -40,27 +60,7 @@
       },
       "import": "./dist/vue-router.mjs",
       "require": "./index.js"
-    },
-    ".": {
-      "types": "./dist/vue-router.d.ts",
-      "node": {
-        "import": {
-          "production": "./dist/vue-router.node.mjs",
-          "development": "./dist/vue-router.node.mjs",
-          "default": "./dist/vue-router.node.mjs"
-        },
-        "require": {
-          "production": "./dist/vue-router.prod.cjs",
-          "development": "./dist/vue-router.cjs",
-          "default": "./index.js"
-        }
-      },
-      "import": "./dist/vue-router.mjs",
-      "require": "./index.js"
-    },
-    "./dist/*": "./dist/*",
-    "./vetur/*": "./vetur/*",
-    "./package.json": "./package.json"
+    }
   },
   "sideEffects": false,
   "author": {


### PR DESCRIPTION
In the `exports` of `package.json`, place the `.` entry higher than `./auto-routes` and `./auto`.
This can prevent `./auto-routes` and `./auto` from overriding `.` in certain import scenarios.

### Reference
> Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.

https://nodejs.org/api/packages.html#conditional-exports

### Related Links
- https://github.com/nuxt/nuxt/issues/28218
- https://github.com/nuxt/nuxt/pull/28333
