### PR TITLE
chore: make `warnDeprecatedUsage` warn info more explicit

### DIFF
--- a/packages/router/src/RouterView.ts
+++ b/packages/router/src/RouterView.ts
@@ -251,7 +251,7 @@ function warnDeprecatedUsage() {
   ) {
     const comp = parentName === 'KeepAlive' ? 'keep-alive' : 'transition'
     warn(
-      `<router-view> can no longer be used directly inside <transition> or <keep-alive>.\n` +
+      `<router-view> can no longer be used directly inside <${comp}>.\n` +
         `Use slot props instead:\n\n` +
         `<router-view v-slot="{ Component }">\n` +
         `  <${comp}>\n` +


### PR DESCRIPTION
There is relevant judgment logic inside the function, and we can make the warning information clearer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the deprecation warning mechanism to provide more accurate component context information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->