### PR TITLE
docs: Fix route-map.d.ts path

### DIFF
--- a/packages/docs/guide/migration/v4-to-v5.md
+++ b/packages/docs/guide/migration/v4-to-v5.md
@@ -149,7 +149,7 @@ or to your `tsconfig.json`:
   "include": [
     "./typed-router.d.ts", // [!code --]
     "unplugin-vue-router/client", // [!code --]
-    "./src/route-map.d.ts", // [!code ++]
+    // ...
   ],
 }
 ```


### PR DESCRIPTION
By default `route-map.d.ts` is stored in `src`, as shown in the `vite.config.ts` diff, so the `tsconfig.json` diff should reflect that as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to clarify build-tool and TypeScript configuration, added an example showing how to generate and reference route type definitions, corrected include/path references and troubleshooting guidance to point to the generated types file. These changes help ensure generated types are referenced correctly during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->