### PR TITLE
feat: update vueschool banner script url for adblocker prevention

### DIFF
--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -108,7 +108,7 @@ export const sharedConfig = defineConfig({
     [
       'script',
       {
-        src: 'https://vueschool.io/banner.js?affiliate=vuerouter&type=top',
+        src: 'https://media.bitterbrains.com/main.js?from=vuerouter&type=top',
         // @ts-expect-error: vitepress bug
         async: true,
         type: 'text/javascript',


### PR DESCRIPTION
This PR is to update Vue School Banner script to https://media.bitterbrains.com/main.js to prevent adblockers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the top banner on the documentation site to use a new script source while preserving existing behavior.
  - Banner continues to load asynchronously and should not impact page performance or navigation.
  - No changes to documentation content or structure; the update only affects the promotional banner display across pages.
  - Users may notice minor visual or tracking improvements tied to the banner, with no required action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->