### PR TITLE
Fix typo in Routes' Matching Syntax section

### DIFF
--- a/packages/docs/guide/essentials/route-matching-syntax.md
+++ b/packages/docs/guide/essentials/route-matching-syntax.md
@@ -46,7 +46,7 @@ Since the closing parentheses `)` is used to mark the end of a custom regex, you
 ```js
 const routes = [
   // note the escaped closing parentheses of the group within the regexp
-  { path: '/:custom(somethnig-(nested|other\\))' },
+  { path: '/:custom(something-(nested|other\\))' },
 ]
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Fixed a typo in the route matching syntax guide documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->