### PR TITLE
docs: fix relative redirect example

### DIFF
--- a/packages/docs/guide/essentials/redirect-and-alias.md
+++ b/packages/docs/guide/essentials/redirect-and-alias.md
@@ -54,9 +54,7 @@ const routes = [
     path: '/users/:id/posts',
     redirect: to => {
       // the function receives the target route as the argument
-      // a relative location doesn't start with `/`
-      // or { path: 'profile'}
-      return 'profile'
+      return to.path.replace(/posts$/, 'profile')
     },
   },
 ]

--- a/packages/docs/zh/guide/essentials/redirect-and-alias.md
+++ b/packages/docs/zh/guide/essentials/redirect-and-alias.md
@@ -54,9 +54,7 @@ const routes = [
     path: '/users/:id/posts',
     redirect: to => {
       // 该函数接收目标路由作为参数
-      // 相对位置不以`/`开头
-      // 或 { path: 'profile'}
-      return 'profile'
+      return to.path.replace(/posts$/, 'profile')
     },
   },
 ]


### PR DESCRIPTION
The current example in the `Relative redirecting` section of the docs seems misleading:

```js
const routes = [
  {
    // will always redirect /users/123/posts to /users/123/profile
    path: '/users/:id/posts',
    redirect: to => {
      // the function receives the target route as the argument
      // a relative location doesn't start with `/`
      // or { path: 'profile'}
      return 'profile'
    },
  },
]
```

Returning the value `'profile'` won't necessarily yield a path of `/users/123/profile`. A relative path is resolved relative the current active route, not the `to` route.

When this was first pointed out to me I thought it was a bug, but based on #1902 it seems it's considered correct. The reproduction provided in #1902 is almost identical to the example in the docs - I'm not sure whether **posva** was aware of that when he closed that issue.

Perhaps this is something that should be changed in the next major version? I'm not sure how the current behaviour would be useful in practice, having the redirect resolve relative to the `to` route seems much more useful.

This example in the docs comes from #1090, which updated an earlier example. From reading through that PR I'm not entirely clear what the original intent was.

I think we have 3 options here to fix the docs (short of a major rewrite):
1. We could delete the `Relative redirecting` section. Using a function for `redirect` is already covered further up, so we wouldn't be losing much.
2. Tweak the existing example so that it actually works as described. It would no longer be using a 'relative redirect' in the strictest sense, but it would show how to achieve the desired outcome.
3. Come up with a better example and an actual explanation of the current behaviour for `redirect`. I'm reluctant to go with this option because (as I noted above) this feels like an undesirable feature to me and it's easier to change it if it isn't explicitly documented.

This PR implements option 2, but I'm happy to switch to one of the other options if they seem preferable.

For testing purposes, I've put together a playground based on this example:

- [Playground](https://play.vuejs.org/#eNp9VFtP2zAU/itehpSitXEpjIcsVGwIjU27IDbtZdlDmritIbEt26FFVf/7ji+5lBZUVUnO5TvfOd+xN0GVURbdqyAOaCW41GiDckkyTT4KgbZoLnmFwseahCnzAZLXmkjvibD77Nwmr/FlQkQuN2Ut6gD+xylDKKoVGbh0913xmulB+BbSwuNgGPh04JZoUokS8qcmMFmeTG9IWXJT7E2C4dOahX3Ai9KSs8X0qpaSMM8YiUwv4wR7H9ps0JF1RPO6LG/BibZbC4MdTsKyxwbwzrL8RtkD0vwiDXAaTD9zeEc3vCIJ7vwvZkCzUuGTySkWXGnVAjx37IEluCGSGLF2C/yhZIWwj/PuBLfTgiG6AR+U+DupuHy6oUrDY+iNDrcv/aiVuBXZdG1LN0o3Bi93swszyNyJay3dXnCmvEQKXaC/ppWNEwuFOARaHMAY6Bh3ZbdDG+ZGgTFa0bJEWbnKnhSSpKCS5Hpvss+nLfmclsRhNPWcO6aFSwltHdRixgbjApbHmY1D15KBNTIIkSQw95wMXPYRHqLQlwntiju6Pql1OY9dvp3GDpDyGZ5WbzTtYC1Kyv49m62E2fYFHtgaS6d9fGghBse2ilMGXrfQQcrI2ipbkHlWlw02rFl/AQ4c2Mm0CYDjOtlb0p21OJjeRhzMd/s2qjIBi84ZINj2Uu+A0xY3Q02DbqWNOQ2WWgsVY1wz8bCIYKa4i7g8i95HY1zASHrWiKhqNJN8BcJAwTTweqTBJQThgjxqzks1ygR9qcRe4OV5dB6d4JLOMKBjygqytthe0C20qRUoOqeLZ02aNYCtkD+FpqD4TrMZXJOrr9amZU1aovmS5A8H7Pdq7SjfSgLdPZJeczqTC6Kd+/rXD7KG99ZZ8aKG0/Sa844oXtaGowv7VLMCaPfiLNsvVjPKFr/V9VoTppqmDNHukFghr15pvaN7Gp31pqj0U0lUlCtzJcLdOkTm4nR5My4LImM0EWsEZGmB3o7H4w/GVQEcZaMZ15pXMToZi7W1i6wogGxrgSopA1g0RRl6B38L7LNLMofD2o9cTvqVO/iOQJ7nPQIxGsNv4hGC7X/WgZmI)