### PR TITLE
fix(router): use pagehide for iOS navigation

### DIFF
--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -126,9 +126,7 @@ function useHistoryListeners(
     return teardown
   }
 
-  function beforeHiddenListener() {
-    document.hidden && beforeUnloadListener()
-  }
+  function beforeHiddenListener() { document.hidden && beforeUnloadListener() }
 
   function beforeUnloadListener() {
     const { history } = window
@@ -143,7 +141,6 @@ function useHistoryListeners(
     for (const teardown of teardowns) teardown()
     teardowns = []
     window.removeEventListener('popstate', popStateHandler)
-    window.removeEventListener('beforeunload', beforeUnloadListener)
     window.removeEventListener('pagehide', beforeUnloadListener)
     document.removeEventListener('visibilitychange', beforeHiddenListener)
   }
@@ -153,9 +150,6 @@ function useHistoryListeners(
   // https://developer.chrome.com/blog/page-lifecycle-api/
   // note: iOS safari does not fire beforeunload, so we
   // use pagehide and visibilitychange instead
-  window.addEventListener('beforeunload', beforeUnloadListener, {
-    passive: true,
-  })
   window.addEventListener('pagehide', beforeUnloadListener)
   document.addEventListener('visibilitychange', beforeHiddenListener)
 

--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -126,6 +126,10 @@ function useHistoryListeners(
     return teardown
   }
 
+  function beforeHiddenListener() {
+    document.hidden && beforeUnloadListener()
+  }
+
   function beforeUnloadListener() {
     const { history } = window
     if (!history.state) return
@@ -140,15 +144,20 @@ function useHistoryListeners(
     teardowns = []
     window.removeEventListener('popstate', popStateHandler)
     window.removeEventListener('beforeunload', beforeUnloadListener)
+    window.removeEventListener('pagehide', beforeUnloadListener)
+    document.removeEventListener('visibilitychange', beforeHiddenListener)
   }
 
   // set up the listeners and prepare teardown callbacks
   window.addEventListener('popstate', popStateHandler)
-  // TODO: could we use 'pagehide' or 'visibilitychange' instead?
   // https://developer.chrome.com/blog/page-lifecycle-api/
+  // note: iOS safari does not fire beforeunload, so we
+  // use pagehide and visibilitychange instead
   window.addEventListener('beforeunload', beforeUnloadListener, {
     passive: true,
   })
+  window.addEventListener('pagehide', beforeUnloadListener)
+  document.addEventListener('visibilitychange', beforeHiddenListener)
 
   return {
     pauseListeners,

--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -126,15 +126,15 @@ function useHistoryListeners(
     return teardown
   }
 
-  function beforeHiddenListener() { document.hidden && beforeUnloadListener() }
-
   function beforeUnloadListener() {
-    const { history } = window
-    if (!history.state) return
-    history.replaceState(
-      assign({}, history.state, { scroll: computeScrollPosition() }),
-      ''
-    )
+    if (document.visibilityState === 'hidden') {
+      const { history } = window
+      if (!history.state) return
+      history.replaceState(
+        assign({}, history.state, { scroll: computeScrollPosition() }),
+        ''
+      )
+    }
   }
 
   function destroy() {
@@ -142,7 +142,7 @@ function useHistoryListeners(
     teardowns = []
     window.removeEventListener('popstate', popStateHandler)
     window.removeEventListener('pagehide', beforeUnloadListener)
-    document.removeEventListener('visibilitychange', beforeHiddenListener)
+    document.removeEventListener('visibilitychange', beforeUnloadListener)
   }
 
   // set up the listeners and prepare teardown callbacks
@@ -151,7 +151,7 @@ function useHistoryListeners(
   // note: iOS safari does not fire beforeunload, so we
   // use pagehide and visibilitychange instead
   window.addEventListener('pagehide', beforeUnloadListener)
-  document.addEventListener('visibilitychange', beforeHiddenListener)
+  document.addEventListener('visibilitychange', beforeUnloadListener)
 
   return {
     pauseListeners,


### PR DESCRIPTION
fix #2536

### Steps to reproduce
On iOS safari, scroll to the middle of the page, refresh, it'll go back to top instead of going back to the correct position.

### What is expected?
It behaves properly in chrome for e.g., it'd restore the scroll position.

### What is actually happening?
It's going back to the top of the page instead of restoring the scroll position.

---
The code window.addEventListener('beforeunload', beforeUnloadListener) does not trigger on iOS, we should use window.addEventListener('pagehide', ...) instead