### PR TITLE
fix: 修改当父、子路由路径和名称一样时，子路由upper为-1导致插入有误的问题

### DIFF
--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -569,6 +569,9 @@ function findInsertionIndex(
     }
   }
 
+  // Copy the upper and return its original position when it is -1
+  const upperBackup = upper
+
   // Second phase: check for an ancestor with the same score
   const insertionAncestor = getInsertionAncestor(matcher)
 
@@ -580,6 +583,7 @@ function findInsertionIndex(
       warn(
         `Finding ancestor route "${insertionAncestor.record.path}" failed for "${matcher.record.path}"`
       )
+      return upperBackup
     }
   }
 


### PR DESCRIPTION
[test.zip](https://github.com/user-attachments/files/17438312/test.zip)


下载附件运行点击 click here按钮可以查看到 `ErrorPage` 在第一个路由，理想情况应当是当 `matchers.lastIndexOf(insertionAncestor, upper - 1)` 返回-1时，使用原始值。

否则会导致 其被插入至最后一个路由的前面