### PR TITLE
chore: use `with` instead of `assert` in rollup.mjs

### DIFF
--- a/packages/router/rollup.config.mjs
+++ b/packages/router/rollup.config.mjs
@@ -6,7 +6,7 @@ import replace from '@rollup/plugin-replace'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import chalk from 'chalk'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 import terser from '@rollup/plugin-terser'
 
 const name = pkg.name


### PR DESCRIPTION
Fixes a build error on newer versions of Node.js. Import attributes by specification should use `with` keyword instead of `assert` and it's already on stage 3, so proposal is accepted. https://github.com/tc39/proposal-import-attributes

This is also mentioned in TypeScript 5.3 https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#import-attributes

```
Scope: 3 of 4 workspace projects
packages/router build$ rimraf dist && rollup -c rollup.config.mjs
│ [!] SyntaxError: Unexpected identifier 'assert'
```