### PR TITLE
fix(unplugin): generate param types from override paths and stop inheritance on absolute overrides

### DIFF
--- a/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
@@ -463,6 +463,55 @@ describe('generateRouteNamedMap', () => {
     `)
   })
 
+  it('types params added by a path override', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    const node = tree.insert('users/profile', 'users/profile.vue')
+    node.value.setOverride('users/profile', { path: '/users/:id' })
+    expect(
+      formatExports(generateRouteNamedMap(tree, DEFAULT_OPTIONS, new Map()))
+    ).toMatchInlineSnapshot(`
+      "export interface RouteNamedMap {
+        '/users/profile': RouteRecordInfo<
+          '/users/profile',
+          '/users/:id',
+          { id: ParamValue<true> },
+          { id: ParamValue<false> },
+          | never
+        >,
+      }"
+    `)
+  })
+
+  it('does not inherit parent params on an absolute path override', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    tree.insert('org/[orgId]', 'org/[orgId].vue')
+    const child = tree.insert(
+      'org/[orgId]/dashboard',
+      'org/[orgId]/dashboard.vue'
+    )
+    child.value.setOverride('org/[orgId]/dashboard', { path: '/dash/:id' })
+    expect(
+      formatExports(generateRouteNamedMap(tree, DEFAULT_OPTIONS, new Map()))
+    ).toMatchInlineSnapshot(`
+      "export interface RouteNamedMap {
+        '/org/[orgId]': RouteRecordInfo<
+          '/org/[orgId]',
+          '/org/:orgId',
+          { orgId: ParamValue<true> },
+          { orgId: ParamValue<false> },
+          | '/org/[orgId]/dashboard'
+        >,
+        '/org/[orgId]/dashboard': RouteRecordInfo<
+          '/org/[orgId]/dashboard',
+          '/dash/:id',
+          { id: ParamValue<true> },
+          { id: ParamValue<false> },
+          | never
+        >,
+      }"
+    `)
+  })
+
   it('adds children route names', () => {
     const tree = new PrefixTree(DEFAULT_OPTIONS)
     tree.insert('parent', 'parent.vue')

--- a/packages/router/src/unplugin/codegen/generateRouteResolver.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteResolver.spec.ts
@@ -1419,6 +1419,90 @@ describe('generateRouteResolver', () => {
     expect(resolver).toMatchSnapshot()
   })
 
+  describe('path overrides', () => {
+    // FIXME: `node.regexp` and `node.matcherPatternPathDynamicParts` are built
+    // from the file segments and ignore `overrides.path`, while
+    // `node.pathParams` follows the override. `MatcherPatternPathDynamic`
+    // consumes them positionally, so they disagree today. The snapshots below
+    // are the wanted output and are marked as failing until the matcher honors
+    // overrides.
+    it.todo('builds the matcher regexp from an absolute path override', () => {
+      const tree = new PrefixTree(DEFAULT_OPTIONS)
+      const node = tree.insert('shop/[id]', 'shop/[id].vue')
+      node.value.setOverride('shop/[id]', { path: '/store/:slug' })
+
+      // the regexp still matches `/shop/:id` while the param is named `slug`
+      expect(
+        generateRouteResolver(
+          tree,
+          DEFAULT_OPTIONS,
+          new ImportsMap(),
+          new Map()
+        )
+        // FIXME: should the name change and be similar to the path?
+      ).toMatchInlineSnapshot(`
+        "
+        const __route_0 = normalizeRouteRecord({
+          name: '/shop/[id]',
+          path: new MatcherPatternPathDynamic(
+            /^\\/store\\/([^/]+?)$/i,
+            {
+              slug: [/* no parser */],
+            },
+            ["store",1],
+            /* trailingSlash */
+          ),
+          components: {
+            'default': () => import('shop/[id].vue')
+          },
+        })
+
+        export const resolver = createFixedResolver([
+          __route_0,  // /store/:slug
+        ])
+        "
+      `)
+    })
+
+    it.todo('builds one capture group per param of the override path', () => {
+      const tree = new PrefixTree(DEFAULT_OPTIONS)
+      const node = tree.insert('shop/[id]', 'shop/[id].vue')
+      node.value.setOverride('shop/[id]', { path: '/shop/:a/:b' })
+
+      // two params for a single capture group
+      expect(
+        generateRouteResolver(
+          tree,
+          DEFAULT_OPTIONS,
+          new ImportsMap(),
+          new Map()
+        )
+      ).toMatchInlineSnapshot(`
+        "
+        const __route_0 = normalizeRouteRecord({
+          name: '/shop/[id]',
+          path: new MatcherPatternPathDynamic(
+            /^\\/shop\\/([^/]+?)\\/([^/]+?)$/i,
+            {
+              a: [/* no parser */],
+              b: [/* no parser */],
+            },
+            ["shop",1,1],
+            /* trailingSlash */
+          ),
+          components: {
+            'default': () => import('shop/[id].vue')
+          },
+        })
+
+        export const resolver = createFixedResolver([
+          __route_0,  // /shop/:a/:b
+        ])
+        "
+      `)
+    })
+  })
+
   describe('aliases', () => {
     it('generates alias records for static alias paths', () => {
       const tree = new PrefixTree(DEFAULT_OPTIONS)

--- a/packages/router/src/unplugin/codegen/generateRouteResolver.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteResolver.ts
@@ -325,7 +325,7 @@ function generatePathCode(
     ${node.regexp},
     ${generatePathParamsOptions(params, importsMap, paramParsersMap)},
     ${JSON.stringify(node.matcherPatternPathDynamicParts)},
-    ${node.isSplat ? 'null,' : '/* trailingSlash */'}
+    ${node.endsWithSplat ? 'null,' : '/* trailingSlash */'}
   ),`
   } else {
     return `path: new MatcherPatternPathStatic(${toStringLiteral(node.fullPath)}),`

--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -727,6 +727,141 @@ describe('Tree', () => {
     } satisfies Partial<TreePathParam>)
   })
 
