### PR TITLE
fix(resolve): exclude empty optional arguments from params

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -158,6 +158,15 @@
       <li>
         <router-link to="/p_1/absolute-a">/p_1/absolute-a</router-link>
       </li>
+      <li>
+        <router-link :to="{ name: 'features' }">Go to Features (name)</router-link>
+      </li>
+      <li>
+        <router-link to="/features">Go to Features (string)</router-link>
+      </li>
+      <li>
+        <router-link to="/features/one">Go to Feature one</router-link>
+      </li>
     </ul>
     <button @click="toggleViewName">Toggle view</button>
     <RouterView :name="viewName" v-slot="{ Component, route }">

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -159,7 +159,9 @@
         <router-link to="/p_1/absolute-a">/p_1/absolute-a</router-link>
       </li>
       <li>
-        <router-link :to="{ name: 'features' }">Go to Features (name)</router-link>
+        <router-link :to="{ name: 'features' }"
+          >Go to Features (name)</router-link
+        >
       </li>
       <li>
         <router-link to="/features">Go to Features (string)</router-link>

--- a/packages/playground/src/router.ts
+++ b/packages/playground/src/router.ts
@@ -159,6 +159,11 @@ export const router = createRouter({
         { path: 'settings', component },
       ],
     },
+    {
+      path: '/features/:pathMatch(.*)*',
+      name: 'features',
+      component: User,
+    },
   ],
   async scrollBehavior(to, from, savedPosition) {
     await scrollWaiter.wait()

--- a/packages/router/__tests__/matcher/resolve.spec.ts
+++ b/packages/router/__tests__/matcher/resolve.spec.ts
@@ -685,12 +685,12 @@ describe('RouterMatcher.resolve', () => {
       assertRecordMatch(
         { path: '/:a?', components, name: 'a' },
         { path: '/' },
-        { path: '/', params: { a: '' }, name: 'a' }
+        { path: '/', params: {}, name: 'a' }
       )
       assertRecordMatch(
         { path: '/a/:a?', components, name: 'a' },
         { path: '/a/' },
-        { path: '/a/', params: { a: '' }, name: 'a' }
+        { path: '/a/', params: {}, name: 'a' }
       )
     })
 

--- a/packages/router/__tests__/matcher/resolve.spec.ts
+++ b/packages/router/__tests__/matcher/resolve.spec.ts
@@ -888,6 +888,29 @@ describe('RouterMatcher.resolve', () => {
         { name: 'h', path: '/', params: {} }
       )
     })
