### PR TITLE
fix(view): prevent undefined access during functional component unmount

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -158,6 +158,9 @@
       <li>
         <router-link to="/p_1/absolute-a">/p_1/absolute-a</router-link>
       </li>
+      <li>
+        <router-link to="/func_comp">/func_comp</router-link>
+      </li>
     </ul>
     <button @click="toggleViewName">Toggle view</button>
     <RouterView :name="viewName" v-slot="{ Component, route }">

--- a/packages/playground/src/router.ts
+++ b/packages/playground/src/router.ts
@@ -12,6 +12,7 @@ const component = () => {
 import LongView from './views/LongView.vue'
 import GuardedWithLeave from './views/GuardedWithLeave.vue'
 import ComponentWithData from './views/ComponentWithData.vue'
+import FuncComp from './views/FuncComp'
 import { globalState } from './store'
 import { scrollWaiter } from './scrollWaiter'
 import RepeatedParams from './views/RepeatedParams.vue'
@@ -158,6 +159,10 @@ export const router = createRouter({
         { path: 'dashboard', component },
         { path: 'settings', component },
       ],
+    },
+    {
+      path: '/func_comp',
+      component: FuncComp,
     },
   ],
   async scrollBehavior(to, from, savedPosition) {

--- a/packages/playground/src/views/FuncComp.ts
+++ b/packages/playground/src/views/FuncComp.ts
@@ -1,0 +1,7 @@
+import { h, type FunctionalComponent } from 'vue'
+
+const FuncComp: FunctionalComponent = () => {
+  return h('div', {}, 'Demo Functional Component')
+}
+
+export default FuncComp

--- a/packages/router/src/RouterView.ts
+++ b/packages/router/src/RouterView.ts
@@ -160,7 +160,9 @@ export const RouterViewImpl = /*#__PURE__*/ defineComponent({
 
       const onVnodeUnmounted: VNodeProps['onVnodeUnmounted'] = vnode => {
         // remove the instance reference to prevent leak
-        if (vnode.component!.isUnmounted) {
+        const component = vnode.component
+        // the component instance of functional component is null
+        if (!component || component.isUnmounted) {
           matchedRoute.instances[currentName] = null
         }
       }


### PR DESCRIPTION
Fix #2512 

Functional components are like pure functions without creating component instance and life style. 

> https://vuejs.org/guide/extras/render-function.html#functional-components

 So need to check it before invoking `isUnmounted`