### PR TITLE
feat: make typed `useRoute(currentRouteName)` return children route types as well

### DIFF
--- a/packages/docs/guide/advanced/typed-routes.md
+++ b/packages/docs/guide/advanced/typed-routes.md
@@ -9,8 +9,8 @@ It's possible to configure the router to have a _map_ of typed routes. While thi
 Here is an example of how to manually configure typed routes:
 
 ```ts
-// import the `RouteRecordInfo` and `RouteMeta` type from vue-router to type your routes
-import type { RouteRecordInfo, RouteMeta } from 'vue-router'
+// import the `RouteRecordInfo` type from vue-router to type your routes
+import type { RouteRecordInfo } from 'vue-router'
 
 // Define an interface of routes
 export interface RouteNamedMap {
@@ -24,8 +24,6 @@ export interface RouteNamedMap {
     Record<never, never>,
     // these are the normalized params
     Record<never, never>,
-    // these are the `meta` fields
-    RouteMeta,
     // this is a union of all children route names
     never
   >
@@ -36,7 +34,6 @@ export interface RouteNamedMap {
     '/:name',
     { name: string | number }, // raw value
     { name: string }, // normalized value
-    RouteMeta,
     'named-param-edit'
   >
   'named-param-edit': RouteRecordInfo<
@@ -44,7 +41,6 @@ export interface RouteNamedMap {
     '/:name/edit',
     { name: string | number }, // raw value
     { name: string }, // normalized value
-    RouteMeta,
     never
   >
   'article-details': RouteRecordInfo<
@@ -52,7 +48,6 @@ export interface RouteNamedMap {
     '/articles/:id+',
     { id: Array<number | string> },
     { id: string[] },
-    RouteMeta,
     never
   >
   'not-found': RouteRecordInfo<
@@ -60,7 +55,6 @@ export interface RouteNamedMap {
     '/:path(.*)',
     { path: string },
     { path: string },
-    RouteMeta,
     never
   >
 }

--- a/packages/docs/guide/advanced/typed-routes.md
+++ b/packages/docs/guide/advanced/typed-routes.md
@@ -9,8 +9,8 @@ It's possible to configure the router to have a _map_ of typed routes. While thi
 Here is an example of how to manually configure typed routes:
 
 ```ts
