### PR TITLE
chore: build path compatibility with nodejs v20

### DIFF
--- a/packages/docs/run-typedoc.mjs
+++ b/packages/docs/run-typedoc.mjs
@@ -2,8 +2,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createTypeDocApp } from './typedoc-markdown.mjs'
 
-const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
-const __dirname = path.dirname(pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 createTypeDocApp({
   name: 'API Documentation',

--- a/packages/docs/run-typedoc.mjs
+++ b/packages/docs/run-typedoc.mjs
@@ -1,7 +1,9 @@
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { createTypeDocApp } from './typedoc-markdown.mjs'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
+const __dirname = path.dirname(pathname)
 
 createTypeDocApp({
   name: 'API Documentation',

--- a/packages/docs/typedoc-markdown.mjs
+++ b/packages/docs/typedoc-markdown.mjs
@@ -4,8 +4,7 @@ import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 import { Application, PageEvent, TSConfigReader } from 'typedoc'
 
-const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
-const __dirname = path.dirname(pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const DEFAULT_OPTIONS = {
   // disableOutputCheck: true,

--- a/packages/docs/typedoc-markdown.mjs
+++ b/packages/docs/typedoc-markdown.mjs
@@ -1,9 +1,11 @@
 // @ts-check
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 import { Application, PageEvent, TSConfigReader } from 'typedoc'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
+const __dirname = path.dirname(pathname)
 
 const DEFAULT_OPTIONS = {
   // disableOutputCheck: true,

--- a/packages/router/size-checks/rollup.config.mjs
+++ b/packages/router/size-checks/rollup.config.mjs
@@ -7,8 +7,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import terser from '@rollup/plugin-terser'
 import { defineConfig } from 'rollup'
 
-const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
-const __dirname = path.dirname(pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const config = defineConfig({
   external: ['vue'],

--- a/packages/router/size-checks/rollup.config.mjs
+++ b/packages/router/size-checks/rollup.config.mjs
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 import ts from 'rollup-plugin-typescript2'
 import replace from '@rollup/plugin-replace'
 import resolve from '@rollup/plugin-node-resolve'
@@ -6,7 +7,8 @@ import commonjs from '@rollup/plugin-commonjs'
 import terser from '@rollup/plugin-terser'
 import { defineConfig } from 'rollup'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
+const __dirname = path.dirname(pathname)
 
 const config = defineConfig({
   external: ['vue'],

--- a/scripts/check-size.mjs
+++ b/scripts/check-size.mjs
@@ -5,8 +5,7 @@ import chalk from 'chalk'
 import { gzipSync } from 'zlib'
 import { compress } from 'brotli'
 
-const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
-const __dirname = path.dirname(pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 async function checkFileSize(filePath) {
   const stat = await fs.stat(filePath).catch(() => null)

--- a/scripts/check-size.mjs
+++ b/scripts/check-size.mjs
@@ -1,10 +1,12 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 import chalk from 'chalk'
 import { gzipSync } from 'zlib'
 import { compress } from 'brotli'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const pathname = process.platform === 'win32' ? fileURLToPath(import.meta.url) : new URL(import.meta.url).pathname
+const __dirname = path.dirname(pathname)
 
 async function checkFileSize(filePath) {
   const stat = await fs.stat(filePath).catch(() => null)


### PR DESCRIPTION
The expression path.dirname(new URL(import.meta.url).pathname) returns a path with a double G:\ prefix on nodejs v20, causing path resolution errors. Modify it using a ternary operator to make it compatible with nodejs v20.