+  describe('path override and params extraction', () => {
+    it('reproduces missing params from custom path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('users/profile', 'users/profile.vue')
+
+      node.setCustomRouteBlock('users/profile.vue', {
+        path: '/users/:id',
+      })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual(['id'])
+    })
+
+    it('preserves parser, optional, repeatable, and splat metadata from custom path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('x/y', 'x/y.vue')
+      node.setCustomRouteBlock('x/y.vue', {
+        path: '/docs/:chapters+/:tags*/:path(.*)',
+        params: {
+          path: {
+            chapters: 'int',
+          },
+        },
+      })
+
+      expect(node.pathParams).toEqual([
+        expect.objectContaining({
+          paramName: 'chapters',
+          parser: 'int',
+          modifier: '+',
+          optional: false,
+          repeatable: true,
+          isSplat: false,
+        }),
+        expect.objectContaining({
+          paramName: 'tags',
+          modifier: '*',
+          optional: true,
+          repeatable: true,
+          isSplat: false,
+        }),
+        expect.objectContaining({
+          paramName: 'path',
+          modifier: '',
+          optional: false,
+          repeatable: false,
+          isSplat: true,
+        }),
+      ])
+    })
+
+    it('uses absolute path overrides as param inheritance boundaries', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      const parent = tree.insert('org/[orgId]', 'org/[orgId].vue')
+      parent.setCustomRouteBlock('org/[orgId].vue', {
+        params: {
+          query: {
+            q: {},
+          },
+        },
+      })
+
+      const absoluteChild = tree.insert(
+        'org/[orgId]/dashboard',
+        'org/[orgId]/dashboard.vue'
+      )
+      absoluteChild.setCustomRouteBlock('org/[orgId]/dashboard.vue', {
+        path: '/dash/:id',
+        params: {
+          query: {
+            tab: {},
+          },
+        },
+      })
+
+      const relativeChild = tree.insert(
+        'org/[orgId]/reports',
+        'org/[orgId]/reports.vue'
+      )
+      relativeChild.setCustomRouteBlock('org/[orgId]/reports.vue', {
+        path: ':id',
+        params: {
+          query: {
+            tab: {},
+          },
+        },
+      })
+
+      const middle = tree.insert(
+        'org/[orgId]/projects/[projectId]',
+        'org/[orgId]/projects/[projectId].vue'
+      )
+      middle.setCustomRouteBlock('org/[orgId]/projects/[projectId].vue', {
+        path: '/p/:projectId',
+        params: {
+          query: {
+            page: {},
+          },
+        },
+      })
+
+      const leaf = tree.insert(
+        'org/[orgId]/projects/[projectId]/settings/[section]',
+        'org/[orgId]/projects/[projectId]/settings/[section].vue'
+      )
+
+      expect(absoluteChild.pathParams.map(param => param.paramName)).toEqual([
+        'id',
+      ])
+      expect(absoluteChild.params.map(param => param.paramName)).toEqual([
+        'id',
+        'tab',
+      ])
+      expect(relativeChild.pathParams.map(param => param.paramName)).toEqual([
+        'orgId',
+        'id',
+      ])
+      expect(relativeChild.params.map(param => param.paramName)).toEqual([
+        'orgId',
+        'q',
+        'id',
+        'tab',
+      ])
+      expect(leaf.pathParams.map(param => param.paramName)).toEqual([
+        'projectId',
+        'section',
+      ])
+      expect(leaf.params.map(param => param.paramName)).toEqual([
+        'projectId',
+        'page',
+        'section',
+      ])
+    })
+  })
+
   it('removes trailing slash from path but not from name', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
     tree.insert('a/index', 'a/index.vue')

--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -735,6 +735,141 @@ describe('Tree', () => {
     } satisfies Partial<TreePathParam>)
   })
 