-// import the `RouteRecordInfo` type from vue-router to type your routes
-import type { RouteRecordInfo } from 'vue-router'
+// import the `RouteRecordInfo` and `RouteMeta` type from vue-router to type your routes
+import type { RouteRecordInfo, RouteMeta } from 'vue-router'
 
 // Define an interface of routes
 export interface RouteNamedMap {
@@ -23,7 +23,11 @@ export interface RouteNamedMap {
     // these are the raw params. In this case, there are no params allowed
     Record<never, never>,
     // these are the normalized params
-    Record<never, never>
+    Record<never, never>,
+    // these are the `meta` fields
+    RouteMeta,
+    // this is a union of all children route names
+    never
   >
   // repeat for each route..
   // Note you can name them whatever you want
@@ -31,19 +35,33 @@ export interface RouteNamedMap {
     'named-param',
     '/:name',
     { name: string | number }, // raw value
-    { name: string } // normalized value
+    { name: string }, // normalized value
+    RouteMeta,
+    'named-param-edit'
+  >
+  'named-param-edit': RouteRecordInfo<
+    'named-param-edit',
+    '/:name/edit',
+    { name: string | number }, // raw value
+    { name: string }, // normalized value
+    RouteMeta,
+    never
   >
   'article-details': RouteRecordInfo<
     'article-details',
     '/articles/:id+',
     { id: Array<number | string> },
-    { id: string[] }
+    { id: string[] },
+    RouteMeta,
+    never
   >
   'not-found': RouteRecordInfo<
     'not-found',
     '/:path(.*)',
     { path: string },
-    { path: string }
+    { path: string },
+    RouteMeta,
+    never
   >
 }
 

--- a/packages/docs/guide/advanced/typed-routes.md
+++ b/packages/docs/guide/advanced/typed-routes.md
@@ -20,27 +20,28 @@ export interface RouteNamedMap {
     'home',
     // this is the path, it will appear in autocompletion
     '/',
-    // these are the raw params. In this case, there are no params allowed
+    // these are the raw params (what can be passed to router.push() and RouterLink's "to" prop)
+    // In this case, there are no params allowed
     Record<never, never>,
-    // these are the normalized params
+    // these are the normalized params (what you get from useRoute())
     Record<never, never>,
-    // this is a union of all children route names
+    // this is a union of all children route names, in this case, there are none
     never
   >
-  // repeat for each route..
+  // repeat for each route...
   // Note you can name them whatever you want
   'named-param': RouteRecordInfo<
     'named-param',
     '/:name',
-    { name: string | number }, // raw value
-    { name: string }, // normalized value
+    { name: string | number }, // Allows string or number
+    { name: string }, // but always returns a string from the URL
     'named-param-edit'
   >
   'named-param-edit': RouteRecordInfo<
     'named-param-edit',
     '/:name/edit',
-    { name: string | number }, // raw value
-    { name: string }, // normalized value
+    { name: string | number }, // we also include parent params
+    { name: string },
     never
   >
   'article-details': RouteRecordInfo<

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -4,7 +4,12 @@ import type { ComponentPublicInstance } from 'vue'
 import { router, routerHistory } from './router'
 import { globalState } from './store'
 import App from './App.vue'
-import { useRoute, type ParamValue, type RouteRecordInfo } from 'vue-router'
+import {
+  useRoute,
+  type ParamValue,
+  type RouteRecordInfo,
+  type RouteMeta,
+} from 'vue-router'
 
 declare global {
   interface Window {
@@ -32,18 +37,37 @@ app.use(router)
 window.vm = app.mount('#app')
 
 export interface RouteNamedMap {
-  home: RouteRecordInfo<'home', '/', Record<never, never>, Record<never, never>>
+  home: RouteRecordInfo<
+    'home',
+    '/',
+    Record<never, never>,
+    Record<never, never>,
+    RouteMeta,
+    never
+  >
   '/[name]': RouteRecordInfo<
     '/[name]',
     '/:name',
     { name: ParamValue<true> },
-    { name: ParamValue<false> }
+    { name: ParamValue<false> },
+    RouteMeta,
+    '/[name]/edit'
+  >
+  '/[name]/edit': RouteRecordInfo<
+    '/[name]/edit',
+    '/:name/edit',
+    { name: ParamValue<true> },
+    { name: ParamValue<false> },
+    RouteMeta,
+    never
   >
   '/[...path]': RouteRecordInfo<
     '/[...path]',
     '/:path(.*)',
     { path: ParamValue<true> },
-    { path: ParamValue<false> }
+    { path: ParamValue<false> },
+    RouteMeta,
+    never
   >
 }
 

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -4,12 +4,7 @@ import type { ComponentPublicInstance } from 'vue'
 import { router, routerHistory } from './router'
 import { globalState } from './store'
 import App from './App.vue'
-import {
-  useRoute,
-  type ParamValue,
-  type RouteRecordInfo,
-  type RouteMeta,
-} from 'vue-router'
+import { useRoute, type ParamValue, type RouteRecordInfo } from 'vue-router'
 
 declare global {
   interface Window {
@@ -42,7 +37,6 @@ export interface RouteNamedMap {
     '/',
     Record<never, never>,
     Record<never, never>,
-    RouteMeta,
     never
   >
   '/[name]': RouteRecordInfo<
@@ -50,7 +44,6 @@ export interface RouteNamedMap {
     '/:name',
     { name: ParamValue<true> },
     { name: ParamValue<false> },
-    RouteMeta,
     '/[name]/edit'
   >
   '/[name]/edit': RouteRecordInfo<
@@ -58,7 +51,6 @@ export interface RouteNamedMap {
     '/:name/edit',
     { name: ParamValue<true> },
     { name: ParamValue<false> },
-    RouteMeta,
     never
   >
   '/[...path]': RouteRecordInfo<
@@ -66,7 +58,6 @@ export interface RouteNamedMap {
     '/:path(.*)',
     { path: ParamValue<true> },
     { path: ParamValue<false> },
-    RouteMeta,
     never
   >
 }

--- a/packages/router/__tests__/routeLocation.test-d.ts
+++ b/packages/router/__tests__/routeLocation.test-d.ts
@@ -8,7 +8,7 @@ import type {
   RouteLocationNormalizedTypedList,
 } from '../src'
 
-// TODO: could we move this to an .d.ts file that is only loaded for tests?
+// NOTE: A type allows us to make it work only in this test file
 // https://github.com/microsoft/TypeScript/issues/15300
 type RouteNamedMap = {
   home: RouteRecordInfo<'/', '/', Record<never, never>, Record<never, never>>
@@ -73,7 +73,13 @@ describe('Route Location types', () => {
       name: Name,
       fn: (to: RouteLocationNormalizedTypedList<RouteNamedMap>[Name]) => void
     ): void
-    function withRoute<Name extends RouteRecordName>(...args: unknown[]) {}
+    function withRoute<_Name extends RouteRecordName>(..._args: unknown[]) {}
+
+    withRoute('/[other]', to => {
+      expectTypeOf(to.params).toEqualTypeOf<{ other: string }>()
+      expectTypeOf(to.params).not.toEqualTypeOf<{ gid: string }>()
+      expectTypeOf(to.params).not.toEqualTypeOf<{ notExisting: string }>()
+    })
 
     withRoute('/groups/[gid]', to => {
       expectTypeOf(to.params).toEqualTypeOf<{ gid: string }>()

--- a/packages/router/__tests__/routeLocation.test-d.ts
+++ b/packages/router/__tests__/routeLocation.test-d.ts
@@ -26,7 +26,7 @@ type RouteNamedMap = {
     { gid: ParamValue<true> },
     { gid: ParamValue<false> },
     RouteMeta,
-    '/groups/[gid]/users'
+    '/groups/[gid]/users' | '/groups/[gid]/users/[uid]'
   >
   '/groups/[gid]/users': RouteRecordInfo<
     '/groups/[gid]/users',

--- a/packages/router/__tests__/routeLocation.test-d.ts
+++ b/packages/router/__tests__/routeLocation.test-d.ts
@@ -4,7 +4,6 @@ import type {
   ParamValue,
   ParamValueZeroOrMore,
   RouteRecordInfo,
-  RouteMeta,
   RouteLocationNormalizedTypedList,
 } from '../src'
 
@@ -17,7 +16,6 @@ type RouteNamedMap = {
     '/:other',
     { other: ParamValue<true> },
     { other: ParamValue<false> },
-    RouteMeta,
     never
   >
   '/groups/[gid]': RouteRecordInfo<
@@ -25,7 +23,6 @@ type RouteNamedMap = {
     '/:gid',
     { gid: ParamValue<true> },
     { gid: ParamValue<false> },
-    RouteMeta,
     '/groups/[gid]/users' | '/groups/[gid]/users/[uid]'
   >
   '/groups/[gid]/users': RouteRecordInfo<
@@ -33,7 +30,6 @@ type RouteNamedMap = {
     '/:gid/users',
     { gid: ParamValue<true> },
     { gid: ParamValue<false> },
-    RouteMeta,
     '/groups/[gid]/users/[uid]'
   >
   '/groups/[gid]/users/[uid]': RouteRecordInfo<
@@ -41,7 +37,6 @@ type RouteNamedMap = {
     '/:gid/users/:uid',
     { gid: ParamValue<true>; uid: ParamValue<true> },
     { gid: ParamValue<false>; uid: ParamValue<false> },
-    RouteMeta,
     never
   >
   '/[...path]': RouteRecordInfo<
@@ -49,7 +44,6 @@ type RouteNamedMap = {
     '/:path(.*)',
     { path: ParamValue<true> },
     { path: ParamValue<false> },
-    RouteMeta,
     never
   >
   '/deep/nesting/works/[[files]]+': RouteRecordInfo<
@@ -57,7 +51,6 @@ type RouteNamedMap = {
     '/deep/nesting/works/:files*',
     { files?: ParamValueZeroOrMore<true> },
     { files?: ParamValueZeroOrMore<false> },
-    RouteMeta,
     never
   >
 }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -113,6 +113,7 @@ export type {
   RouteLocationAsPathTypedList,
 
   // route records
+  RouteRecordInfoGeneric,
   RouteRecordInfo,
   RouteRecordNameGeneric,
   RouteRecordName,

--- a/packages/router/src/typed-routes/route-map.ts
+++ b/packages/router/src/typed-routes/route-map.ts
@@ -18,7 +18,7 @@ export interface RouteRecordInfo<
   ParamsRaw extends RouteParamsRawGeneric = RouteParamsRawGeneric,
   Params extends RouteParamsGeneric = RouteParamsGeneric,
   Meta extends RouteMeta = RouteMeta,
-  _ChildrenRouteNames extends string | symbol = never,
+  ChildrenNames extends string | symbol | never = never | string | symbol,
 > {
   name: Name
   path: Path
@@ -26,6 +26,7 @@ export interface RouteRecordInfo<
   params: Params
   // TODO: implement meta with a defineRoute macro
   meta: Meta
+  childrenNames: ChildrenNames
 }
 
 /**
@@ -40,28 +41,3 @@ export type RouteMap =
  * Generic version of the `RouteMap`.
  */
 export type RouteMapGeneric = Record<string | symbol, RouteRecordInfo>
-
-/**
- * Returns a union of route names from children of the route with given route name
- */
-export type GetDeepChildrenRouteNames<Name extends keyof RouteMap> =
-  RouteMap[Name] extends RouteRecordInfo<
-    any,
-    any,
-    any,
-    any,
-    any,
-    infer ChildrenNames
-  >
-    ? ChildrenNames extends any
-      ? ChildrenNames | GetDeepChildrenRouteNames<ChildrenNames>
-      : never
-    : never
-
-/**
- * Returns a union of given route name and the route names of children of that route
- */
-export type RouteNameWithChildren<Name extends keyof RouteMap> =
-  RouteMapGeneric extends RouteMap
-    ? Name
-    : Name | GetDeepChildrenRouteNames<Name>

--- a/packages/router/src/typed-routes/route-map.ts
+++ b/packages/router/src/typed-routes/route-map.ts
@@ -18,7 +18,7 @@ export interface RouteRecordInfo<
   ParamsRaw extends RouteParamsRawGeneric = RouteParamsRawGeneric,
   Params extends RouteParamsGeneric = RouteParamsGeneric,
   Meta extends RouteMeta = RouteMeta,
-  ChildrenNames extends string | symbol | never = never | string | symbol,
+  ChildrenNames extends string | symbol = never,
 > {
   name: Name
   path: Path
@@ -28,6 +28,15 @@ export interface RouteRecordInfo<
   meta: Meta
   childrenNames: ChildrenNames
 }
+
+export type RouteRecordInfoGeneric = RouteRecordInfo<
+  string | symbol,
+  string,
+  RouteParamsRawGeneric,
+  RouteParamsGeneric,
+  RouteMeta,
+  string | symbol
+>
 
 /**
  * Convenience type to get the typed RouteMap or a generic one if not provided. It is extracted from the {@link TypesConfig} if it exists, it becomes {@link RouteMapGeneric} otherwise.
@@ -40,4 +49,4 @@ export type RouteMap =
 /**
  * Generic version of the `RouteMap`.
  */
-export type RouteMapGeneric = Record<string | symbol, RouteRecordInfo>
+export type RouteMapGeneric = Record<string | symbol, RouteRecordInfoGeneric>

--- a/packages/router/src/typed-routes/route-map.ts
+++ b/packages/router/src/typed-routes/route-map.ts
@@ -18,6 +18,7 @@ export interface RouteRecordInfo<
   ParamsRaw extends RouteParamsRawGeneric = RouteParamsRawGeneric,
   Params extends RouteParamsGeneric = RouteParamsGeneric,
   Meta extends RouteMeta = RouteMeta,
+  _ChildrenRouteNames extends string | symbol = never,
 > {
   name: Name
   path: Path
@@ -39,3 +40,19 @@ export type RouteMap =
  * Generic version of the `RouteMap`.
  */
 export type RouteMapGeneric = Record<string | symbol, RouteRecordInfo>
+
+/**
+ * Returns a union of route names from children of the route with given route name
+ */
+export type GetDeepChildrenRouteNames<T extends keyof RouteMap> =
+  RouteMap[T] extends RouteRecordInfo<any, any, any, any, any, infer N>
+    ? N extends any
+      ? N | GetDeepChildrenRouteNames<N>
+      : never
+    : never
+
+/**
+ * Returns a union of given route name and the route names of children of that route
+ */
+export type RouteNameWithChildren<T extends keyof RouteMap> =
+  RouteMapGeneric extends RouteMap ? T : T | GetDeepChildrenRouteNames<T>

--- a/packages/router/src/typed-routes/route-map.ts
+++ b/packages/router/src/typed-routes/route-map.ts
@@ -44,15 +44,24 @@ export type RouteMapGeneric = Record<string | symbol, RouteRecordInfo>
 /**
  * Returns a union of route names from children of the route with given route name
  */
-export type GetDeepChildrenRouteNames<T extends keyof RouteMap> =
-  RouteMap[T] extends RouteRecordInfo<any, any, any, any, any, infer N>
-    ? N extends any
-      ? N | GetDeepChildrenRouteNames<N>
+export type GetDeepChildrenRouteNames<Name extends keyof RouteMap> =
+  RouteMap[Name] extends RouteRecordInfo<
+    any,
+    any,
+    any,
+    any,
+    any,
+    infer ChildrenNames
+  >
+    ? ChildrenNames extends any
+      ? ChildrenNames | GetDeepChildrenRouteNames<ChildrenNames>
       : never
     : never
 
 /**
  * Returns a union of given route name and the route names of children of that route
  */
-export type RouteNameWithChildren<T extends keyof RouteMap> =
-  RouteMapGeneric extends RouteMap ? T : T | GetDeepChildrenRouteNames<T>
+export type RouteNameWithChildren<Name extends keyof RouteMap> =
+  RouteMapGeneric extends RouteMap
+    ? Name
+    : Name | GetDeepChildrenRouteNames<Name>

--- a/packages/router/src/typed-routes/route-map.ts
+++ b/packages/router/src/typed-routes/route-map.ts
@@ -1,9 +1,5 @@
 import type { TypesConfig } from '../config'
-import type {
-  RouteMeta,
-  RouteParamsGeneric,
-  RouteParamsRawGeneric,
-} from '../types'
+import type { RouteParamsGeneric, RouteParamsRawGeneric } from '../types'
 import type { RouteRecord } from '../matcher/types'
 
 /**
@@ -17,16 +13,20 @@ export interface RouteRecordInfo<
   // TODO: could probably be inferred from the Params
   ParamsRaw extends RouteParamsRawGeneric = RouteParamsRawGeneric,
   Params extends RouteParamsGeneric = RouteParamsGeneric,
-  Meta extends RouteMeta = RouteMeta,
+  // NOTE: this is the only type param that feels wrong because its default
+  // value is the default value to avoid breaking changes but it should be the
+  // generic version by default instead (string | symbol)
   ChildrenNames extends string | symbol = never,
+  // TODO: implement meta with a defineRoute macro
+  // Meta extends RouteMeta = RouteMeta,
 > {
   name: Name
   path: Path
   paramsRaw: ParamsRaw
   params: Params
-  // TODO: implement meta with a defineRoute macro
-  meta: Meta
   childrenNames: ChildrenNames
+  // TODO: implement meta with a defineRoute macro
+  // meta: Meta
 }
 
 export type RouteRecordInfoGeneric = RouteRecordInfo<
@@ -34,7 +34,6 @@ export type RouteRecordInfoGeneric = RouteRecordInfo<
   string,
   RouteParamsRawGeneric,
   RouteParamsGeneric,
-  RouteMeta,
   string | symbol
 >
 

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -257,7 +257,7 @@ export interface _RouteRecordBase extends PathParserOptions {
  * }
  * ```
  */
-export interface RouteMeta extends Record<string | number | symbol, unknown> {}
+export interface RouteMeta extends Record<PropertyKey, unknown> {}
 
 /**
  * Route Record defining one single component with the `component` option.

--- a/packages/router/src/useApi.ts
+++ b/packages/router/src/useApi.ts
@@ -1,7 +1,7 @@
 import { inject } from 'vue'
 import { routerKey, routeLocationKey } from './injectionSymbols'
 import { Router } from './router'
-import { RouteMap } from './typed-routes/route-map'
+import { RouteMap, RouteNameWithChildren } from './typed-routes/route-map'
 import { RouteLocationNormalizedLoaded } from './typed-routes'
 
 /**
@@ -12,12 +12,17 @@ export function useRouter(): Router {
   return inject(routerKey)!
 }
 
+type GetRouteLocationNormalizedLoaded<Name extends keyof RouteMap> =
+  Name extends any ? RouteLocationNormalizedLoaded<Name> : never
+
 /**
  * Returns the current route location. Equivalent to using `$route` inside
  * templates.
  */
-export function useRoute<Name extends keyof RouteMap = keyof RouteMap>(
-  _name?: Name
-): RouteLocationNormalizedLoaded<Name> {
-  return inject(routeLocationKey)!
+export function useRoute<
+  CurrentRouteName extends keyof RouteMap = keyof RouteMap,
+>(_currentRouteName?: CurrentRouteName) {
+  return inject(routeLocationKey) as GetRouteLocationNormalizedLoaded<
+    RouteNameWithChildren<CurrentRouteName>
+  >
 }

--- a/packages/router/src/useApi.ts
+++ b/packages/router/src/useApi.ts
@@ -1,7 +1,7 @@
 import { inject } from 'vue'
 import { routerKey, routeLocationKey } from './injectionSymbols'
 import { Router } from './router'
-import { RouteMap, RouteNameWithChildren } from './typed-routes/route-map'
+import { RouteMap } from './typed-routes/route-map'
 import { RouteLocationNormalizedLoaded } from './typed-routes'
 
 /**
@@ -12,17 +12,14 @@ export function useRouter(): Router {
   return inject(routerKey)!
 }
 
-type GetRouteLocationNormalizedLoaded<Name extends keyof RouteMap> =
-  Name extends any ? RouteLocationNormalizedLoaded<Name> : never
-
 /**
  * Returns the current route location. Equivalent to using `$route` inside
  * templates.
  */
-export function useRoute<
-  CurrentRouteName extends keyof RouteMap = keyof RouteMap,
->(_currentRouteName?: CurrentRouteName) {
-  return inject(routeLocationKey) as GetRouteLocationNormalizedLoaded<
-    RouteNameWithChildren<CurrentRouteName>
+export function useRoute<Name extends keyof RouteMap = keyof RouteMap>(
+  _name?: Name
+) {
+  return inject(routeLocationKey) as RouteLocationNormalizedLoaded<
+    Name | RouteMap[Name]['childrenNames']
   >
 }

--- a/packages/router/test-dts/typed-routes.test-d.ts
+++ b/packages/router/test-dts/typed-routes.test-d.ts
@@ -8,7 +8,7 @@ import {
   createRouter,
   createWebHistory,
   useRoute,
-  RouteLocationNormalizedLoadedTyped,
+  RouteLocationNormalizedLoadedTypedList,
 } from './index'
 
 // type is needed instead of an interface
@@ -63,6 +63,15 @@ export type RouteMap = {
     never
   >
 }
+
+// the type allows for type params to distribute types:
+// RouteLocationNormalizedLoadedLoaded<'/[a]' | '/'> will become RouteLocationNormalizedLoadedTyped<RouteMap>['/[a]'] | RouteLocationTypedList<RouteMap>['/']
+// it's closer to what the end users uses but with the RouteMap type fixed so it doesn't
+// pollute globals
+type RouteLocationNormalizedLoaded<
+  Name extends keyof RouteMap = keyof RouteMap,
+> = RouteLocationNormalizedLoadedTypedList<RouteMap>[Name]
+// type Test = RouteLocationNormalizedLoaded<'/a' | '/a/b' | '/a/b/c'>
 
 declare module './index' {
   interface TypesConfig {
@@ -170,9 +179,17 @@ describe('RouterTyped', () => {
   })
 
   it('useRoute', () => {
-    expectTypeOf(useRoute('/[a]')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/[a]'>>();
-    expectTypeOf(useRoute('/a')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/a'> | RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b'> | RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b/c'>>();
-    expectTypeOf(useRoute('/a/b')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b'> | RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b/c'>>();
-    expectTypeOf(useRoute('/a/b/c')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b/c'>>();
+    expectTypeOf(useRoute('/[a]')).toEqualTypeOf<
+      RouteLocationNormalizedLoaded<'/[a]'>
+    >()
+    expectTypeOf(useRoute('/a')).toEqualTypeOf<
+      RouteLocationNormalizedLoaded<'/a' | '/a/b' | '/a/b/c'>
+    >()
+    expectTypeOf(useRoute('/a/b')).toEqualTypeOf<
+      RouteLocationNormalizedLoaded<'/a/b' | '/a/b/c'>
+    >()
+    expectTypeOf(useRoute('/a/b/c')).toEqualTypeOf<
+      RouteLocationNormalizedLoaded<'/a/b/c'>
+    >()
   })
 })

--- a/packages/router/test-dts/typed-routes.test-d.ts
+++ b/packages/router/test-dts/typed-routes.test-d.ts
@@ -36,7 +36,7 @@ export type RouteMap = {
     Record<never, never>,
     Record<never, never>,
     RouteMeta,
-    '/a/b'
+    '/a/b' | '/a/b/c'
   >
   '/a/b': RouteRecordInfo<
     '/a/b',

--- a/packages/router/test-dts/typed-routes.test-d.ts
+++ b/packages/router/test-dts/typed-routes.test-d.ts
@@ -4,7 +4,6 @@ import {
   type ParamValue,
   type ParamValueOneOrMore,
   type RouteLocationTyped,
-  type RouteMeta,
   createRouter,
   createWebHistory,
   useRoute,
@@ -19,7 +18,6 @@ export type RouteMap = {
     '/:path(.*)',
     { path: ParamValue<true> },
     { path: ParamValue<false> },
-    RouteMeta,
     never
   >
   '/[a]': RouteRecordInfo<
@@ -27,7 +25,6 @@ export type RouteMap = {
     '/:a',
     { a: ParamValue<true> },
     { a: ParamValue<false> },
-    RouteMeta,
     never
   >
   '/a': RouteRecordInfo<
@@ -35,7 +32,6 @@ export type RouteMap = {
     '/a',
     Record<never, never>,
     Record<never, never>,
-    RouteMeta,
     '/a/b' | '/a/b/c'
   >
   '/a/b': RouteRecordInfo<
@@ -43,7 +39,6 @@ export type RouteMap = {
     '/a/b',
     Record<never, never>,
     Record<never, never>,
-    RouteMeta,
     '/a/b/c'
   >
   '/a/b/c': RouteRecordInfo<
@@ -51,7 +46,6 @@ export type RouteMap = {
     '/a/b/c',
     Record<never, never>,
     Record<never, never>,
-    RouteMeta,
     never
   >
   '/[id]+': RouteRecordInfo<
@@ -59,7 +53,6 @@ export type RouteMap = {
     '/:id+',
     { id: ParamValueOneOrMore<true> },
     { id: ParamValueOneOrMore<false> },
-    RouteMeta,
     never
   >
 }

--- a/packages/router/test-dts/typed-routes.test-d.ts
+++ b/packages/router/test-dts/typed-routes.test-d.ts
@@ -4,8 +4,11 @@ import {
   type ParamValue,
   type ParamValueOneOrMore,
   type RouteLocationTyped,
+  type RouteMeta,
   createRouter,
   createWebHistory,
+  useRoute,
+  RouteLocationNormalizedLoadedTyped,
 } from './index'
 
 // type is needed instead of an interface
@@ -15,20 +18,49 @@ export type RouteMap = {
     '/[...path]',
     '/:path(.*)',
     { path: ParamValue<true> },
-    { path: ParamValue<false> }
+    { path: ParamValue<false> },
+    RouteMeta,
+    never
   >
   '/[a]': RouteRecordInfo<
     '/[a]',
     '/:a',
     { a: ParamValue<true> },
-    { a: ParamValue<false> }
+    { a: ParamValue<false> },
+    RouteMeta,
+    never
   >
-  '/a': RouteRecordInfo<'/a', '/a', Record<never, never>, Record<never, never>>
+  '/a': RouteRecordInfo<
+    '/a',
+    '/a',
+    Record<never, never>,
+    Record<never, never>,
+    RouteMeta,
+    '/a/b'
+  >
+  '/a/b': RouteRecordInfo<
+    '/a/b',
+    '/a/b',
+    Record<never, never>,
+    Record<never, never>,
+    RouteMeta,
+    '/a/b/c'
+  >
+  '/a/b/c': RouteRecordInfo<
+    '/a/b/c',
+    '/a/b/c',
+    Record<never, never>,
+    Record<never, never>,
+    RouteMeta,
+    never
+  >
   '/[id]+': RouteRecordInfo<
     '/[id]+',
     '/:id+',
     { id: ParamValueOneOrMore<true> },
-    { id: ParamValueOneOrMore<false> }
+    { id: ParamValueOneOrMore<false> },
+    RouteMeta,
+    never
   >
 }
 
@@ -135,5 +167,12 @@ describe('RouterTyped', () => {
       }
       return true
     })
+  })
+
+  it('useRoute', () => {
+    expectTypeOf(useRoute('/[a]')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/[a]'>>();
+    expectTypeOf(useRoute('/a')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/a'> | RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b'> | RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b/c'>>();
+    expectTypeOf(useRoute('/a/b')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b'> | RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b/c'>>();
+    expectTypeOf(useRoute('/a/b/c')).toEqualTypeOf<RouteLocationNormalizedLoadedTyped<RouteMap, '/a/b/c'>>();
   })
 })


### PR DESCRIPTION
In an app (with a typed router) where route `/a/b` is a child of route `/a`, this makes `useRoute('/a')` return `RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/a"> | RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/a/b">`.

It works in a recursive manner, so whenever route `/a/b/c` is added as a child of `/a/b`,  `useRoute('/a')` will return `RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/a"> | RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/a/b">` | RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/a/b/c">`.

Of course `useRoute('/a/b/c')` will *only* return `RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/a/b/c">`.

> [!NOTE] 
> This PR is intended to be paired with the following `unplugin-vue-router` PR: https://github.com/posva/unplugin-vue-router/pull/602
> That PR changes the DTS generation to include `RouteMeta` and a union of the children route's names as generics to every `RouteRecordInfo` type.
