### PR TITLE
feat: add basePath feature with runtime updates and normalized hooks

### DIFF
--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -178,6 +178,7 @@ export function isSameRouteLocation(
     aLastIndex > -1 &&
     aLastIndex === bLastIndex &&
     isSameRouteRecord(a.matched[aLastIndex], b.matched[bLastIndex]) &&
+    (a.basePath || '') === (b.basePath || '') &&
     isSameRouteLocationParams(a.params, b.params) &&
     stringifyQuery(a.query) === stringifyQuery(b.query) &&
     a.hash === b.hash
@@ -306,6 +307,7 @@ export function resolveRelativePath(to: string, from: string): string {
  * ```
  */
 export const START_LOCATION_NORMALIZED: RouteLocationNormalizedLoaded = {
+  basePath: '',
   path: '/',
   // TODO: could we use a symbol in the future?
   name: undefined,

--- a/packages/router/src/types/index.ts
+++ b/packages/router/src/types/index.ts
@@ -155,6 +155,10 @@ export interface _RouteLocationBase extends Pick<
   'name' | 'path' | 'params' | 'meta'
 > {
   /**
+   * Runtime base path used to expose the route in the URL.
+   */
+  basePath?: string
+  /**
    * The whole location including the `search` and `hash`. This string is
    * percentage encoded.
    */


### PR DESCRIPTION
## Summary
This PR adds runtime `basePath` support to the router, allowing apps to expose path-prefixed URLs without changing route records.

This is especially valuable for **multi-tenant by path** scenarios (e.g. `/acme`, `/globex`).

## What Changed
1. Added `basePath?: string` to `RouterOptions`.
2. Added runtime API on `Router`:
   - `router.basePath` (getter/setter)
   - `router.setBasePath(basePath)`
   - `router.getBasePath()`
3. Added `route.basePath` to resolved/current route objects.
4. Updated duplicated-navigation logic to consider `basePath`.
5. Kept hooks compatible:
   - `normalizeLocationPath(path)`
   - `transformFullPath(fullPath)`

## Behavior
1. Route matching still runs on clean internal paths.
2. `resolve().href` and `resolve().fullPath` include current `basePath`.
3. Prefixing is idempotent (no double prefix).
4. Runtime `basePath` switching works without recreating router.
5. Root path is normalized correctly (`/` + `/acme` => `/acme`, not `/acme/`).

## Why This Is Useful
For path-based multi-tenancy, routes can remain standard (`/dashboard`, `/users/:id`) while public URLs become tenant-aware (`/acme/dashboard`) at runtime, including programmatic navigation and link resolution.

## Hooks Notes
1. `normalizeLocationPath` is applied in the matching pipeline (after built-in basePath stripping).
2. `transformFullPath` is applied in the public URL pipeline (after built-in basePath application).
3. Both remain optional and backward-compatible.

## Tests
Covered and validated:
1. Resolve with and without prefix.
2. Push/replace idempotency.
3. Runtime `basePath` updates.
4. `route.basePath` exposure.
5. No duplicated-navigation false positive when only `basePath` changes.
6. Root path behavior with base path.

## Playground
Updated playground to start with no `basePath` and provide UI controls to set/clear `basePath` while preserving current route, query, and hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime base path management to the router with ability to get and set the base path dynamically.
  * New UI controls in the playground app to display, modify, and manage the router base path with Apply and Clear actions.
  * Added support for path normalization and full path transformation to enable multi-tenant routing scenarios.

* **Tests**
  * Added comprehensive test coverage for multi-tenant and base path features in the router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->