+  describe('path override and params extraction', () => {
+    it('reproduces missing params from custom path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('users/profile', 'users/profile.vue')
+
+      node.setCustomRouteBlock('users/profile.vue', {
+        path: '/users/:id',
+      })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual(['id'])
+    })
+
+    it('preserves parser, optional, repeatable, and splat metadata from custom path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('x/y', 'x/y.vue')
+      node.setCustomRouteBlock('x/y.vue', {
+        path: '/docs/:chapters+/:tags*/:path(.*)',
+        params: {
+          path: {
+            chapters: 'int',
+          },
+        },
+      })
+
+      expect(node.pathParams).toEqual([
+        expect.objectContaining({
+          paramName: 'chapters',
+          parser: 'int',
+          modifier: '+',
+          optional: false,
+          repeatable: true,
+          isSplat: false,
+        }),
+        expect.objectContaining({
+          paramName: 'tags',
+          modifier: '*',
+          optional: true,
+          repeatable: true,
+          isSplat: false,
+        }),
+        expect.objectContaining({
+          paramName: 'path',
+          modifier: '',
+          optional: false,
+          repeatable: false,
+          isSplat: true,
+        }),
+      ])
+    })
+
+    it('uses absolute path overrides as param inheritance boundaries', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      const parent = tree.insert('org/[orgId]', 'org/[orgId].vue')
+      parent.setCustomRouteBlock('org/[orgId].vue', {
+        params: {
+          query: {
+            q: {},
+          },
+        },
+      })
+
+      const absoluteChild = tree.insert(
+        'org/[orgId]/dashboard',
+        'org/[orgId]/dashboard.vue'
+      )
+      absoluteChild.setCustomRouteBlock('org/[orgId]/dashboard.vue', {
+        path: '/dash/:id',
+        params: {
+          query: {
+            tab: {},
+          },
+        },
+      })
+
+      const relativeChild = tree.insert(
+        'org/[orgId]/reports',
+        'org/[orgId]/reports.vue'
+      )
+      relativeChild.setCustomRouteBlock('org/[orgId]/reports.vue', {
+        path: ':id',
+        params: {
+          query: {
+            tab: {},
+          },
+        },
+      })
+
+      const middle = tree.insert(
+        'org/[orgId]/projects/[projectId]',
+        'org/[orgId]/projects/[projectId].vue'
+      )
+      middle.setCustomRouteBlock('org/[orgId]/projects/[projectId].vue', {
+        path: '/p/:projectId',
+        params: {
+          query: {
+            page: {},
+          },
+        },
+      })
+
+      const leaf = tree.insert(
+        'org/[orgId]/projects/[projectId]/settings/[section]',
+        'org/[orgId]/projects/[projectId]/settings/[section].vue'
+      )
+
+      expect(absoluteChild.pathParams.map(param => param.paramName)).toEqual([
+        'id',
+      ])
+      expect(absoluteChild.params.map(param => param.paramName)).toEqual([
+        'id',
+        'tab',
+      ])
+      expect(relativeChild.pathParams.map(param => param.paramName)).toEqual([
+        'orgId',
+        'id',
+      ])
+      expect(relativeChild.params.map(param => param.paramName)).toEqual([
+        'orgId',
+        'q',
+        'id',
+        'tab',
+      ])
+      expect(leaf.pathParams.map(param => param.paramName)).toEqual([
+        'projectId',
+        'section',
+      ])
+      expect(leaf.params.map(param => param.paramName)).toEqual([
+        'projectId',
+        'page',
+        'section',
+      ])
+    })
+  })
+
   it('removes trailing slash from path but not from name', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
     tree.insert('a/index', 'a/index.vue')

--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -736,7 +736,7 @@ describe('Tree', () => {
   })
 
   describe('path override and params extraction', () => {
-    it('reproduces missing params from custom path override', () => {
+    it('extracts params from a custom path override', () => {
       const tree = new PrefixTree(RESOLVED_OPTIONS)
       const node = tree.insert('users/profile', 'users/profile.vue')
 
@@ -745,6 +745,123 @@ describe('Tree', () => {
       })
 
       expect(node.pathParams.map(param => param.paramName)).toEqual(['id'])
+      expect(node.params.map(param => param.paramName)).toEqual(['id'])
+    })
+
+    it('extracts multiple params from a single override segment', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('users/profile', 'users/profile.vue')
+
+      node.setCustomRouteBlock('users/profile.vue', {
+        path: '/users/:id-:slug',
+      })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual([
+        'id',
+        'slug',
+      ])
+    })
+
+    it('has no params when the override path removes them', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('[id]', '[id].vue')
+
+      node.setCustomRouteBlock('[id].vue', {
+        path: '/static',
+      })
+
+      expect(node.pathParams).toEqual([])
+    })
+
+    // NOTE: redeclaring a parent param in a relative override is invalid: it
+    // currently yields the param twice (a duplicated key in the generated
+    // types) instead of warning and keeping one. Might not be worth
+    // implementing, the case is unlikely to happen
+    it.todo('warns and keeps one param when a relative override redeclares a parent param', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('[a]', '[a].vue')
+      const node = tree.insert('[a]/b', '[a]/b.vue')
+      node.setCustomRouteBlock('[a]/b.vue', { path: ':a' })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual(['a'])
+      expect(`param "a" is declared twice`).toHaveBeenWarned()
+    })
+
+    it('keeps parent params on a static relative override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+      const node = tree.insert('org/[orgId]/dashboard', 'dashboard.vue')
+      node.setCustomRouteBlock('dashboard.vue', { path: 'overview' })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual(['orgId'])
+      expect(node.fullPath).toBe('/org/:orgId/overview')
+    })
+
+    it('adds the params of a relative override to the parent ones', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+      const node = tree.insert('org/[orgId]/reports', 'reports.vue')
+      node.setCustomRouteBlock('reports.vue', { path: ':year/:month' })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual([
+        'orgId',
+        'year',
+        'month',
+      ])
+      expect(node.fullPath).toBe('/org/:orgId/:year/:month')
+    })
+
+    it('replaces its own param with the one of a relative override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+      const node = tree.insert('org/[orgId]/[id]', '[id].vue')
+      node.setCustomRouteBlock('[id].vue', { path: ':slug' })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual([
+        'orgId',
+        'slug',
+      ])
+    })
+
+    it('drops its own param when a relative override is static', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+      const node = tree.insert('org/[orgId]/[id]', '[id].vue')
+      node.setCustomRouteBlock('[id].vue', { path: 'latest' })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual(['orgId'])
+    })
+
+    it('keeps params of all ancestors on a relative override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+      tree.insert('org/[orgId]/projects/[projectId]', '[projectId].vue')
+      const node = tree.insert(
+        'org/[orgId]/projects/[projectId]/settings',
+        'settings.vue'
+      )
+      node.setCustomRouteBlock('settings.vue', { path: 'config/:section' })
+
+      expect(node.pathParams.map(param => param.paramName)).toEqual([
+        'orgId',
+        'projectId',
+        'section',
+      ])
+    })
+
+    it('keeps parent params when a relative override adds a parser', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+      const node = tree.insert('org/[orgId]/posts', 'posts.vue')
+      node.setCustomRouteBlock('posts.vue', {
+        path: ':page',
+        params: { path: { page: 'int' } },
+      })
+
+      expect(node.pathParams).toEqual([
+        expect.objectContaining({ paramName: 'orgId', parser: null }),
+        expect.objectContaining({ paramName: 'page', parser: 'int' }),
+      ])
     })
 
     it('preserves parser, optional, repeatable, and splat metadata from custom path override', () => {
@@ -785,7 +902,25 @@ describe('Tree', () => {
       ])
     })
 
