### PR TITLE
types(router): add | undefined to optional properties

### DIFF
--- a/packages/router/src/experimental/route-resolver/resolver-abstract.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-abstract.ts
@@ -147,8 +147,8 @@ export interface ResolverLocationAsNamed {
   name: RecordName
   // FIXME: should this be optional?
   params: MatcherParamsFormatted
-  query?: LocationQueryRaw
-  hash?: string
+  query?: LocationQueryRaw | undefined
+  hash?: string | undefined
 
   /**
    * @deprecated This is ignored when `name` is provided
@@ -168,8 +168,8 @@ export interface ResolverLocationAsNamed {
  */
 export interface ResolverLocationAsPathRelative {
   path: string
-  query?: LocationQueryRaw
-  hash?: string
+  query?: LocationQueryRaw | undefined
+  hash?: string | undefined
 
   /**
    * @deprecated This is ignored when `path` is provided
@@ -208,9 +208,9 @@ export interface ResolverLocationAsPathAbsolute extends ResolverLocationAsPathRe
  * ```
  */
 export interface ResolverLocationAsRelative {
-  params?: MatcherParamsFormatted
-  query?: LocationQueryRaw
-  hash?: string
+  params?: MatcherParamsFormatted | undefined
+  query?: LocationQueryRaw | undefined
+  hash?: string | undefined
 
   /**
    * @deprecated This location is relative to the next parameter. This `name` will be ignored.

--- a/packages/router/src/experimental/route-resolver/resolver-fixed.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-fixed.ts
@@ -32,35 +32,35 @@ export interface EXPERIMENTAL_ResolverRecord_Base {
    * Name of the matcher. Unique across all matchers. If missing, this record
    * cannot be matched. This is useful for grouping records.
    */
-  name?: RecordName
+  name?: RecordName | undefined
 
   /**
    * {@link MatcherPattern} for the path section of the URI.
    */
-  path?: MatcherPatternPath
+  path?: MatcherPatternPath | undefined
 
   /**
    * {@link MatcherPattern} for the query section of the URI.
    */
-  query?: MatcherPatternQuery[]
+  query?: MatcherPatternQuery[] | undefined
 
   /**
    * {@link MatcherPattern} for the hash section of the URI.
    */
-  hash?: MatcherPatternHash
+  hash?: MatcherPatternHash | undefined
 
   /**
    * Parent record. The parent can be a group or a matchable record.
    * It will be included in the `matched` array of a resolved location.
    */
-  parent?: EXPERIMENTAL_ResolverRecord_Base | null // the parent can be matchable or not
+  parent?: EXPERIMENTAL_ResolverRecord_Base | null | undefined // the parent can be matchable or not
 
   /**
    * If this record is an alias of another record, this points to the original
    * record. Alias records are not added to the name map and resolve to the
    * original record's name.
    */
-  aliasOf?: EXPERIMENTAL_ResolverRecord_Base | null
+  aliasOf?: EXPERIMENTAL_ResolverRecord_Base | null | undefined
 }
 
 /**

--- a/packages/router/src/experimental/router.ts
+++ b/packages/router/src/experimental/router.ts
@@ -131,7 +131,7 @@ export interface EXPERIMENTAL_RouterOptions_Base extends PathParserOptions {
    * }
    * ```
    */
-  scrollBehavior?: RouterScrollBehavior
+  scrollBehavior?: RouterScrollBehavior | undefined
 
   /**
    * Custom implementation to parse a query. See its counterpart,
@@ -150,26 +150,26 @@ export interface EXPERIMENTAL_RouterOptions_Base extends PathParserOptions {
    * })
    * ```
    */
-  parseQuery?: typeof originalParseQuery
+  parseQuery?: typeof originalParseQuery | undefined
 
   /**
    * Custom implementation to stringify a query object. Should not prepend a leading `?`.
    * {@link parseQuery} counterpart to handle query parsing.
    */
 
-  stringifyQuery?: typeof originalStringifyQuery
+  stringifyQuery?: typeof originalStringifyQuery | undefined
 
   /**
    * Default class applied to active {@link RouterLink}. If none is provided,
    * `router-link-active` will be applied.
    */
-  linkActiveClass?: string
+  linkActiveClass?: string | undefined
 
   /**
    * Default class applied to exact active {@link RouterLink}. If none is provided,
    * `router-link-exact-active` will be applied.
    */
-  linkExactActiveClass?: string
+  linkExactActiveClass?: string | undefined
 
   /**
    * Default class applied to non-active {@link RouterLink}. If none is provided,
@@ -187,7 +187,7 @@ export interface EXPERIMENTAL_RouteRecord_Base extends EXPERIMENTAL_ResolverReco
    * before any navigation guard and triggers a new navigation with the new
    * target location.
    */
-  redirect?: RouteRecordRedirectOption
+  redirect?: RouteRecordRedirectOption | undefined
 
   // TODO: deprecate, expose utils to compare resolved routes, and document
   // how to create a meta field that does the same
@@ -202,22 +202,22 @@ export interface EXPERIMENTAL_RouteRecord_Base extends EXPERIMENTAL_ResolverReco
   /**
    * Arbitrary data attached to the record.
    */
-  meta?: RouteMeta
+  meta?: RouteMeta | undefined
 
   /**
    * Components to display when the URL matches this route. Allow using named views.
    */
-  components?: Record<string, RawRouteComponent>
+  components?: Record<string, RawRouteComponent> | undefined
 
   /**
    * Parent of this component if any
    */
-  parent?: EXPERIMENTAL_RouteRecordNormalized | null
+  parent?: EXPERIMENTAL_RouteRecordNormalized | null | undefined
 
   /**
    * References another record if this record is an alias of it.
    */
-  aliasOf?: EXPERIMENTAL_RouteRecordNormalized | null
+  aliasOf?: EXPERIMENTAL_RouteRecordNormalized | null | undefined
 
   // TODO:
   /**
@@ -231,7 +231,7 @@ export interface EXPERIMENTAL_RouteRecord_Redirect
   extends
     Omit<EXPERIMENTAL_RouteRecord_Base, 'name' | 'path'>,
     Omit<EXPERIMENTAL_ResolverRecord_Matchable, 'parent' | 'aliasOf'> {
-  components?: Record<string, RawRouteComponent>
+  components?: Record<string, RawRouteComponent> | undefined
 
   redirect: RouteRecordRedirectOption // must be defined
 }
@@ -244,7 +244,7 @@ export interface EXPERIMENTAL_RouteRecord_Group
       'name' | 'path' | 'query' | 'hash'
     >,
     Omit<EXPERIMENTAL_ResolverRecord_Group, 'parent' | 'aliasOf'> {
-  components?: Record<string, RawRouteComponent>
+  components?: Record<string, RawRouteComponent> | undefined
 }
 
 export interface EXPERIMENTAL_RouteRecord_Components
@@ -254,7 +254,7 @@ export interface EXPERIMENTAL_RouteRecord_Components
     Omit<EXPERIMENTAL_ResolverRecord_Matchable, 'parent' | 'aliasOf'> {
   components: Record<string, RawRouteComponent>
 
-  redirect?: never
+  redirect?: never | undefined
 }
 
 export type EXPERIMENTAL_RouteRecord_Matchable =

--- a/packages/router/src/matcher/pathParserRanker.ts
+++ b/packages/router/src/matcher/pathParserRanker.ts
@@ -57,14 +57,14 @@ export interface _PathParserOptions {
    *
    * @defaultValue `false`
    */
-  sensitive?: boolean
+  sensitive?: boolean | undefined
 
   /**
    * Whether to disallow a trailing slash or not.
    *
    * @defaultValue `false`
    */
-  strict?: boolean
+  strict?: boolean | undefined
 
   /**
    * Should the RegExp match from the beginning by prepending a `^` to it.
@@ -72,7 +72,7 @@ export interface _PathParserOptions {
    *
    * @defaultValue `true`
    */
-  start?: boolean
+  start?: boolean | undefined
 
   /**
    * Should the RegExp match until the end by appending a `$` to it.
@@ -81,7 +81,7 @@ export interface _PathParserOptions {
    *
    * @defaultValue `true`
    */
-  end?: boolean
+  end?: boolean | undefined
 }
 
 export type PathParserOptions = Pick<

--- a/packages/router/src/scrollBehavior.ts
+++ b/packages/router/src/scrollBehavior.ts
@@ -12,9 +12,9 @@ import { warn } from './warning'
  * Note that not all browsers support `behavior`.
  */
 export type ScrollPositionCoordinates = {
-  behavior?: ScrollOptions['behavior']
-  left?: number
-  top?: number
+  behavior?: ScrollOptions['behavior'] | undefined
+  left?: number | undefined
+  top?: number | undefined
 }
 
 /**
@@ -24,7 +24,7 @@ export type ScrollPositionCoordinates = {
  * @internal
  */
 export type _ScrollPositionNormalized = {
-  behavior?: ScrollOptions['behavior']
+  behavior?: ScrollOptions['behavior'] | undefined
   left: number
   top: number
 }

--- a/packages/router/src/typed-routes/route-location.ts
+++ b/packages/router/src/typed-routes/route-location.ts
@@ -131,8 +131,8 @@ export type RouteLocationNormalizedLoadedTypedList<
  */
 export interface RouteLocationAsRelativeGeneric
   extends RouteQueryAndHash, RouteLocationOptions {
-  name?: RouteRecordNameGeneric
-  params?: RouteParamsRawGeneric
+  name?: RouteRecordNameGeneric | undefined
+  params?: RouteParamsRawGeneric | undefined
   /**
    * A relative path to the current location. This property should be removed
    */
@@ -147,8 +147,8 @@ export interface RouteLocationAsRelativeTyped<
     RouteMapGeneric,
   Name extends keyof RouteMap = keyof RouteMap,
 > extends RouteLocationAsRelativeGeneric {
-  name?: Extract<Name, string | symbol>
-  params?: RouteMap[Name]['paramsRaw']
+  name?: Extract<Name, string | symbol> | undefined
+  params?: RouteMap[Name]['paramsRaw'] | undefined
 }
 
 /**

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -52,8 +52,8 @@ export type RouteParamsRawGeneric = Record<
  * @internal
  */
 export interface RouteQueryAndHash {
-  query?: LocationQueryRaw
-  hash?: string
+  query?: LocationQueryRaw | undefined
+  hash?: string | undefined
 }
 
 /**
@@ -73,7 +73,7 @@ export interface MatcherLocationAsName {
    * Ignored path property since we are dealing with a relative location. Only `undefined` is allowed.
    */
   path?: undefined
-  params?: RouteParamsGeneric
+  params?: RouteParamsGeneric | undefined
 }
 
 /**
@@ -85,20 +85,20 @@ export interface MatcherLocationAsRelative {
    * Ignored path property since we are dealing with a relative location. Only `undefined` is allowed.
    */
   path?: undefined
-  params?: RouteParamsGeneric
+  params?: RouteParamsGeneric | undefined
 }
 
 /**
  * @internal
  */
 export interface LocationAsRelativeRaw {
-  name?: RouteRecordNameGeneric
+  name?: RouteRecordNameGeneric | undefined
   // to allow checking location.path == null
   /**
    * Ignored path property since we are dealing with a relative location. Only `undefined` is allowed.
    */
   path?: undefined
-  params?: RouteParamsRawGeneric
+  params?: RouteParamsRawGeneric | undefined
 }
 
 /**
@@ -108,19 +108,19 @@ export interface RouteLocationOptions {
   /**
    * Replace the entry in the history instead of pushing a new entry
    */
