### PR TITLE
build: reinstate ESM browser builds

### DIFF
--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -63,6 +63,34 @@ const esm = {
   // sourcemap: true,
 } satisfies Options
 
+const esmBrowser = {
+  ...commonOptions,
+  outputOptions: {
+    ...commonOptions.outputOptions,
+    dir: undefined, // must be unset with file
+    file: 'dist/vue-router.esm-browser.js',
+  },
+  define: {
+    ...commonOptions.define,
+    __DEV__: 'true',
+    __FEATURE_PROD_DEVTOOLS__: 'true',
+  },
+} satisfies Options
+
+const esmBrowserProd = {
+  ...esmBrowser,
+  minify: true,
+  outputOptions: {
+    ...esmBrowser.outputOptions,
+    file: 'dist/vue-router.esm-browser.prod.js',
+  },
+  define: {
+    ...esmBrowser.define,
+    __DEV__: 'false',
+    __FEATURE_PROD_DEVTOOLS__: 'false',
+  },
+} satisfies Options
+
 const cjs = {
   ...commonOptions,
   format: 'cjs',
@@ -122,6 +150,8 @@ const iifeProd = {
 export default [
   //
   esm,
+  esmBrowser,
+  esmBrowserProd,
   cjs,
   cjsProd,
   iife,


### PR DESCRIPTION
`vue-router.esm-browser.js` and `vue-router.esm-browser.prod.js` are missing from Vue Router 4.6.0. This PR brings them back.

These files are used when importing directly from a CDN.

It is possible to use `vue-router.mjs` directly in the browser, but it requires polyfills. `vue-router.esm-browser.js` removes references to `process.env` and `__VUE_PROD_DEVTOOLS__`, so it can be used without those polyfills.

`vue-router.esm-browser.prod.js` has dev-only code removed, is minified, and has no dependency on `@vue/devtools-api`.

See also https://github.com/vuejs/router/issues/2569#issuecomment-3406580486.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added browser-targeted ESM bundles for direct use in modern browsers and CDNs.
  - Included both a development build (with development flags enabled) and a minified production build (development flags disabled) for optimized performance.
  - Improves flexibility for loading the router without bundlers and enhances compatibility with ESM-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->