### PR TITLE
fix(volar): use `ts.getTokenPosOfNode` instead of `node.getStart`

### DIFF
--- a/packages/router/src/volar/entries/sfc-typed-router.ts
+++ b/packages/router/src/volar/entries/sfc-typed-router.ts
@@ -75,10 +75,7 @@ const plugin: VueLanguagePlugin<{ options?: { rootDir?: string } }> = ({
               useRouteNameTypeParam
             )
           } else {
-            const start: number = (ts as any).getTokenPosOfNode(
-              node,
-              sfc.scriptSetup!.ast
-            )
+            const { start, end } = getStartEnd(node, sfc.scriptSetup!.ast)
             replaceSourceRange(
               embeddedCode.content,
               sfc.scriptSetup!.name,
@@ -89,8 +86,8 @@ const plugin: VueLanguagePlugin<{ options?: { rootDir?: string } }> = ({
             replaceSourceRange(
               embeddedCode.content,
               sfc.scriptSetup!.name,
-              node.end,
-              node.end,
+              end,
+              end,
               ` as ReturnType<typeof useRoute${useRouteNameTypeParam}>)`
             )
           }
@@ -119,6 +116,13 @@ const plugin: VueLanguagePlugin<{ options?: { rootDir?: string } }> = ({
         augmentVlsCtx(embeddedCode.content, vlsCtxAugmentations)
       }
     },
+  }
+
+  function getStartEnd(node: ts.Node, ast: ts.SourceFile) {
+    return {
+      start: (ts as any).getTokenPosOfNode(node, ast) as number,
+      end: node.end,
+    }
   }
 }
 


### PR DESCRIPTION
fix vuejs/language-tools#5962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved placement accuracy of generated/injected code inside embedded script blocks to reduce mismatches and rendering anomalies.
  * Results in more reliable embedded content handling with fewer edge-case placement issues.
  * No changes to public APIs or exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->