-    it('uses absolute path overrides as param inheritance boundaries', () => {
+    it('stops inheriting parent path params on an absolute path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+
+      const child = tree.insert(
+        'org/[orgId]/dashboard',
+        'org/[orgId]/dashboard.vue'
+      )
+      child.setCustomRouteBlock('org/[orgId]/dashboard.vue', {
+        path: '/dash/:id',
+      })
+
+      // `orgId` cannot be reached from `/dash/:id`
+      expect(child.pathParams.map(param => param.paramName)).toEqual(['id'])
+      expect(child.params.map(param => param.paramName)).toEqual(['id'])
+    })
+
+    it('inherits parent query params', () => {
       const tree = new PrefixTree(RESOLVED_OPTIONS)
 
       const parent = tree.insert('org/[orgId]', 'org/[orgId].vue')
@@ -797,11 +932,44 @@ describe('Tree', () => {
         },
       })
 
-      const absoluteChild = tree.insert(
+      const child = tree.insert(
         'org/[orgId]/dashboard',
         'org/[orgId]/dashboard.vue'
       )
-      absoluteChild.setCustomRouteBlock('org/[orgId]/dashboard.vue', {
+      child.setCustomRouteBlock('org/[orgId]/dashboard.vue', {
+        params: {
+          query: {
+            tab: {},
+          },
+        },
+      })
+
+      expect(child.params.map(param => param.paramName)).toEqual([
+        'orgId',
+        'q',
+        'tab',
+      ])
+    })
+
+    // query params are matched for the whole chain of records, so `q` survives
+    // an absolute override: only path param inheritance stops at the boundary
+    it('inherits parent query params across an absolute path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      const parent = tree.insert('org/[orgId]', 'org/[orgId].vue')
+      parent.setCustomRouteBlock('org/[orgId].vue', {
+        params: {
+          query: {
+            q: {},
+          },
+        },
+      })
+
+      const child = tree.insert(
+        'org/[orgId]/dashboard',
+        'org/[orgId]/dashboard.vue'
+      )
+      child.setCustomRouteBlock('org/[orgId]/dashboard.vue', {
         path: '/dash/:id',
         params: {
           query: {
@@ -810,11 +978,36 @@ describe('Tree', () => {
         },
       })
 
-      const relativeChild = tree.insert(
+      // `orgId` is gone with the path, but the parent record is still matched
+      // so its query params still apply
+      expect(child.params.map(param => param.paramName)).toEqual([
+        'id',
+        'q',
+        'tab',
+      ])
+      expect(child.queryParams.map(param => param.paramName)).toEqual([
+        'q',
+        'tab',
+      ])
+    })
+
+    it('keeps inheriting parent params on a relative path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      const parent = tree.insert('org/[orgId]', 'org/[orgId].vue')
+      parent.setCustomRouteBlock('org/[orgId].vue', {
+        params: {
+          query: {
+            q: {},
+          },
+        },
+      })
+
+      const child = tree.insert(
         'org/[orgId]/reports',
         'org/[orgId]/reports.vue'
       )
-      relativeChild.setCustomRouteBlock('org/[orgId]/reports.vue', {
+      child.setCustomRouteBlock('org/[orgId]/reports.vue', {
         path: ':id',
         params: {
           query: {
@@ -823,17 +1016,30 @@ describe('Tree', () => {
         },
       })
 
+      expect(child.pathParams.map(param => param.paramName)).toEqual([
+        'orgId',
+        'id',
+      ])
+      // `params` groups all path params before the query ones
+      expect(child.params.map(param => param.paramName)).toEqual([
+        'orgId',
+        'id',
+        'q',
+        'tab',
+      ])
+    })
+
+    it('stops at the closest ancestor with an absolute path override', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      tree.insert('org/[orgId]', 'org/[orgId].vue')
+
       const middle = tree.insert(
         'org/[orgId]/projects/[projectId]',
         'org/[orgId]/projects/[projectId].vue'
       )
       middle.setCustomRouteBlock('org/[orgId]/projects/[projectId].vue', {
         path: '/p/:projectId',
-        params: {
-          query: {
-            page: {},
-          },
-        },
       })
 
       const leaf = tree.insert(
@@ -841,30 +1047,9 @@ describe('Tree', () => {
         'org/[orgId]/projects/[projectId]/settings/[section].vue'
       )
 
-      expect(absoluteChild.pathParams.map(param => param.paramName)).toEqual([
-        'id',
-      ])
-      expect(absoluteChild.params.map(param => param.paramName)).toEqual([
-        'id',
-        'tab',
-      ])
-      expect(relativeChild.pathParams.map(param => param.paramName)).toEqual([
-        'orgId',
-        'id',
-      ])
-      expect(relativeChild.params.map(param => param.paramName)).toEqual([
-        'orgId',
-        'q',
-        'id',
-        'tab',
-      ])
+      // `orgId` is left out: it is above the `/p/:projectId` boundary
       expect(leaf.pathParams.map(param => param.paramName)).toEqual([
         'projectId',
-        'section',
-      ])
-      expect(leaf.params.map(param => param.paramName)).toEqual([
-        'projectId',
-        'page',
         'section',
       ])
     })
@@ -1223,6 +1408,41 @@ describe('Tree', () => {
     })
   })
 
+  describe('endsWithSplat', () => {
+    function checkEndsWithSplat(path: string, expected: boolean) {
+      const node = new PrefixTree(RESOLVED_OPTIONS).insert(path, path + '.vue')
+      expect(node.endsWithSplat).toBe(expected)
+    }
+
+    it('is true for a splat segment', () => {
+      checkEndsWithSplat('[...path]', true)
+      checkEndsWithSplat('a/[...path]', true)
+    })
+
+    it('is true when a static sub segment precedes the splat', () => {
+      checkEndsWithSplat('prefix-[...path]', true)
+    })
+
+    it('is false when a static sub segment follows the splat', () => {
+      checkEndsWithSplat('[...path]-end', false)
+    })
+
+    it('is false when a param sub segment follows the splat', () => {
+      checkEndsWithSplat('[...path]-[id]', false)
+    })
+
+    it('is false for a child of a splat segment', () => {
+      checkEndsWithSplat('[...path]/other', false)
+      checkEndsWithSplat('[...path]/[id]', false)
+    })
+
+    it('is false without a splat', () => {
+      checkEndsWithSplat('about', false)
+      checkEndsWithSplat('[id]', false)
+      checkEndsWithSplat('[id]+', false)
+    })
+  })
+
   // TODO: check warns with different order
   it.todo(`warns when a group's path conflicts with an existing file`)
 
@@ -1396,6 +1616,17 @@ describe('Tree', () => {
         paramName: 'when',
         parser: 'date',
       })
+      expect('VUE_ROUTER_B0021').toHaveBeenWarned()
+    })
+
+    it('does not warn when only the filename declares a parser', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const node = tree.insert('events/[when=int]', 'events/[when=int].vue')
+
+      expect(node.pathParams).toEqual([
+        expect.objectContaining({ paramName: 'when', parser: 'int' }),
+      ])
+      expect('VUE_ROUTER_B0021').not.toHaveBeenWarned()
     })
 
     it('leaves untouched path params when override only mentions some', () => {

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -3,6 +3,7 @@ import {
   CONVENTION_OVERRIDE_NAME,
   createTreeNodeValue,
   escapeRegex,
+  isTreePathParam,
   type TreeNodeValueOptions,
   type TreePathParam,
   type TreeQueryParam,
@@ -370,10 +371,17 @@ export class TreeNode {
    */
   get params(): (TreePathParam | TreeQueryParam)[] {
     const params = [...this.value.params]
+    if (this.value.overrides.path?.startsWith('/')) {
+      return params
+    }
+
     let node = this.parent
     // add all the params from the parents
     while (node) {
       params.unshift(...node.value.params)
+      if (node.value.overrides.path?.startsWith('/')) {
+        break
+      }
       node = node.parent
     }
 
@@ -384,12 +392,17 @@ export class TreeNode {
    * Array of route params coming from the path. It includes all the params from the parents as well.
    */
   get pathParams(): TreePathParam[] {
-    const params = this.value.isParam() ? [...this.value.pathParams] : []
+    const params = this.value.params.filter(isTreePathParam)
+    if (this.value.overrides.path?.startsWith('/')) {
+      return params
+    }
+
     let node = this.parent
     // add all the params from the parents
     while (node) {
-      if (node.value.isParam()) {
-        params.unshift(...node.value.pathParams)
+      params.unshift(...node.value.params.filter(isTreePathParam))
+      if (node.value.overrides.path?.startsWith('/')) {
+        break
       }
       node = node.parent
     }

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -3,6 +3,7 @@ import {
   CONVENTION_OVERRIDE_NAME,
   createTreeNodeValue,
   escapeRegex,
+  isTreePathParam,
   type TreeNodeValueOptions,
   type TreePathParam,
   type TreeQueryParam,
@@ -378,12 +379,17 @@ export class TreeNode {
    * declared by this specific node.
    */
   get pathParams(): TreePathParam[] {
-    const params = this.value.isParam() ? [...this.value.pathParams] : []
+    const params = this.value.params.filter(isTreePathParam)
+    if (this.value.overrides.path?.startsWith('/')) {
+      return params
+    }
+
     let node = this.parent
     // add all the params from the parents
     while (node) {
-      if (node.value.isParam()) {
-        params.unshift(...node.value.pathParams)
+      params.unshift(...node.value.params.filter(isTreePathParam))
+      if (node.value.overrides.path?.startsWith('/')) {
+        break
       }
       node = node.parent
     }

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -379,7 +379,7 @@ export class TreeNode {
    * declared by this specific node.
    */
   get pathParams(): TreePathParam[] {
-    const params = this.value.params.filter(isTreePathParam)
+    const params = this.value.pathParams
     if (this.value.overrides.path?.startsWith('/')) {
       return params
     }
@@ -387,7 +387,8 @@ export class TreeNode {
     let node = this.parent
     // add all the params from the parents
     while (node) {
-      params.unshift(...node.value.params.filter(isTreePathParam))
+      params.unshift(...node.value.pathParams)
+      // an absolute path drops everything above it from the url
       if (node.value.overrides.path?.startsWith('/')) {
         break
       }
@@ -484,10 +485,13 @@ export class TreeNode {
   }
 
   /**
-   * Is this node a splat (catch-all) param
+   * True if the last segment of the path is a splat (catch-all) param e.g.
+   * /some/thing/:path(.*). Useful to compute the trailing slash behavior of
+   * the route.
    */
-  get isSplat(): boolean {
-    return this.value.isParam() && this.value.pathParams.some(p => p.isSplat)
+  get endsWithSplat(): boolean {
+    const lastSegment = this.value.subSegments.at(-1)
+    return !!lastSegment && isTreePathParam(lastSegment) && lastSegment.isSplat
   }
 
   /**

--- a/packages/router/src/unplugin/core/treeNodeValue.ts
+++ b/packages/router/src/unplugin/core/treeNodeValue.ts
@@ -19,7 +19,7 @@ const RE_HEX_CHARS = /^[0-9a-fA-F]{2}$/
  */
 export type RouteRecordOverride = CustomRouteBlock
 
-export type SubSegment = string | TreePathParam
+export type PathSubSegment = string | TreePathParam
 
 // internal name used for overrides set by file-based conventions (e.g. _parent)
 export const CONVENTION_OVERRIDE_NAME = '@@convention'
@@ -47,13 +47,19 @@ class _TreeNodeValueBase {
   /**
    * Array of sub segments. This is usually one single elements but can have more for paths like `prefix-[param]-end.vue`
    */
-  subSegments: SubSegment[]
+  subSegments: PathSubSegment[]
 
   /**
    * Overrides defined by each file. The map is necessary to handle named views.
    */
   private _overrides = new Map<string, RouteRecordOverride>()
   // TODO: measure perf bottlenecks with large trees and use caching if it can potentially improve
+
+  /**
+   * Params already warned about declaring a parser twice, so the warning is
+   * emitted once per param even though `pathParams` is a getter.
+   */
+  private _warnedParsers = new Set<string>()
 
   /**
    * View name (Vue Router feature) mapped to their corresponding file. By default, the view name is `default` unless
@@ -65,7 +71,7 @@ class _TreeNodeValueBase {
     rawSegment: string,
     parent: TreeNodeValue | undefined,
     pathSegment: string = rawSegment,
-    subSegments: SubSegment[] = [pathSegment]
+    subSegments: PathSubSegment[] = [pathSegment]
   ) {
     // type should be defined in child
     this._type = 0
@@ -143,36 +149,54 @@ class _TreeNodeValueBase {
    * does not include params from parent nodes.
    */
   get params(): (TreePathParam | TreeQueryParam)[] {
-    return [...this.getPathParams(), ...this.queryParams]
+    return [...this.pathParams, ...this.queryParams]
   }
 
   /**
-   * Gets all path params for the node, including params defined in path overrides.
+   * Gets the path params for the node. They come from the `path` override when
+   * there is one, otherwise from the file based segment. Parsers declared in
+   * `params.path` are applied on top. This does not include params from parent
+   * nodes.
    */
-  getPathParams(): TreePathParam[] {
+  get pathParams(): TreePathParam[] {
     const overridePath = this.overrides.path
-
-    if (!overridePath) {
-      return this.isParam() ? [...this.pathParams] : []
-    }
-
-    const overrideParsers = this.overrides.params?.path ?? {}
     const params: TreePathParam[] = []
 
-    for (const segment of overridePath.split('/')) {
-      if (!segment) continue
-
-      const [, segmentParams] = parseRawPathSegment(segment)
-
-      for (const param of segmentParams) {
-        params.push({
-          ...param,
-          parser: overrideParsers[param.paramName] ?? param.parser,
-        })
+    if (overridePath) {
+      for (const segment of overridePath.split('/')) {
+        if (!segment) continue
+        const [, segmentParams] = parseRawPathSegment(segment)
+        params.push(...segmentParams)
       }
+    } else {
+      // the params are the same objects referenced by `subSegments`
+      params.push(...this.subSegments.filter(isTreePathParam))
     }
 
-    return params
+    const declaredParsers = this.overrides.params?.path
+    if (!declaredParsers) {
+      return params
+    }
+
+    return params.map(param => {
+      const parser = declaredParsers[param.paramName]
+      // an explicit `null` removes the parser declared in the file name
+      if (parser === undefined) {
+        return param
+      }
+
+      if (parser && param.parser && !this._warnedParsers.has(param.paramName)) {
+        this._warnedParsers.add(param.paramName)
+        diagnostics.VUE_ROUTER_B0021({
+          paramName: param.paramName,
+          segment: this.rawSegment,
+          filenameParser: param.parser,
+          declaredParser: parser,
+        })
+      }
+
+      return { ...param, parser }
+    })
   }
 
   toString(): string {
@@ -389,9 +413,9 @@ export function isTreeParamRepeatable(
  * @internal
  */
 export function isTreePathParam(
-  param: TreePathParam | TreeQueryParam
+  param: TreePathParam | TreeQueryParam | PathSubSegment
 ): param is TreePathParam {
-  return 'modifier' in param
+  return typeof param !== 'string' && 'modifier' in param
 }
 
 /**
@@ -418,10 +442,6 @@ export class TreeNodeValueParam extends _TreeNodeValueBase {
    *
    * @param parent The parent node in the tree, if any.
    *
-   * @param filenamePathParams Path params parsed from the file segment
-   * (filename convention). The public `pathParams` getter overlays
-   * `definePage()` parser overrides on top of these.
-   *
    * @param pathSegment The transformed version of the segment into a
    * vue-router path, e.g. `:id`, `prefix-:param-end`, etc.
    *
@@ -431,26 +451,10 @@ export class TreeNodeValueParam extends _TreeNodeValueBase {
   constructor(
     rawSegment: string,
     parent: TreeNodeValue | undefined,
-    private filenamePathParams: TreePathParam[],
     pathSegment: string,
-    subSegments: SubSegment[]
+    subSegments: PathSubSegment[]
   ) {
     super(rawSegment, parent, pathSegment, subSegments)
-  }
-
-  /**
-   * Path params for this node, with `definePage({ params: { path: ... } })`
-   * parser overrides applied on top of the filename-based parsers.
-   */
-  get pathParams(): TreePathParam[] {
-    const overridePath = this.overrides.params?.path
-    if (!overridePath) return this.filenamePathParams
-    return this.filenamePathParams.map(p =>
-      // an explicit `null` override removes the filename-based parser
-      overridePath[p.paramName] !== undefined
-        ? { ...p, parser: overridePath[p.paramName] }
-        : p
-    )
   }
 
   // Calculate score for each subsegment to handle mixed static/param parts
@@ -612,13 +616,8 @@ export function createTreeNodeValue(
         parseFileSegment(segment, options)
 
   if (pathParams.length) {
-    return new TreeNodeValueParam(
-      segment,
-      parent,
-      pathParams,
-      pathSegment,
-      subSegments
-    )
+    // the params are read back from `subSegments` by `pathParams`
+    return new TreeNodeValueParam(segment, parent, pathSegment, subSegments)
   }
 
   return new TreeNodeValueStatic(segment, parent, pathSegment)
@@ -659,13 +658,13 @@ const IS_VARIABLE_CHAR_RE = /[0-9a-zA-Z_]/
 function parseFileSegment(
   segment: string,
   { dotNesting }: ParseSegmentOptions
-): [string, TreePathParam[], SubSegment[]] {
+): [string, TreePathParam[], PathSubSegment[]] {
   let buffer = ''
   let paramParserBuffer = ''
   let state: ParseFileSegmentState = ParseFileSegmentState.static
   const params: TreePathParam[] = []
   let pathSegment = ''
-  const subSegments: SubSegment[] = []
+  const subSegments: PathSubSegment[] = []
   let currentTreeRouteParam: TreePathParam = createEmptyRouteParam()
 
   // position in segment
@@ -849,11 +848,11 @@ const IS_MODIFIER_RE = /[+*?]/
  */
 function parseRawPathSegment(
   segment: string
-): [string, TreePathParam[], SubSegment[]] {
+): [string, TreePathParam[], PathSubSegment[]] {
   let buffer = ''
   let state: ParseRawPathSegmentState = ParseRawPathSegmentState.static
   const params: TreePathParam[] = []
-  const subSegments: SubSegment[] = []
+  const subSegments: PathSubSegment[] = []
   let currentTreeRouteParam: TreePathParam = createEmptyRouteParam()
 
   // position in segment

--- a/packages/router/src/unplugin/core/treeNodeValue.ts
+++ b/packages/router/src/unplugin/core/treeNodeValue.ts
@@ -143,7 +143,36 @@ class _TreeNodeValueBase {
    * does not include params from parent nodes.
    */
   get params(): (TreePathParam | TreeQueryParam)[] {
-    return [...(this.isParam() ? this.pathParams : []), ...this.queryParams]
+    return [...this.getPathParams(), ...this.queryParams]
+  }
+
+  /**
+   * Gets all path params for the node, including params defined in path overrides.
+   */
+  getPathParams(): TreePathParam[] {
+    const overridePath = this.overrides.path
+
+    if (!overridePath) {
+      return this.isParam() ? [...this.pathParams] : []
+    }
+
+    const overrideParsers = this.overrides.params?.path ?? {}
+    const params: TreePathParam[] = []
+
+    for (const segment of overridePath.split('/')) {
+      if (!segment) continue
+
+      const [, segmentParams] = parseRawPathSegment(segment)
+
+      for (const param of segmentParams) {
+        params.push({
+          ...param,
+          parser: overrideParsers[param.paramName] ?? param.parser,
+        })
+      }
+    }
+
+    return params
   }
 
   toString(): string {

--- a/packages/router/src/unplugin/diagnostics.ts
+++ b/packages/router/src/unplugin/diagnostics.ts
@@ -79,6 +79,16 @@ export const diagnostics = /*#__PURE__*/ defineDiagnostics({
         `Invalid parameter in path "${p.segment}": parameter name cannot be empty. Using default name "pathMatch" for ':()'.`,
       fix: 'Give the parameter a name, e.g. ":id".',
     },
+    VUE_ROUTER_B0021: {
+      why: (p: {
+        paramName: string
+        segment: string
+        filenameParser: string
+        declaredParser: string
+      }) =>
+        `param "${p.paramName}" declares a parser twice in "${p.segment}": "${p.filenameParser}" in the file name and "${p.declaredParser}" in \`params.path\`. Keeping "${p.declaredParser}".`,
+      fix: 'Remove one of the two parsers.',
+    },
 
     // --- core/customBlock.ts ---
     VUE_ROUTER_B0012: {


### PR DESCRIPTION
I discovered this problem while migrating from `vite-plugin-pages`.

### Problem

When overriding route `path` via `<route>` or `definePage()`:

1. Params from the override path are not always reflected in generated types.
2. Absolute override paths (`/`-prefixed) can still inherit ancestor params/query in types, producing invalid keys.

### Solution

1. Infer path params directly from override `path`, including:
   - optional: `:id?`
   - repeatable: `:id+` / `:id*`
   - splat: `:id(.*)`
2. Apply `params.path` parser overrides to inferred params.
3. Treat absolute override paths as inheritance boundaries:
   - stop inheriting ancestor params/query above that node.
4. Keep relative override paths inheriting parent params/query as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Absolute path overrides now correctly exclude parent parameters, while relative overrides continue to inherit them.
  * Improved handling of multiple, optional, repeatable, query, and splat parameters in route paths.
  * Route matching now correctly identifies trailing splat segments, including nested routes.
  * Added a build-time warning when the same parameter parser is declared in both the filename and route configuration.

* **Tests**
  * Expanded coverage for path overrides, parameter inheritance, parser metadata, and splat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->