-  replace?: boolean
+  replace?: boolean | undefined
   /**
    * Triggers the navigation even if the location is the same as the current one.
    * Note this will also add a new entry to the history unless `replace: true`
    * is passed.
    */
-  force?: boolean
+  force?: boolean | undefined
   /**
    * State to save using the History API. This cannot contain any reactive
    * values and some primitives like Symbols are forbidden. More info at
    * https://developer.mozilla.org/en-US/docs/Web/API/History/state
    */
-  state?: HistoryState
+  state?: HistoryState | undefined
 }
 
 /**
@@ -201,19 +201,19 @@ export interface _RouteRecordBase extends PathParserOptions {
    * before any navigation guard and triggers a new navigation with the new
    * target location.
    */
-  redirect?: RouteRecordRedirectOption
+  redirect?: RouteRecordRedirectOption | undefined
 
   /**
    * Aliases for the record. Allows defining extra paths that will behave like a
    * copy of the record. Allows having paths shorthands like `/users/:id` and
    * `/u/:id`. All `alias` and `path` values must share the same params.
    */
-  alias?: string | string[]
+  alias?: string | string[] | undefined
 
   /**
    * Name for the route record. Must be unique.
    */
-  name?: RouteRecordNameGeneric
+  name?: RouteRecordNameGeneric | undefined
 
   /**
    * Before Enter guard specific to this record. Note `beforeEnter` has no
@@ -222,21 +222,22 @@ export interface _RouteRecordBase extends PathParserOptions {
   beforeEnter?:
     | NavigationGuardWithThis<undefined>
     | NavigationGuardWithThis<undefined>[]
+    | undefined
 
   /**
    * Arbitrary data attached to the record.
    */
