### PR TITLE
Make the production build output compatible with v4.5

### DIFF
--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -79,6 +79,7 @@ const esmBrowser = {
 
 const esmBrowserProd = {
   ...esmBrowser,
+  target: 'es2015',
   minify: true,
   outputOptions: {
     ...esmBrowser.outputOptions,
@@ -135,6 +136,7 @@ const iife = {
 
 const iifeProd = {
   ...iife,
+  target: 'es2015',
   minify: true,
   outputOptions: {
     ...iife.outputOptions,


### PR DESCRIPTION
A breaking change has occurred between v4.6 and v4.5.

Before v4.6, vue-router use rollup to build, the `rollup.config.mjs` use `es2015` as compress target:

```js
// rollup.config.mjs in v4.5
function createMinifiedConfig(format) {
  return createConfig(
    format,
    {
      file: outputConfigs[format].file.replace(/.js$/, '.prod.js'),
      format: outputConfigs[format].format,
    },
    [
      terser({
        module: /^esm/.test(format),
        compress: {
          ecma: 2015,
          pure_getters: true,
        },
      }),
    ]
  )
}
```

Since version v4.6 switched to using tsdown for building, up until now the `tsdown.config.ts` configuration file has not specified a target for the production build.

As a result, the production build output of several v4.6 releases is no longer compatible with v4.5, showing noticeable inconsistencies in behavior — effectively introducing breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build configuration to explicitly target ES2015 for browser and IIFE outputs, ensuring consistent JavaScript compatibility across production builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->