### PR TITLE
chore: lint more files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ __build__
 dist
 coverage
 tests_output
+packages/docs/.vitepress/cache

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "play": "pnpm run -r play",
     "build:size": "pnpm run -r build:size",
     "lint": "pnpm run lint:script && pnpm run lint:html",
-    "lint:script": "prettier -c --parser typescript \"packages/*/{src,__tests__,e2e}/**/*.[jt]s?(x)\"",
+    "lint:script": "prettier -c --parser typescript \"packages/**/*.?(m)[jt]s?(x)\" \"scripts/*.mjs\"",
     "lint:html": "prettier -c --parser html \"packages/**/*.html\"",
     "lint:fix": "pnpm run lint:script --write && pnpm run lint:html --write",
     "test": "pnpm run -r test",
@@ -54,11 +54,14 @@
     "commit-msg": "node scripts/verifyCommit.mjs"
   },
   "lint-staged": {
-    "*.js": [
+    "*.?(m)js": [
       "prettier --write"
     ],
-    "*.ts?(x)": [
+    "*.?(m)ts?(x)": [
       "prettier --parser=typescript --write"
+    ],
+    "*.html": [
+      "prettier --parser=html --write"
     ]
   },
   "pnpm": {

--- a/packages/docs/.vitepress/config/index.ts
+++ b/packages/docs/.vitepress/config/index.ts
@@ -10,7 +10,15 @@ export default defineConfig({
     root: { label: 'English', lang: 'en-US', link: '/', ...enConfig },
     zh: { label: '简体中文', lang: 'zh-CN', link: '/zh/', ...zhConfig },
     ko: { label: '한국어', lang: 'ko-KR', link: 'https://router.vuejs.kr/' },
-    pt: { label: 'Português', lang: 'pt-PT', link: 'https://vue-router-docs-pt.netlify.app/' },
-    ru: { label: 'Русский', lang: 'ru-RU', link: 'https://vue-router-ru.netlify.app' },
+    pt: {
+      label: 'Português',
+      lang: 'pt-PT',
+      link: 'https://vue-router-docs-pt.netlify.app/',
+    },
+    ru: {
+      label: 'Русский',
+      lang: 'ru-RU',
+      link: 'https://vue-router-ru.netlify.app',
+    },
   },
 })

--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -135,7 +135,8 @@ export const sharedConfig = defineConfig({
     ],
 
     footer: {
-      copyright: 'Copyright © 2014-present Evan You, Eduardo San Martin Morote',
+      copyright:
+        'Copyright © 2014-present Evan You, Eduardo San Martin Morote',
       message: 'Released under the MIT License.',
     },
 

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -21,7 +21,7 @@ const theme: Theme = {
       // 'home-features-after': () => h(HomeSponsors),
       'aside-ads-before': () => h(AsideSponsors),
       'doc-before': () => h(TranslationStatus, { status, i18nLabels }),
-      'layout-top': () => h(MadVueBanner)
+      'layout-top': () => h(MadVueBanner),
     })
   },
 


### PR DESCRIPTION
There are several files that aren't currently being formatted by Prettier. I've tried to expand that to include more files.

- Add `mjs` and `mts` extensions.
- Add `*.html` to `lint-staged`.
- Expand the paths in `lint:script` to cover more files in `packages`, as well as `scripts`.

Changing the paths in `lint:script` is probably the trickiest part. It's not entirely clear to me whether I've got those paths correct.

It's worth noting that `lint-staged` doesn't take those paths into account, it just formats anything with the appropriate extensions. However, it only formats *staged* files, so anything in `.gitignore` is implicitly ignored by `lint-staged`.

Prettier 3 does take the root `.gitignore` into account, but it doesn't consider nested `.gitignore` files, which are being used in this project. I needed to add the VitePress cache to `.prettierignore` to account for that. Perhaps other files should be added too, but it wasn't clear to me what some of the things in the nested `.gitignore` files were.

There are also 3 VitePress config files in this PR with minor formatting tweaks. These are files that are now picked up by `lint:script` that weren't previously. They should have already been picked up by `lint-staged`, but prior to #2466 that wasn't working for most people.