-  meta?: RouteMeta
+  meta?: RouteMeta | undefined
 
   /**
    * Array of nested routes.
    */
-  children?: RouteRecordRaw[]
+  children?: RouteRecordRaw[] | undefined
 
   /**
    * Allow passing down params as props to the component rendered by `router-view`.
    */
-  props?: _RouteRecordProps | Record<string, _RouteRecordProps>
+  props?: _RouteRecordProps | Record<string, _RouteRecordProps> | undefined
 }
 
 /**
@@ -265,14 +266,14 @@ export interface RouteRecordSingleView extends _RouteRecordBase {
    * Component to display when the URL matches this route.
    */
   component: RawRouteComponent
-  components?: never
-  children?: never
-  redirect?: never
+  components?: never | undefined
+  children?: never | undefined
+  redirect?: never | undefined
 
   /**
    * Allow passing down params as props to the component rendered by `router-view`.
    */
-  props?: _RouteRecordProps
+  props?: _RouteRecordProps | undefined
 }
 
 /**
@@ -285,14 +286,14 @@ export interface RouteRecordSingleViewWithChildren extends _RouteRecordBase {
    * Component to display when the URL matches this route.
    */
   component?: RawRouteComponent | null | undefined
-  components?: never
+  components?: never | undefined
 
   children: RouteRecordRaw[]
 
   /**
    * Allow passing down params as props to the component rendered by `router-view`.
    */
