### PR TITLE
feat: add data attributes for active links in RouterLink component

### DIFF
--- a/packages/router/__tests__/RouterLink.spec.ts
+++ b/packages/router/__tests__/RouterLink.spec.ts
@@ -991,4 +991,39 @@ describe('RouterLink', () => {
       })
     })
   })
+  describe('data attributes for active links', () => {
+    it('sets data-is-active and data-is-exact-active when the link is exactly active', async () => {
+      const { wrapper } = await factory(
+        locations.basic.normalized,
+        { to: locations.basic.string },
+        locations.basic.normalized
+      )
+      expect(wrapper.find('a')!.attributes('data-is-active')).toBe('true')
+      expect(wrapper.find('a')!.attributes('data-is-exact-active')).toBe('true')
+    })
+
+    it('does not include the data attributes when the link is not active', async () => {
+      const { wrapper } = await factory(
+        START_LOCATION_NORMALIZED,
+        { to: locations.foo.string },
+        locations.basic.normalized
+      )
+      expect(wrapper.find('a')!.attributes('data-is-active')).toBeUndefined()
+      expect(
+        wrapper.find('a')!.attributes('data-is-exact-active')
+      ).toBeUndefined()
+    })
+
+    it('sets only data-is-active for a parent link when a child is active', async () => {
+      const { wrapper } = await factory(
+        locations.child.normalized,
+        { to: locations.parent.string },
+        locations.parent.normalized
+      )
+      expect(wrapper.find('a')!.attributes('data-is-active')).toBe('true')
+      expect(
+        wrapper.find('a')!.attributes('data-is-exact-active')
+      ).toBeUndefined()
+    })
+  })
 })

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -341,6 +341,10 @@ export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
                 ? props.ariaCurrentValue
                 : null,
               href: link.href,
+              'data-is-active': link.isActive ? link.isActive : null,
+              'data-is-exact-active': link.isExactActive
+                ? link.isExactActive
+                : null,
               // this would override user added attrs but Vue will still add
               // the listener, so we end up triggering both
               onClick: link.navigate,


### PR DESCRIPTION
## Summary

This PR enhances the `<RouterLink>` component by injecting two new data attributes on the rendered `<a>` element:

* `data-is-active` — present when the link matches the current route (inclusive match)
* `data-is-exact-active` — present when the link exactly matches the current route

These attributes allow authors to target active link states via attribute selectors (e.g. in Tailwind CSS) with higher specificity than relying solely on utility class ordering.

---

## Motivation

Tailwind’s JIT-generated CSS emits utility rules in a deterministic sequence. If the base link color rule happens to appear **after** your active-color rule in the compiled stylesheet, the base color will win and your active style won’t apply. By exposing `data-is-active` and `data-is-exact-active`, developers can write attribute-based selectors that reliably override base styles regardless of class order. For example:

```jsx
<RouterLink
  to="/posts"
  class="
    text-blue-800 
    hover:text-blue-600 
    data-[is-active=true]:text-blue-600 
  "
>
  Posts
</RouterLink>
```
