### PR TITLE
fix(unplugin): Avoid generating empty routes

### DIFF
--- a/packages/router/src/unplugin/codegen/__snapshots__/generateRouteRecords.spec.ts.snap
+++ b/packages/router/src/unplugin/codegen/__snapshots__/generateRouteRecords.spec.ts.snap
@@ -104,6 +104,24 @@ exports[`generateRouteRecord > does not encode RFC 3986 valid path characters 1`
 ]"
 `;
 
+exports[`generateRouteRecord > drops the wrapper when its last child is deleted 1`] = `
+"[
+  {
+    path: '/home',
+    /* internal name: '/home' */
+    /* no component */
+    children: [
+      {
+        path: 'user',
+        name: '/home/user',
+        component: () => import('home/user.vue'),
+        /* no children */
+      }
+    ],
+  }
+]"
+`;
+
 exports[`generateRouteRecord > encodes special characters in path segments 1`] = `
 "[
   {

--- a/packages/router/src/unplugin/codegen/generateRouteRecords.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteRecords.spec.ts
@@ -48,6 +48,17 @@ describe('generateRouteRecord', () => {
     expect(generateRouteRecordSimple(tree)).toContain("path: '/nested'")
   })
 
+  it('skips nested lone _parent files', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    tree.insert('users/index', 'users/index.vue')
+    tree.insert('users/settings/_parent', 'users/settings/_parent.vue')
+
+    const routes = generateRouteRecordSimple(tree)
+
+    expect(routes).toContain("path: '/users'")
+    expect(routes).not.toContain("path: '/users/settings'")
+  })
+
   it('works with some paths at root', () => {
     const tree = new PrefixTree(DEFAULT_OPTIONS)
     tree.insert('a', 'a.vue')

--- a/packages/router/src/unplugin/codegen/generateRouteRecords.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteRecords.spec.ts
@@ -59,6 +59,18 @@ describe('generateRouteRecord', () => {
     expect(routes).not.toContain("path: '/users/settings'")
   })
 
+  // regression test for https://github.com/vuejs/router/issues/2641
+  // when beforeWriteFiles removes the only child of a wrapper node, the
+  // wrapper must disappear too instead of emitting an empty route record
+  it('drops the wrapper when its last child is deleted', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    tree.insert('home/user', 'home/user.vue')
+    const leaf = tree.insert('home/component/foo', 'home/component/foo.vue')
+    leaf.delete()
+
+    expect(generateRouteRecordSimple(tree)).toMatchSnapshot()
+  })
+
   it('works with some paths at root', () => {
     const tree = new PrefixTree(DEFAULT_OPTIONS)
     tree.insert('a', 'a.vue')

--- a/packages/router/src/unplugin/codegen/generateRouteRecords.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteRecords.ts
@@ -19,6 +19,14 @@ export function generateRouteRecords(
   importsMap: ImportsMap,
   indent = 0
 ): string {
+  // delete lone children nodes - they only provide layout wrapping for children
+  // so without children they don't make sense to be included in the route records
+  node.children.forEach(child => {
+    if (!child.isMatchable() && child.children.size === 0) {
+      child.delete()
+    }
+  })
+
   if (node.isRoot()) {
     return `[
 ${node
@@ -26,12 +34,6 @@ ${node
   .map(child => generateRouteRecords(child, options, importsMap, indent + 1))
   .join(',\n')}
 ]`
-  }
-
-  // Skip lone parent nodes - they only provide layout wrapping for children
-  // so without children they don't make sense to be included in the route records
-  if (!node.isMatchable() && node.children.size === 0) {
-    return ''
   }
 
   const definePageDataList: string[] = []
@@ -98,7 +100,6 @@ ${overrides.props != null ? indentStr + `props: ${overrides.props},\n` : ''}${
 ${node
   .getChildrenSorted()
   .map(child => generateRouteRecords(child, options, importsMap, indent + 2))
-  .filter(Boolean)
   .join(',\n')}
 ${indentStr}],`
       : '/* no children */'

--- a/packages/router/src/unplugin/codegen/generateRouteRecords.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteRecords.ts
@@ -98,6 +98,7 @@ ${overrides.props != null ? indentStr + `props: ${overrides.props},\n` : ''}${
 ${node
   .getChildrenSorted()
   .map(child => generateRouteRecords(child, options, importsMap, indent + 2))
+  .filter(Boolean)
   .join(',\n')}
 ${indentStr}],`
       : '/* no children */'

--- a/packages/router/src/unplugin/codegen/generateRouteRecords.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteRecords.ts
@@ -19,14 +19,6 @@ export function generateRouteRecords(
   importsMap: ImportsMap,
   indent = 0
 ): string {
-  // delete lone parent nodes - they only provide layout wrapping for children
-  // so without children they don't make sense to be included in the route records
-  node.children.forEach(child => {
-    if (!child.isMatchable() && child.children.size === 0) {
-      child.delete()
-    }
-  })
-
   if (node.isRoot()) {
     return `[
 ${node
@@ -34,6 +26,12 @@ ${node
   .map(child => generateRouteRecords(child, options, importsMap, indent + 1))
   .join(',\n')}
 ]`
+  }
+
+  // Skip lone parent nodes - they only provide layout wrapping for children
+  // so without children they don't make sense to be included in the route records
+  if (!node.isMatchable() && node.children.size === 0) {
+    return ''
   }
 
   const definePageDataList: string[] = []

--- a/packages/router/src/unplugin/codegen/generateRouteRecords.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteRecords.ts
@@ -19,7 +19,7 @@ export function generateRouteRecords(
   importsMap: ImportsMap,
   indent = 0
 ): string {
-  // delete lone children nodes - they only provide layout wrapping for children
+  // delete lone parent nodes - they only provide layout wrapping for children
   // so without children they don't make sense to be included in the route records
   node.children.forEach(child => {
     if (!child.isMatchable() && child.children.size === 0) {

--- a/packages/router/src/unplugin/core/extendRoutes.spec.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.spec.ts
@@ -35,6 +35,22 @@ describe('EditableTreeNode', () => {
     expect(tree.children.get('foo')?.path).toBe('/foo')
   })
 
+  it('removes parent when deleting last child of a non-matchable node', () => {
+    const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+    const editable = new EditableTreeNode(tree)
+    editable.insert('about', 'about.vue')
+    const toDelete = editable.insert('a/b/c', 'a/b/c.vue')
+
+    expect(tree.children.size).toBe(2)
+    toDelete.delete()
+    expect(tree.children.size).toBe(1)
+    expect(tree.children.has('a')).toBe(false)
+    expect(tree.children.has('about')).toBe(true)
+    // repeatedly delete a node,  should be no error reported
+    expect(() => toDelete.delete()).not.toThrow()
+  })
+
   it('keeps nested routes flat', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
     const editable = new EditableTreeNode(tree)

--- a/packages/router/src/unplugin/core/extendRoutes.spec.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.spec.ts
@@ -47,7 +47,7 @@ describe('EditableTreeNode', () => {
     expect(tree.children.size).toBe(1)
     expect(tree.children.has('a')).toBe(false)
     expect(tree.children.has('about')).toBe(true)
-    // repeatedly delete a node,  should be no error reported
+    // repeatedly deleting a node should not throw
     expect(() => toDelete.delete()).not.toThrow()
   })
 

--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -511,6 +511,15 @@ describe('Tree', () => {
     expect(tree.children.size).toBe(1)
   })
 
+  it('removes parent when deleting last child of a non-matchable node', () => {
+    const tree = new PrefixTree(RESOLVED_OPTIONS)
+    const abc = tree.insert('a/b/c', 'a/b/c.vue')
+    tree.insert('admin/_parent', 'admin/_parent.vue')
+    expect(tree.children.has('a')).toBe(true)
+    abc.delete()
+    expect(tree.children.has('a')).toBe(false)
+  })
+
   it('handles multiple params', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
     tree.insert('[a]-[b]', '[a]-[b].vue')

--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -514,7 +514,6 @@ describe('Tree', () => {
   it('removes parent when deleting last child of a non-matchable node', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
     const abc = tree.insert('a/b/c', 'a/b/c.vue')
-    tree.insert('admin/_parent', 'admin/_parent.vue')
     expect(tree.children.has('a')).toBe(true)
     abc.delete()
     expect(tree.children.has('a')).toBe(false)

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -205,16 +205,16 @@ export class TreeNode {
    * Delete and detach itself from the tree.
    */
   delete() {
-    if (!this.parent) {
+    if (this.isRoot()) {
       throw new Error('Cannot delete the root node.')
     }
-    this.parent.children.delete(this.value.rawSegment)
+    this.parent?.children.delete(this.value.rawSegment)
     // delete lone parent nodes - they only provide layout wrapping for children
     // so without children they don't make sense to be included in the route records
     if (
-      !this.parent.isRoot() &&
-      !this.parent.isMatchable() &&
-      this.parent.children.size === 0
+      !this.parent?.isRoot() &&
+      !this.parent?.isMatchable() &&
+      this.parent?.children.size === 0
     ) {
       this.parent.delete()
     }

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -211,7 +211,11 @@ export class TreeNode {
     this.parent.children.delete(this.value.rawSegment)
     // delete lone parent nodes - they only provide layout wrapping for children
     // so without children they don't make sense to be included in the route records
-    if (!this.parent.isMatchable() && this.parent.children.size === 0) {
+    if (
+      !this.parent.isRoot() &&
+      !this.parent.isMatchable() &&
+      this.parent.children.size === 0
+    ) {
       this.parent.delete()
     }
     // clear link to parent

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -209,6 +209,11 @@ export class TreeNode {
       throw new Error('Cannot delete the root node.')
     }
     this.parent.children.delete(this.value.rawSegment)
+    // delete lone parent nodes - they only provide layout wrapping for children
+    // so without children they don't make sense to be included in the route records
+    if (!this.parent.isMatchable() && this.parent.children.size === 0) {
+      this.parent.delete()
+    }
     // clear link to parent
     this.parent = undefined
   }

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -202,23 +202,29 @@ export class TreeNode {
   }
 
   /**
+   * Delete a child node. If the child node has no more children and no
+   * components, it will be deleted as well. This is used to recursively delete
+   * empty nodes after removing a route.
+   *
+   * @param child - child node to delete
+   */
+  protected deleteChild(child: TreeNode): void {
+    this.children.delete(child.value.rawSegment)
+    // recursively delete empty parents
+    if (!this.isRoot() && !this.isMatchable() && this.children.size === 0) {
+      this.delete()
+    }
+  }
+
+  /**
    * Delete and detach itself from the tree.
    */
-  delete() {
+  delete(): void {
     if (this.isRoot()) {
       throw new Error('Cannot delete the root node.')
     }
-    this.parent?.children.delete(this.value.rawSegment)
-    // delete lone parent nodes - they only provide layout wrapping for children
-    // so without children they don't make sense to be included in the route records
-    if (
-      !this.parent?.isRoot() &&
-      !this.parent?.isMatchable() &&
-      this.parent?.children.size === 0
-    ) {
-      this.parent.delete()
-    }
-    // clear link to parent
+    this.parent?.deleteChild(this)
+    // clear link to parent so a repeated delete() is a no-op
     this.parent = undefined
   }
 


### PR DESCRIPTION
fix #2641 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for nested route structures with parent file configurations.

* **Bug Fixes**
  * Enhanced route tree cleanup to properly remove empty wrapper nodes when children are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->