-  props?: _RouteRecordProps
+  props?: _RouteRecordProps | undefined
 }
 
 /**
@@ -303,16 +304,16 @@ export interface RouteRecordMultipleViews extends _RouteRecordBase {
    * Components to display when the URL matches this route. Allow using named views.
    */
   components: Record<string, RawRouteComponent>
-  component?: never
-  children?: never
-  redirect?: never
+  component?: never | undefined
+  children?: never | undefined
+  redirect?: never | undefined
 
   /**
    * Allow passing down params as props to the component rendered by
    * `router-view`. Should be an object with the same keys as `components` or a
    * boolean to be applied to every component.
    */
-  props?: Record<string, _RouteRecordProps> | boolean
+  props?: Record<string, _RouteRecordProps> | boolean | undefined
 }
 
 /**
@@ -323,7 +324,7 @@ export interface RouteRecordMultipleViewsWithChildren extends _RouteRecordBase {
    * Components to display when the URL matches this route. Allow using named views.
    */
   components?: Record<string, RawRouteComponent> | null | undefined
-  component?: never
+  component?: never | undefined
 
   children: RouteRecordRaw[]
 
@@ -332,7 +333,7 @@ export interface RouteRecordMultipleViewsWithChildren extends _RouteRecordBase {
    * `router-view`. Should be an object with the same keys as `components` or a
    * boolean to be applied to every component.
    */
-  props?: Record<string, _RouteRecordProps> | boolean
+  props?: Record<string, _RouteRecordProps> | boolean | undefined
 }
 
 /**
@@ -341,9 +342,9 @@ export interface RouteRecordMultipleViewsWithChildren extends _RouteRecordBase {
  */
 export interface RouteRecordRedirect extends _RouteRecordBase {
   redirect: RouteRecordRedirectOption
-  component?: never
-  components?: never
-  props?: never
+  component?: never | undefined
+  components?: never | undefined
+  props?: never | undefined
 }
 
 export type RouteRecordRaw =

