### PR TITLE
docs: nginx example

### DIFF
--- a/packages/docs/guide/essentials/history-mode.md
+++ b/packages/docs/guide/essentials/history-mode.md
@@ -87,9 +87,16 @@ Instead of `mod_rewrite`, you could also use [`FallbackResource`](https://httpd.
 
 ### nginx
 
+`/etc/nginx/conf.d/default.conf`
 ```nginx
-location / {
-  try_files $uri $uri/ /index.html;
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+      try_files $uri $uri/ /index.html;
+  }
 }
 ```
 

--- a/packages/docs/guide/essentials/history-mode.md
+++ b/packages/docs/guide/essentials/history-mode.md
@@ -87,15 +87,22 @@ Instead of `mod_rewrite`, you could also use [`FallbackResource`](https://httpd.
 
 ### nginx
 
-`/etc/nginx/conf.d/default.conf`
+```nginx
+location / {
+  try_files $uri $uri/ /index.html;
+}
+```
+
+For a standalone server config (e.g. when using the official `nginx` docker image), drop the following into `/etc/nginx/conf.d/default.conf`:
+
 ```nginx
 server {
-    listen 80;
-    server_name localhost;
-    root /usr/share/nginx/html;
-    index index.html;
-    location / {
-      try_files $uri $uri/ /index.html;
+  listen 80;
+  server_name localhost;
+  root /usr/share/nginx/html;
+  index index.html;
+  location / {
+    try_files $uri $uri/ /index.html;
   }
 }
 ```


### PR DESCRIPTION
as i was really struggling with the nginx example, because i deployed in a docker nginx-alpine image that doesn't need any config in development mode with hash-router, i changed the example to a full working server config example that works in a fresh nginx docker-image.

this now works copied inside the docker-container to: `etc/nginx/conf.d/default.conf`
useing it togehter with a zitadel behind a traefik with stepca instance.

serving a vue3 app build with vite from a sub-path of the server. maybe others can spare a bit of time, as all these props are needed otherwise there will be an error inside the nginx and the zitadel redirect back to the vue3 app after authentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended nginx history-mode configuration documentation with a new standalone server block example suitable for containerized deployments, complementing existing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->