+
+    // #2419 (skirtles-code's comment): `{ params: { id: undefined } }`
+    // should resolve the same as omitting the key entirely so active-link
+    // comparisons stay consistent. `null` is a type error and is not
+    // supported (see commented-out case below).
+    it('treats explicit undefined optional params as absent', () => {
+      const record = {
+        path: '/features/:id?',
+        name: 'features',
+        components,
+      }
+      assertRecordMatch(
+        record,
+        { name: 'features', params: { id: undefined } },
+        { name: 'features', path: '/features', params: {} }
+      )
+      // null is rejected by the types and not supported at runtime:
+      // assertRecordMatch(
+      //   record,
+      //   { name: 'features', params: { id: null } },
+      //   { name: 'features', path: '/features', params: {} }
+      // )
+    })
   })
 
   describe('LocationAsRelative', () => {

--- a/packages/router/__tests__/matcher/resolve.spec.ts
+++ b/packages/router/__tests__/matcher/resolve.spec.ts
@@ -694,6 +694,25 @@ describe('RouterMatcher.resolve', () => {
       )
     })
 
+    // #2419: resolving by string path must match the same-named route's
+    // missing-optional-params behavior so active-link comparisons stay in sync
+    it('drops missing optional splat when resolving by path', () => {
+      assertRecordMatch(
+        { path: '/features/:pathMatch(.*)*', components, name: 'features' },
+        { path: '/features' },
+        { path: '/features', params: {}, name: 'features' }
+      )
+      assertRecordMatch(
+        { path: '/features/:pathMatch(.*)*', components, name: 'features' },
+        { path: '/features/one' },
+        {
+          path: '/features/one',
+          params: { pathMatch: ['one'] },
+          name: 'features',
+        }
+      )
+    })
+
     it('keeps required trailing slash (strict: true)', () => {
       const record = {
         path: '/home/',

--- a/packages/router/__tests__/matcher/resolve.spec.ts
+++ b/packages/router/__tests__/matcher/resolve.spec.ts
@@ -888,29 +888,6 @@ describe('RouterMatcher.resolve', () => {
         { name: 'h', path: '/', params: {} }
       )
     })
-
-    // #2419 (skirtles-code's comment): `{ params: { id: undefined } }`
-    // should resolve the same as omitting the key entirely so active-link
-    // comparisons stay consistent. `null` is a type error and is not
-    // supported (see commented-out case below).
-    it('treats explicit undefined optional params as absent', () => {
-      const record = {
-        path: '/features/:id?',
-        name: 'features',
-        components,
-      }
-      assertRecordMatch(
-        record,
-        { name: 'features', params: { id: undefined } },
-        { name: 'features', path: '/features', params: {} }
-      )
-      // null is rejected by the types and not supported at runtime:
-      // assertRecordMatch(
-      //   record,
-      //   { name: 'features', params: { id: null } },
-      //   { name: 'features', path: '/features', params: {} }
-      // )
-    })
   })
 
   describe('LocationAsRelative', () => {

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -399,7 +399,7 @@ function pickParams(
   const newParams = {} as MatcherLocation['params']
 
   for (const key of keys) {
-    if (key in params) newParams[key] = params[key]
+    if (key in params && params[key] !== undefined) newParams[key] = params[key]
   }
 
   return newParams

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -326,7 +326,7 @@ export function createRouterMatcher(
         params = matcher.parse(path)!
         name = matcher.record.name
 
-        matcher?.keys.forEach(key => {
+        matcher.keys.forEach(key => {
           if (key.optional && params[key.name] === '') {
             delete params[key.name]
           }

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -325,6 +325,12 @@ export function createRouterMatcher(
         // we know the matcher works because we tested the regexp
         params = matcher.parse(path)!
         name = matcher.record.name
+
+        matcher?.keys.forEach(key => {
+          if (key.optional && params[key.name] === '') {
+            delete params[key.name]
+          }
+        })
       }
       // location is a relative path
     } else {

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -326,8 +326,10 @@ export function createRouterMatcher(
         params = matcher.parse(path)!
         name = matcher.record.name
 
+        // delete all optional params that have falsy values
+        // noramlizes '', null, and undefined into deleting the key
         matcher.keys.forEach(key => {
-          if (key.optional && params[key.name] === '') {
+          if (key.optional && !params[key.name]) {
             delete params[key.name]
           }
         })
@@ -399,7 +401,7 @@ function pickParams(
   const newParams = {} as MatcherLocation['params']
 
   for (const key of keys) {
-    if (key in params && params[key] !== undefined) newParams[key] = params[key]
+    if (key in params) newParams[key] = params[key]
   }
 
   return newParams


### PR DESCRIPTION

fix https://github.com/vuejs/router/issues/2419

Removed if optional parameter is empty
Now the param will match if :to is string and if it is object

In the case of string path, it should not be an empty string parameter(Right?)
, so I thought there would be no problem with excluding it.

However, this may be a breaking change if you have users who were using this

In addition, I added a router-link to Playgound to check the operation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added navigation links and a route to access feature pages, including nested feature paths.

* **Bug Fixes**
  * Fixed resolution so missing optional route parameters are omitted instead of returning empty placeholders.

* **Tests**
  * Added tests covering optional-parameter resolution, including catch-all nested paths and differences when resolving by path vs name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->