--- a/packages/router/src/unplugin/options.ts
+++ b/packages/router/src/unplugin/options.ts
@@ -45,19 +45,19 @@ export interface RoutesFolderOption {
    * },
    * ```
    */
-  path?: string | ((filepath: string) => string)
+  path?: string | ((filepath: string) => string) | undefined
 
   /**
    * Allows to override the global `filePattern` option for this folder. It can also extend the global values by passing
    * a function that returns an array.
    */
-  filePatterns?: _OverridableOption<string[], string | string[]>
+  filePatterns?: _OverridableOption<string[], string | string[]> | undefined
 
   /**
    * Allows to override the global `exclude` option for this folder. It can
    * also extend the global values by passing a function that returns an array.
    */
-  exclude?: _OverridableOption<string[], string | string[]>
+  exclude?: _OverridableOption<string[], string | string[]> | undefined
 
   /**
    * Allows to override the global `extensions` option for this folder. It can
@@ -66,7 +66,7 @@ export interface RoutesFolderOption {
    * `.page.vue` allows to suffix all pages with `.page.vue` and remove it from
    * the route name.
    */
-  extensions?: _OverridableOption<string[]>
+  extensions?: _OverridableOption<string[]> | undefined
 }
 
 /**
@@ -131,7 +131,7 @@ export interface Options {
    * bigger part of the filename e.g. `index.page.vue` -> `index` if an extension of `.page.vue` is provided.
    * @default `['.vue']`
    */
-  extensions?: string[]
+  extensions?: string[] | undefined
 
   /**
    * Folder(s) to scan for files and generate routes. Can also be an array if you want to add multiple
@@ -140,7 +140,7 @@ export interface Options {
    *
    * @default `"src/pages"`
    */
-  routesFolder?: RoutesFolder
+  routesFolder?: RoutesFolder | undefined
 
   /**
    * Array of `picomatch` globs to ignore. Note the globs are relative to the cwd, so avoid writing
@@ -148,7 +148,7 @@ export interface Options {
    * `['src/pages/ignored/**']` or use `['**​/ignored']` to match every folder named `ignored`.
    * @default `[]`
    */
-  exclude?: string[] | string
+  exclude?: string[] | string | undefined
 
   /**
    * Pattern to match files in the `routesFolder`. Defaults to `*\/*` plus a
@@ -158,13 +158,13 @@ export interface Options {
    *
    * @default `['*\/*']`
    */
-  filePatterns?: string[] | string
+  filePatterns?: string[] | string | undefined
 
   /**
    * Method to generate the name of a route. It's recommended to keep the default value to guarantee a consistent,
    * unique, and predictable naming.
    */
-  getRouteName?: (node: TreeNode) => string
+  getRouteName?: ((node: TreeNode) => string) | undefined
 
   /**
    * Allows extending a route by modifying its node, adding children, or even deleting it. This will be invoked once for
@@ -172,55 +172,61 @@ export interface Options {
    *
    * @param route - {@link EditableTreeNode} of the route to extend
    */
-  extendRoute?: (route: EditableTreeNode) => _Awaitable<void>
+  extendRoute?: ((route: EditableTreeNode) => _Awaitable<void>) | undefined
 
   /**
    * Allows to do some changes before writing the files. This will be invoked **every time** the files need to be written.
    *
    * @param rootRoute - {@link EditableTreeNode} of the root route
    */
-  beforeWriteFiles?: (rootRoute: EditableTreeNode) => _Awaitable<void>
+  beforeWriteFiles?:
+    | ((rootRoute: EditableTreeNode) => _Awaitable<void>)
+    | undefined
 
   /**
    * Defines how page components should be imported. Defaults to dynamic imports to enable lazy loading of pages.
    * @default `'async'`
    */
-  importMode?: 'sync' | 'async' | ((filepath: string) => 'sync' | 'async')
+  importMode?:
+    | 'sync'
+    | 'async'
+    | ((filepath: string) => 'sync' | 'async')
+    | undefined
 
   /**
    * Root of the project. All paths are resolved relatively to this one.
    * @default `process.cwd()`
    */
-  root?: string
+  root?: string | undefined
 
   /**
    * Language for `<route>` blocks in SFC files.
    * @default `'json5'`
    */
-  routeBlockLang?: 'yaml' | 'yml' | 'json5' | 'json'
+  routeBlockLang?: 'yaml' | 'yml' | 'json5' | 'json' | undefined
 
   /**
    * Should we generate d.ts files or ont. Defaults to `true` if `typescript` is installed. Can be set to a string of
    * the filepath to write the d.ts files to. By default it will generate a file named `typed-router.d.ts`.
    * @default `true`
    */
-  dts?: boolean | string
+  dts?: boolean | string | undefined
 
   /**
    * Allows inspection by vite-plugin-inspect by not adding the leading `\0` to the id of virtual modules.
    * @internal
    */
-  _inspect?: boolean
+  _inspect?: boolean | undefined
 
   /**
    * Activates debug logs.
    */
-  logs?: boolean
+  logs?: boolean | undefined
 
   /**
    * @inheritDoc ParseSegmentOptions
    */
-  pathParser?: ParseSegmentOptions
+  pathParser?: ParseSegmentOptions | undefined
 
   /**
    * Whether to watch the files for changes.
@@ -229,27 +235,29 @@ export interface Options {
    *
    * @default `!process.env.CI`
    */
