### PR TITLE
docs: fix incorrect import path for VueRouterAutoImports

### DIFF
--- a/packages/docs/file-based-routing/index.md
+++ b/packages/docs/file-based-routing/index.md
@@ -296,7 +296,7 @@ If you are using [unplugin-auto-import](https://github.com/unplugin/unplugin-aut
 ```ts
 import { defineConfig } from 'vite'
 import AutoImport from 'unplugin-auto-import/vite'
-import { VueRouterAutoImports } from 'vue-router' // [!code ++]
+import { VueRouterAutoImports } from 'vue-router/unplugin' // [!code ++]
 
 export default defineConfig({
   plugins: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in the Auto Imports guidance to reflect the correct module import paths for VueRouterAutoImports configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->