### PR TITLE
docs: reorder history modes

### DIFF
--- a/packages/docs/guide/essentials/history-mode.md
+++ b/packages/docs/guide/essentials/history-mode.md
@@ -7,23 +7,6 @@
 
 The `history` option when creating the router instance allows us to choose among different history modes.
 
-## Hash Mode
-
-The hash history mode is created with `createWebHashHistory()`:
-
-```js
-import { createRouter, createWebHashHistory } from 'vue-router'
-
-const router = createRouter({
-  history: createWebHashHistory(),
-  routes: [
-    //...
-  ],
-})
-```
-
-It uses a hash character (`#`) before the actual URL that is internally passed. Because this section of the URL is never sent to the server, it doesn't require any special treatment on the server level. **It does however have a bad impact in SEO**. If that's a concern for you, use the HTML5 history mode.
-
 ## HTML5 Mode
 
 The HTML5 mode is created with `createWebHistory()` and is the recommended mode:
@@ -44,6 +27,23 @@ When using `createWebHistory()`, the URL will look "normal," e.g. `https://examp
 Here comes a problem, though: Since our app is a single page client side app, without a proper server configuration, the users will get a 404 error if they access `https://example.com/user/id` directly in their browser. Now that's ugly.
 
 Not to worry: To fix the issue, all you need to do is add a simple catch-all fallback route to your server. If the URL doesn't match any static assets, it should serve the same `index.html` page that your app lives in. Beautiful, again!
+
+## Hash Mode
+
+The hash history mode is created with `createWebHashHistory()`:
+
+```js
+import { createRouter, createWebHashHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    //...
+  ],
+})
+```
+
+It uses a hash character (`#`) before the actual URL that is internally passed. Because this section of the URL is never sent to the server, it doesn't require any special treatment on the server level. **It does however have a bad impact in SEO**. If that's a concern for you, use the HTML5 history mode.
 
 ## Memory mode
 


### PR DESCRIPTION
Hello, and thank you for such a helpful library! 😄 

I'm submitting a suggestion to reorder the **Different History modes** section so that HTML5 comes first, since it's the recommended way.