### PR TITLE
docs: fix missing comma in route configuration example

### DIFF
--- a/packages/docs/zh/guide/advanced/meta.md
+++ b/packages/docs/zh/guide/advanced/meta.md
@@ -21,7 +21,7 @@ const routes = [
       },
       {
         path: ':id',
-        component: PostsDetail
+        component: PostsDetail,
         // 任何人都可以阅读文章
         meta: { requiresAuth: false },
       }


### PR DESCRIPTION
## 问题描述

在 Vue Router 中文文档的 "路由元信息" 章节中，示例代码存在语法错误。

## 具体问题

文档链接：https://router.vuejs.org/zh/guide/advanced/meta.html

示例代码中：
```javascript
{
  path: ':id',
  component: PostsDetail  // ❌ 这里缺少逗号
  meta: { requiresAuth: false },
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed formatting in code example in advanced guide documentation by adding a trailing comma for improved code consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->