### PR TITLE
fix(volar): use ts.idText() instead of .text in sfc-typed-router

### DIFF
--- a/packages/router/src/volar/entries/sfc-typed-router.ts
+++ b/packages/router/src/volar/entries/sfc-typed-router.ts
@@ -62,7 +62,7 @@ const plugin: VueLanguagePlugin<{ options: { rootDir?: string } }> = ({
         if (
           ts.isCallExpression(node) &&
           ts.isIdentifier(node.expression) &&
-          node.expression.text === 'useRoute' &&
+          ts.idText(node.expression) === 'useRoute' &&
           !node.typeArguments &&
           !node.arguments.length
         ) {


### PR DESCRIPTION
The sfc-typed-router Volar plugin fails to transform `useRoute()` calls when used with `vue-tsc` because it uses `node.expression.text` to check for the identifier name.

The `.text` getter only exists on `IdentifierObject` (TypeScript Language Service nodes), but Volar uses `ts.createSourceFile()` which produces raw Compiler API nodes that only have `.escapedText`.

Use `ts.idText(node.expression)` which works with both node types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved robustness of router type-checking mechanisms by enhancing identifier resolution logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->