### PR TITLE
fix(routerlink): allow event handlers under strictTemplates (fix #2484)

### DIFF
--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -26,6 +26,7 @@ import {
   // @ts-ignore
   ComponentOptionsMixin,
   MaybeRef,
+  AnchorHTMLAttributes,
 } from 'vue'
 import { isSameRouteLocationParams, isSameRouteRecord } from './location'
 import { routerKey, routeLocationKey } from './injectionSymbols'
@@ -365,12 +366,20 @@ export const RouterLink: _RouterLinkI = RouterLinkImpl as any
  *
  * @internal
  */
+type LinkAnchorAttrs = Omit<AnchorHTMLAttributes, 'href'>
+
+type _BaseRouterLinkProps = AllowedComponentProps &
+  ComponentCustomProps &
+  VNodeProps &
+  RouterLinkProps
+
+type RouterLinkTypedProps<C extends boolean | undefined> = C extends true
+  ? _BaseRouterLinkProps & { custom: true }
+  : _BaseRouterLinkProps & { custom?: false | undefined } & LinkAnchorAttrs
+
 export interface _RouterLinkI {
-  new (): {
-    $props: AllowedComponentProps &
-      ComponentCustomProps &
-      VNodeProps &
-      RouterLinkProps
+  new <C extends boolean | undefined = boolean | undefined>(): {
+    $props: RouterLinkTypedProps<C>
 
     $slots: {
       default?: ({

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -363,7 +363,7 @@ export const RouterLink: _RouterLinkI = RouterLinkImpl as any
 /**
  * @internal
  */
-type _BaseRouterLinkProps = AllowedComponentProps &
+type _RouterLinkPropsTypedBase = AllowedComponentProps &
   ComponentCustomProps &
   VNodeProps &
   RouterLinkProps
@@ -371,10 +371,10 @@ type _BaseRouterLinkProps = AllowedComponentProps &
 /**
  * @internal
  */
-type RouterLinkTypedProps<Custom extends boolean | undefined> =
+type RouterLinkPropsTyped<Custom extends boolean | undefined> =
   Custom extends true
-    ? _BaseRouterLinkProps & { custom: true }
-    : _BaseRouterLinkProps & { custom?: false | undefined } & Omit<
+    ? _RouterLinkPropsTypedBase & { custom: true }
+    : _RouterLinkPropsTypedBase & { custom?: false | undefined } & Omit<
           AnchorHTMLAttributes,
           'href'
         >
@@ -387,7 +387,7 @@ type RouterLinkTypedProps<Custom extends boolean | undefined> =
  */
 export interface _RouterLinkI {
   new <Custom extends boolean | undefined = boolean | undefined>(): {
-    $props: RouterLinkTypedProps<Custom>
+    $props: RouterLinkPropsTyped<Custom>
 
     $slots: {
       default?: ({

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -361,25 +361,33 @@ export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
 export const RouterLink: _RouterLinkI = RouterLinkImpl as any
 
 /**
- * Typed version of the `RouterLink` component. Its generic defaults to the typed router, so it can be inferred
- * automatically for JSX.
- *
  * @internal
  */
-type LinkAnchorAttrs = Omit<AnchorHTMLAttributes, 'href'>
-
 type _BaseRouterLinkProps = AllowedComponentProps &
   ComponentCustomProps &
   VNodeProps &
   RouterLinkProps
 
-type RouterLinkTypedProps<C extends boolean | undefined> = C extends true
-  ? _BaseRouterLinkProps & { custom: true }
-  : _BaseRouterLinkProps & { custom?: false | undefined } & LinkAnchorAttrs
+/**
+ * @internal
+ */
+type RouterLinkTypedProps<Custom extends boolean | undefined> =
+  Custom extends true
+    ? _BaseRouterLinkProps & { custom: true }
+    : _BaseRouterLinkProps & { custom?: false | undefined } & Omit<
+          AnchorHTMLAttributes,
+          'href'
+        >
 
+/**
+ * Typed version of the `RouterLink` component. Its generic defaults to the typed router, so it can be inferred
+ * automatically for JSX.
+ *
+ * @internal
+ */
 export interface _RouterLinkI {
-  new <C extends boolean | undefined = boolean | undefined>(): {
-    $props: RouterLinkTypedProps<C>
+  new <Custom extends boolean | undefined = boolean | undefined>(): {
+    $props: RouterLinkTypedProps<Custom>
 
     $slots: {
       default?: ({

--- a/packages/router/test-dts/components.test-d.tsx
+++ b/packages/router/test-dts/components.test-d.tsx
@@ -27,6 +27,17 @@ describe('Components', () => {
     expectTypeOf<JSX.Element>(<RouterLink class="link" to="/foo" />)
     expectTypeOf<JSX.Element>(<RouterLink to={{ path: '/foo' }} />)
     expectTypeOf<JSX.Element>(<RouterLink to={{ path: '/foo' }} custom />)
+    // event handlers and anchor attrs are allowed when not custom
+    expectTypeOf<JSX.Element>(
+      <RouterLink to="/" onFocus={() => {}} onClick={() => {}} />
+    )
+    expectTypeOf<JSX.Element>(
+      <RouterLink to="/" target="_blank" rel="noopener" />
+    )
+    // @ts-expect-error: href is intentionally omitted
+    expectError(<RouterLink to="/" href="/bar" />)
+    // @ts-expect-error: onFocus should not be allowed with custom
+    expectError(<RouterLink to="/" custom onFocus={() => {}} />)
 
     // RouterView
     expectTypeOf<JSX.Element>(<RouterView class="view" />)


### PR DESCRIPTION
### Description
With `vueCompilerOptions.strictTemplates: true`, adding any event handler to `RouterLink` (e.g. `@focus`) triggers a TS error, even though the handler works at runtime (see #2484).

### Solution
- Make `RouterLink` generic over `custom` to preserve anchor event/attrs when `custom !== true` and exclude them when `custom === true`.
- Add `Omit<AnchorHTMLAttributes, 'href'>` so `href` stays disallowed (we derive it from `to`).
- No runtime changes, only types.

### Tests
- Add dts tests to ensure:
  - event handlers and anchor attrs are allowed when not `custom`
  - `href` is not allowed
  - anchor attrs/handlers are disallowed when `custom` is `true`
- All tests pass:
  - `pnpm -C packages/router build && pnpm -C packages/router build:dts`
  - `pnpm -C packages/router test:types`
  - `pnpm -C packages/router test` (coverage/unit/e2e)


- Locally verified with `vue-tsc --noEmit` and `strictTemplates: true` on an SFC.

### Links
Closes #2484

---
Also happy to adjust if maintainers prefer another approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved TypeScript typings for RouterLink to better reflect usage modes: when not using `custom`, standard anchor attributes (e.g., target, rel) and native events are allowed while `href` is excluded; when using `custom`, native anchor events are restricted. No runtime changes.
- **Tests**
  - Added type-check tests to validate the updated RouterLink typings and ensure correct allowances and errors across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->