### PR TITLE
ci: avoid CI failures for forks

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'vuejs/router'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: 'BrowserStack Env Setup'
         uses: 'browserstack/github-actions/setup-env@master'
         # forks do not have access to secrets so just skip this
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: github.repository == 'vuejs/router'
         with:
           username: ${{ secrets.BROWSERSTACK_USERNAME }}
           access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
Some of the CI jobs only work for `vuejs/router` and fail when pushing changes to forks.

This PR restricts those jobs so that they don't run on forks.

The approach is based on:

- https://github.com/vuejs/core/blob/a23fb59e83c8b65b27eaa21964c8baa217ab0573/.github/workflows/ci.yml#L19

The existing check on `github.event.pull_request.head.repo.fork` doesn't seem to work for pushes, presumably because `github.event.pull_request` is only available for PRs and not pushes.

In theory, somebody might want to run these workflows on their fork, but I think that only makes sense if they don't intend to merge them back into the main repo, in which case they can just edit the workflow configs on their fork.