### PR TITLE
docs: fix isNavigationFailure function example

### DIFF
--- a/packages/router/src/errors.ts
+++ b/packages/router/src/errors.ts
@@ -163,7 +163,7 @@ export function createRouterError<E extends RouterError>(
  *     // ...
  *   }
  *   // Aborted or canceled navigations
- *   if (isNavigationFailure(failure, NavigationFailureType.aborted | NavigationFailureType.canceled)) {
+ *   if (isNavigationFailure(failure, NavigationFailureType.aborted | NavigationFailureType.cancelled )) {
  *     // ...
  *   }
  * })


### PR DESCRIPTION
`Property 'canceled' does not exist on type 'typeof NavigationFailureType'. Did you mean 'cancelled'?`

Copied from the example of { isNavigationFailure } Function: [isNavigationFailure](https://router.vuejs.org/api/functions/isNavigationFailure.html)

```ts
router.afterEach((to, from, failure) => {
  // Any kind of navigation failure
  if (isNavigationFailure(failure)) {
    // ...
  }
  // Only duplicated navigations
  if (isNavigationFailure(failure, NavigationFailureType.duplicated)) {
    // ...
  }
  // Aborted or canceled navigations
  if (
    isNavigationFailure(failure, NavigationFailureType.aborted | NavigationFailureType.canceled) // TypeError
  ) {
    // ...
  }
})
```