-  watch?: boolean
+  watch?: boolean | undefined
 
   /**
    * Experimental options. **Warning**: these can change or be removed at any time, even it patch releases. Keep an eye
    * on the Changelog.
    */
-  experimental?: {
-    /**
-     * (Vite only). File paths or globs where loaders are exported. This will be used to filter out imported loaders and
-     * automatically re export them in page components. You can for example set this to `'src/loaders/**\/*'` (without
-     * the backslash) to automatically re export any imported variable from files in the `src/loaders` folder within a
-     * page component.
-     */
-    autoExportsDataLoaders?: string | string[]
+  experimental?:
+    | {
+        /**
+         * (Vite only). File paths or globs where loaders are exported. This will be used to filter out imported loaders and
+         * automatically re export them in page components. You can for example set this to `'src/loaders/**\/*'` (without
+         * the backslash) to automatically re export any imported variable from files in the `src/loaders` folder within a
+         * page component.
+         */
+        autoExportsDataLoaders?: string | string[] | undefined
 
-    /**
-     * Enable experimental support for the new custom resolvers and allows
-     * defining custom param matchers.
-     */
-    paramParsers?: boolean | ParamParsersOptions
-  }
+        /**
+         * Enable experimental support for the new custom resolvers and allows
+         * defining custom param matchers.
+         */
+        paramParsers?: boolean | ParamParsersOptions | undefined
+      }
+    | undefined
 }
 
 /**
@@ -261,7 +269,7 @@ export interface ParamParsersOptions {
    *
    * @default `['src/params']`
    */
-  dir?: string | string[]
+  dir?: string | string[] | undefined
 }
 
 /**


### PR DESCRIPTION
## Problem

vue-router's published types use `prop?: T` without explicit `| undefined` on optional interface properties. This works for the default TypeScript configuration, but fails under `exactOptionalPropertyTypes: true` — a flag that TypeScript 5.9's `tsc --init` now enables by default.

The most visible failure is the interface inheritance in the experimental route resolver where `EXPERIMENTAL_ResolverRecord_Group` narrows base properties to `?: undefined`, which requires `undefined` to be assignable to the base property type.

This also affects all other optional properties in published types (`RouteLocationOptions`, `_RouteRecordBase`, `RouteRecordSingleView`, `ScrollPositionCoordinates`, etc.) for consumers with `exactOptionalPropertyTypes: true` and `skipLibCheck: false`.

## Solution

Add `| undefined` to all optional properties across published interfaces and type definitions. This follows the exact same approach as vuejs/core#12771 ("types(jsx): add undefined to optional properties") which was merged for `@vue/runtime-dom`.

**No runtime changes. No tsconfig change. Only type annotations.**

### Not a breaking change

Per [semver-ts.org](https://www.semver-ts.org/formal-spec/5-compiler-considerations.html): changes which correctly represent runtime behavior are not breaking. Adding `| undefined` makes the types honest about what was always possible at runtime.

- `exactOptionalPropertyTypes: false` (default): **zero impact** — types are identical
- `exactOptionalPropertyTypes: true`: **fixes TS2375 errors**

### Scope: 8 files

- `src/types/index.ts` — `RouteQueryAndHash`, `RouteLocationOptions`, `LocationAsRelativeRaw`, `MatcherLocationAsName`, `MatcherLocationAsRelative`, `_RouteRecordBase`, all `RouteRecordSingleView`/`MultipleViews`/`Redirect` variants
- `src/typed-routes/route-location.ts` — `RouteLocationAsRelativeGeneric`, `RouteLocationAsRelativeTyped`
- `src/scrollBehavior.ts` — `ScrollPositionCoordinates`, `_ScrollPositionNormalized` (type definitions only)
- `src/matcher/pathParserRanker.ts` — `_PathParserOptions`
- `src/experimental/route-resolver/resolver-fixed.ts` — `EXPERIMENTAL_ResolverRecord_Base`
- `src/experimental/route-resolver/resolver-abstract.ts` — `ResolverLocationAsNamed`, `ResolverLocationAsPathRelative`, `ResolverLocationAsRelative`
- `src/experimental/router.ts` — `EXPERIMENTAL_RouterOptions_Base`, `EXPERIMENTAL_RouteRecord_Base`, subrecords
- `src/unplugin/options.ts` — `Options`, `RoutesFolderOption`, `ParamParsersOptions`

## Tests

- `pnpm -C packages/router run build` — ✅
- `pnpm -C packages/router run test:types` — 0 errors
- `pnpm -C packages/router run test:unit` — 1494 passed
