### PR TITLE
docu: add missing export line in router.js code block

### DIFF
--- a/packages/docs/guide/index.md
+++ b/packages/docs/guide/index.md
@@ -67,6 +67,8 @@ const router = createRouter({
   history: createMemoryHistory(),
   routes,
 })
+
+export default router
 ```
 
 The `routes` option defines the routes themselves, mapping URL paths to components. The component specified by the `component` option is the one that will be rendered by the `<RouterView>` in our earlier `App.vue`. These route components are sometimes referred to as _views_, though they are just normal Vue components.

--- a/packages/docs/guide/index.md
+++ b/packages/docs/guide/index.md
@@ -63,12 +63,10 @@ const routes = [
   { path: '/about', component: AboutView },
 ]
 
-const router = createRouter({
+export const router = createRouter({
   history: createMemoryHistory(),
   routes,
 })
-
-export default router
 ```
 
 The `routes` option defines the routes themselves, mapping URL paths to components. The component specified by the `component` option is the one that will be rendered by the `<RouterView>` in our earlier `App.vue`. These route components are sometimes referred to as _views_, though they are just normal Vue components.


### PR DESCRIPTION
This PR adds a missing export statement in the `router.js` code block of the documentation. 
Without this line, the code does not work properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated routing guide examples to declare the router as a named export, making it easier to import by name in snippets.
  * Notes clarify this is a documentation-only change that doesn't affect runtime behavior or existing configurations.
  * Aligns examples with common import patterns to reduce confusion and improve developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->