### PR TITLE
chore: upgrade to Prettier 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint-staged": "^15.2.10",
     "minimist": "^1.2.8",
     "p-series": "^3.0.0",
-    "prettier": "^2.8.8",
+    "prettier": "^3.5.2",
     "semver": "^7.6.3",
     "typedoc": "^0.26.11",
     "typedoc-plugin-markdown": "^4.2.10",

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/__tests__/RouterLink.spec.ts
+++ b/packages/router/__tests__/RouterLink.spec.ts
@@ -47,7 +47,7 @@ function createLocations<
       normalized: RouteLocationResolved
       toResolve?: MatcherLocationRaw & Required<RouteQueryAndHash>
     }
-  >
+  >,
 >(locs: T) {
   return locs
 }

--- a/packages/router/__tests__/guards/guardsContext.spec.ts
+++ b/packages/router/__tests__/guards/guardsContext.spec.ts
@@ -12,12 +12,15 @@ const component = {
 describe('beforeRouteLeave', () => {
   it('invokes with the component context', async () => {
     expect.assertions(2)
-    const spy = vi
-      .fn()
-      .mockImplementationOnce(function (this: any, to, from, next) {
-        expect(typeof this.counter).toBe('number')
-        next()
-      })
+    const spy = vi.fn().mockImplementationOnce(function (
+      this: any,
+      to,
+      from,
+      next
+    ) {
+      expect(typeof this.counter).toBe('number')
+      next()
+    })
     const WithLeave = defineComponent({
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
@@ -54,23 +57,29 @@ describe('beforeRouteLeave', () => {
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
     const WithLeaveTwo = defineComponent({
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
 
     const router = createRouter({
@@ -108,23 +117,29 @@ describe('beforeRouteLeave', () => {
       template: `<router-view/>`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
     const WithLeave = defineComponent({
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
 
     const router = createRouter({
@@ -167,34 +182,43 @@ describe('beforeRouteLeave', () => {
       `,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
     const WithLeaveOne = defineComponent({
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
     const WithLeaveTwo = defineComponent({
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings
       data: () => ({ counter: 0 }),
-      beforeRouteLeave: vi
-        .fn()
-        .mockImplementationOnce(function (this: any, to, from, next) {
-          expect(typeof this.counter).toBe('number')
-          next()
-        }),
+      beforeRouteLeave: vi.fn().mockImplementationOnce(function (
+        this: any,
+        to,
+        from,
+        next
+      ) {
+        expect(typeof this.counter).toBe('number')
+        next()
+      }),
     })
 
     const router = createRouter({
@@ -235,12 +259,15 @@ describe('beforeRouteLeave', () => {
 describe('beforeRouteUpdate', () => {
   it('invokes with the component context', async () => {
     expect.assertions(2)
-    const spy = vi
-      .fn()
-      .mockImplementationOnce(function (this: any, to, from, next) {
-        expect(typeof this.counter).toBe('number')
-        next()
-      })
+    const spy = vi.fn().mockImplementationOnce(function (
+      this: any,
+      to,
+      from,
+      next
+    ) {
+      expect(typeof this.counter).toBe('number')
+      next()
+    })
     const WithParam = defineComponent({
       template: `text`,
       // we use data to check if the context is the right one because saving `this` in a variable logs a few warnings

--- a/packages/router/__tests__/lazyLoading.spec.ts
+++ b/packages/router/__tests__/lazyLoading.spec.ts
@@ -26,7 +26,7 @@ function createLazyComponent() {
   const [promise, resolve, reject] = fakePromise()
 
   return {
-    component: vi.fn(() => promise.then(() => ({} as RouteComponent))),
+    component: vi.fn(() => promise.then(() => ({}) as RouteComponent)),
     promise,
     resolve,
     reject,

--- a/packages/router/e2e/encoding/index.html
+++ b/packages/router/e2e/encoding/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/guards-instances/index.html
+++ b/packages/router/e2e/guards-instances/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/hash/index.html
+++ b/packages/router/e2e/hash/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/index.html
+++ b/packages/router/e2e/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/keep-alive/index.html
+++ b/packages/router/e2e/keep-alive/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/modal/index.html
+++ b/packages/router/e2e/modal/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/multi-app/index.html
+++ b/packages/router/e2e/multi-app/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/scroll-behavior/index.html
+++ b/packages/router/e2e/scroll-behavior/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/suspense/index.html
+++ b/packages/router/e2e/suspense/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/e2e/transitions/index.html
+++ b/packages/router/e2e/transitions/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -455,5 +455,5 @@ const getLinkClass = (
   propClass != null
     ? propClass
     : globalClass != null
-    ? globalClass
-    : defaultClass
+      ? globalClass
+      : defaultClass

--- a/packages/router/src/RouterView.ts
+++ b/packages/router/src/RouterView.ts
@@ -154,8 +154,8 @@ export const RouterViewImpl = /*#__PURE__*/ defineComponent({
         ? routePropsOption === true
           ? route.params
           : typeof routePropsOption === 'function'
-          ? routePropsOption(route)
-          : routePropsOption
+            ? routePropsOption(route)
+            : routePropsOption
         : null
 
       const onVnodeUnmounted: VNodeProps['onVnodeUnmounted'] = vnode => {

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -175,8 +175,8 @@ function isSameRouteLocationParamsValue(
   return isArray(a)
     ? isEquivalentArray(a, b)
     : isArray(b)
-    ? isEquivalentArray(b, a)
-    : a === b
+      ? isEquivalentArray(b, a)
+      : a === b
 }
 
 /**

--- a/packages/router/src/navigationGuards.ts
+++ b/packages/router/src/navigationGuards.ts
@@ -360,35 +360,40 @@ export function loadRouteLocation(
           record =>
             record.components &&
             Promise.all(
-              Object.keys(record.components).reduce((promises, name) => {
-                const rawComponent = record.components![name]
-                if (
-                  typeof rawComponent === 'function' &&
-                  !('displayName' in rawComponent)
-                ) {
-                  promises.push(
-                    (rawComponent as Lazy<RouteComponent>)().then(resolved => {
-                      if (!resolved)
-                        return Promise.reject(
-                          new Error(
-                            `Couldn't resolve component "${name}" at "${record.path}". Ensure you passed a function that returns a promise.`
-                          )
-                        )
+              Object.keys(record.components).reduce(
+                (promises, name) => {
+                  const rawComponent = record.components![name]
+                  if (
+                    typeof rawComponent === 'function' &&
+                    !('displayName' in rawComponent)
+                  ) {
+                    promises.push(
+                      (rawComponent as Lazy<RouteComponent>)().then(
+                        resolved => {
+                          if (!resolved)
+                            return Promise.reject(
+                              new Error(
+                                `Couldn't resolve component "${name}" at "${record.path}". Ensure you passed a function that returns a promise.`
+                              )
+                            )
 
-                      const resolvedComponent = isESModule(resolved)
-                        ? resolved.default
-                        : resolved
-                      // keep the resolved module for plugins like data loaders
-                      record.mods[name] = resolved
-                      // replace the function with the resolved component
-                      // cannot be null or undefined because we went into the for loop
-                      record.components![name] = resolvedComponent
-                      return
-                    })
-                  )
-                }
-                return promises
-              }, [] as Array<Promise<RouteComponent | null | undefined>>)
+                          const resolvedComponent = isESModule(resolved)
+                            ? resolved.default
+                            : resolved
+                          // keep the resolved module for plugins like data loaders
+                          record.mods[name] = resolved
+                          // replace the function with the resolved component
+                          // cannot be null or undefined because we went into the for loop
+                          record.components![name] = resolvedComponent
+                          return
+                        }
+                      )
+                    )
+                  }
+                  return promises
+                },
+                [] as Array<Promise<RouteComponent | null | undefined>>
+              )
             )
         )
       ).then(() => route as RouteLocationNormalizedLoaded)

--- a/packages/router/src/query.ts
+++ b/packages/router/src/query.ts
@@ -140,8 +140,8 @@ export function normalizeQuery(
       normalizedQuery[key] = isArray(value)
         ? value.map(v => (v == null ? null : '' + v))
         : value == null
-        ? value
-        : '' + value
+          ? value
+          : '' + value
     }
   }
 

--- a/packages/router/src/typed-routes/params.ts
+++ b/packages/router/src/typed-routes/params.ts
@@ -6,7 +6,7 @@ import type { RouteMap } from './route-map'
  */
 export type ParamValueOneOrMore<isRaw extends boolean> = [
   ParamValue<isRaw>,
-  ...ParamValue<isRaw>[]
+  ...ParamValue<isRaw>[],
 ]
 
 /**

--- a/packages/router/src/typed-routes/route-location.ts
+++ b/packages/router/src/typed-routes/route-location.ts
@@ -30,7 +30,7 @@ export interface RouteLocationGeneric extends _RouteLocationBase {
  */
 export interface RouteLocationTyped<
   RouteMap extends RouteMapGeneric,
-  Name extends keyof RouteMap
+  Name extends keyof RouteMap,
 > extends RouteLocationGeneric {
   // Extract is needed because keyof can produce numbers
   name: Extract<Name, string | symbol>
@@ -42,7 +42,7 @@ export interface RouteLocationTyped<
  * @internal
  */
 export type RouteLocationTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationTyped<RouteMap, N> }
 
 /**
@@ -62,7 +62,7 @@ export interface RouteLocationNormalizedGeneric extends _RouteLocationBase {
  */
 export interface RouteLocationNormalizedTyped<
   RouteMap extends RouteMapGeneric = RouteMapGeneric,
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > extends RouteLocationNormalizedGeneric {
   name: Extract<Name, string | symbol>
   // we don't override path because it could contain params and in practice it's just not useful
@@ -79,7 +79,7 @@ export interface RouteLocationNormalizedTyped<
  * @internal
  */
 export type RouteLocationNormalizedTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationNormalizedTyped<RouteMap, N> }
 
 /**
@@ -101,7 +101,7 @@ export interface RouteLocationNormalizedLoadedGeneric
  */
 export interface RouteLocationNormalizedLoadedTyped<
   RouteMap extends RouteMapGeneric = RouteMapGeneric,
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > extends RouteLocationNormalizedLoadedGeneric {
   name: Extract<Name, string | symbol>
   // we don't override path because it could contain params and in practice it's just not useful
@@ -113,7 +113,7 @@ export interface RouteLocationNormalizedLoadedTyped<
  * @internal
  */
 export type RouteLocationNormalizedLoadedTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationNormalizedLoadedTyped<RouteMap, N> }
 
 /**
@@ -135,7 +135,7 @@ export interface RouteLocationAsRelativeGeneric
  */
 export interface RouteLocationAsRelativeTyped<
   RouteMap extends RouteMapGeneric = RouteMapGeneric,
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > extends RouteLocationAsRelativeGeneric {
   name?: Extract<Name, string | symbol>
   params?: RouteMap[Name]['paramsRaw']
@@ -146,7 +146,7 @@ export interface RouteLocationAsRelativeTyped<
  * @internal
  */
 export type RouteLocationAsRelativeTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationAsRelativeTyped<RouteMap, N> }
 
 /**
@@ -166,7 +166,7 @@ export interface RouteLocationAsPathGeneric
  */
 export interface RouteLocationAsPathTyped<
   RouteMap extends RouteMapGeneric = RouteMapGeneric,
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > extends RouteLocationAsPathGeneric {
   path: _LiteralUnion<RouteMap[Name]['path']>
 
@@ -179,7 +179,7 @@ export interface RouteLocationAsPathTyped<
  * @internal
  */
 export type RouteLocationAsPathTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationAsPathTyped<RouteMap, N> }
 
 /**
@@ -187,7 +187,7 @@ export type RouteLocationAsPathTypedList<
  */
 export type RouteLocationAsStringTyped<
   RouteMap extends RouteMapGeneric = RouteMapGeneric,
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > = RouteMap[Name]['path']
 
 /**
@@ -195,7 +195,7 @@ export type RouteLocationAsStringTyped<
  * @internal
  */
 export type RouteLocationAsStringTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationAsStringTyped<RouteMap, N> }
 
 /**
@@ -213,7 +213,7 @@ export interface RouteLocationResolvedGeneric extends RouteLocationGeneric {
  */
 export interface RouteLocationResolvedTyped<
   RouteMap extends RouteMapGeneric,
-  Name extends keyof RouteMap
+  Name extends keyof RouteMap,
 > extends RouteLocationTyped<RouteMap, Name> {
   /**
    * Resolved `href` for the route location that will be set on the `<a href="...">`.
@@ -226,7 +226,7 @@ export interface RouteLocationResolvedTyped<
  * @internal
  */
 export type RouteLocationResolvedTypedList<
-  RouteMap extends RouteMapGeneric = RouteMapGeneric
+  RouteMap extends RouteMapGeneric = RouteMapGeneric,
 > = { [N in keyof RouteMap]: RouteLocationResolvedTyped<RouteMap, N> }
 
 /**
@@ -246,7 +246,7 @@ export type RouteLocation<Name extends keyof RouteMap = keyof RouteMap> =
  * {@link RouteLocationNormalizedTyped.matched | `matched` property} cannot contain redirect records
  */
 export type RouteLocationNormalized<
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > = RouteMapGeneric extends RouteMap
   ? RouteLocationNormalizedGeneric
   : RouteLocationNormalizedTypedList<RouteMap>[Name]
@@ -256,7 +256,7 @@ export type RouteLocationNormalized<
  * In other words, it's ready to be rendered by `<RouterView>`.
  */
 export type RouteLocationNormalizedLoaded<
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > = RouteMapGeneric extends RouteMap
   ? RouteLocationNormalizedLoadedGeneric
   : RouteLocationNormalizedLoadedTypedList<RouteMap>[Name]
@@ -266,7 +266,7 @@ export type RouteLocationNormalizedLoaded<
  * `hash` to conveniently change them.
  */
 export type RouteLocationAsRelative<
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > = RouteMapGeneric extends RouteMap
   ? RouteLocationAsRelativeGeneric
   : RouteLocationAsRelativeTypedList<RouteMap>[Name]
@@ -275,7 +275,7 @@ export type RouteLocationAsRelative<
  * Route location resolved with {@link Router | `router.resolve()`}.
  */
 export type RouteLocationResolved<
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > = RouteMapGeneric extends RouteMap
   ? RouteLocationResolvedGeneric
   : RouteLocationResolvedTypedList<RouteMap>[Name]
@@ -284,7 +284,7 @@ export type RouteLocationResolved<
  * Same as {@link RouteLocationAsPath} but as a string literal.
  */
 export type RouteLocationAsString<
-  Name extends keyof RouteMap = keyof RouteMap
+  Name extends keyof RouteMap = keyof RouteMap,
 > = RouteMapGeneric extends RouteMap
   ? string
   : _LiteralUnion<RouteLocationAsStringTypedList<RouteMap>[Name], string>

--- a/packages/router/src/typed-routes/route-map.ts
+++ b/packages/router/src/typed-routes/route-map.ts
@@ -17,7 +17,7 @@ export interface RouteRecordInfo<
   // TODO: could probably be inferred from the Params
   ParamsRaw extends RouteParamsRawGeneric = RouteParamsRawGeneric,
   Params extends RouteParamsGeneric = RouteParamsGeneric,
-  Meta extends RouteMeta = RouteMeta
+  Meta extends RouteMeta = RouteMeta,
 > {
   name: Name
   path: Path
@@ -30,12 +30,10 @@ export interface RouteRecordInfo<
 /**
  * Convenience type to get the typed RouteMap or a generic one if not provided. It is extracted from the {@link TypesConfig} if it exists, it becomes {@link RouteMapGeneric} otherwise.
  */
-export type RouteMap = TypesConfig extends Record<
-  'RouteNamedMap',
-  infer RouteNamedMap
->
-  ? RouteNamedMap
-  : RouteMapGeneric
+export type RouteMap =
+  TypesConfig extends Record<'RouteNamedMap', infer RouteNamedMap>
+    ? RouteNamedMap
+    : RouteMapGeneric
 
 /**
  * Generic version of the `RouteMap`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^2.1.5
-        version: 2.1.5(vitest@2.1.5)
+        version: 2.1.5(vitest@2.1.5(@types/node@22.9.3)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0)(terser@5.32.0))
       '@vitest/ui':
         specifier: ^2.1.5
         version: 2.1.5(vitest@2.1.5)
@@ -39,8 +39,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.5.2
+        version: 3.5.2
       semver:
         specifier: ^7.6.3
         version: 7.6.3
@@ -2862,9 +2862,9 @@ packages:
   preact@10.25.0:
     resolution: {integrity: sha512-6bYnzlLxXV3OSpUxLdaxBmE7PMOu0aR3pG6lryK/0jmvcDFPlcXGQAt5DpK3RITWiDrfYZRI0druyaK/S9kYLg==}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  prettier@3.5.2:
+    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-ms@9.1.0:
@@ -4410,7 +4410,7 @@ snapshots:
       vite: 5.4.11(@types/node@22.9.3)(terser@5.32.0)
       vue: 3.5.13(typescript@5.6.3)
 
-  '@vitest/coverage-v8@2.1.5(vitest@2.1.5)':
+  '@vitest/coverage-v8@2.1.5(vitest@2.1.5(@types/node@22.9.3)(@vitest/ui@2.1.5)(happy-dom@15.11.6)(jsdom@19.0.0)(terser@5.32.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -6606,7 +6606,7 @@ snapshots:
 
   preact@10.25.0: {}
 
-  prettier@2.8.8: {}
+  prettier@3.5.2: {}
 
   pretty-ms@9.1.0:
     dependencies:


### PR DESCRIPTION
Apart from `package.json` and `pnpm-lock.yaml`, all the changes come from running `lint:fix`.

Prettier 2 doesn't support using `with { type: 'json' }` for imports, which we're using in some `.mjs` files. Currently we aren't linting `.mjs` files, but that's something I'd eventually like to change. Upgrading Prettier is a first step towards that.