### PR TITLE
docs: improve typed route configuration

### DIFF
--- a/packages/docs/guide/advanced/typed-routes.md
+++ b/packages/docs/guide/advanced/typed-routes.md
@@ -4,7 +4,7 @@
 
 ![RouterLink to autocomplete](https://user-images.githubusercontent.com/664177/176442066-c4e7fa31-4f06-4690-a49f-ed0fd880dfca.png)
 
-It's possible to configure the router to have a _map_ of typed routes. While this can be done manually, it is recommended to use the [unplugin-vue-router](https://github.com/posva/unplugin-vue-router) plugin to generate the routes and the types automatically.
+It's possible to configure the router to have a _map_ of typed routes. While this can be done manually, it is recommended to use an automatic configuration.
 
 ## Manual Configuration
 
@@ -70,8 +70,8 @@ declare module 'vue-router' {
 }
 ```
 
-::: tip
+## Automatic Configuration
 
-This is indeed tedious and error-prone. That's why it's recommended to use [unplugin-vue-router](https://github.com/posva/unplugin-vue-router) to generate the routes and the types automatically.
+Manually writing types is tedious and error-prone, that's why it's recommended to use [unplugin-vue-router](https://github.com/posva/unplugin-vue-router) to generate the routes and the types automatically.
+This plugin uses a [file-based routing](https://uvr.esm.is/guide/file-based-routing.html) approach, with fully typed routes.
 
-:::


### PR DESCRIPTION
It took me some time to understand that `unplugin-vue-router` only works with file-based routing, as the documentation never explicitly mentions this.

I hope these changes make it clearer that opting into file-based routing is the only option to get automatic types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated typed routes configuration guidance with improved recommendations for automatic setup approaches.
  * Reorganized documentation structure for clearer configuration explanation and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->