### PR TITLE
fix(matcher): finalize param token before processing escaped colon

### DIFF
--- a/packages/router/__tests__/matcher/pathParser.spec.ts
+++ b/packages/router/__tests__/matcher/pathParser.spec.ts
@@ -30,6 +30,58 @@ describe('Path parser', () => {
       ])
     })
 
+    it('escapes : after param', () => {
+      expect(tokenizePath('/:foo\\:abc')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'foo',
+            regexp: '',
+            repeatable: false,
+            optional: false,
+          },
+          { type: TokenType.Static, value: ':abc' },
+        ],
+      ])
+    })
+
+    it('escapes : after param with custom re', () => {
+      expect(tokenizePath('/:foo([^:]+)\\:abc')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'foo',
+            regexp: '[^:]+',
+            repeatable: false,
+            optional: false,
+          },
+          { type: TokenType.Static, value: ':abc' },
+        ],
+      ])
+    })
+
+    it('escapes : between two params', () => {
+      expect(tokenizePath('/:foo([^:]+)\\::bar')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'foo',
+            regexp: '[^:]+',
+            repeatable: false,
+            optional: false,
+          },
+          { type: TokenType.Static, value: ':' },
+          {
+            type: TokenType.Param,
+            value: 'bar',
+            regexp: '',
+            repeatable: false,
+            optional: false,
+          },
+        ],
+      ])
+    })
+
     // not sure how useful this is and if it's worth supporting because of the
     // cost to support the ranking as well
     it.skip('groups', () => {
@@ -805,6 +857,18 @@ describe('Path parser', () => {
       })
       matchParams('/one/:a*', '/one/two/three', {
         a: ['two', 'three'],
+      })
+    })
+
+    it('param followed by escaped colon and static', () => {
+      matchParams('/:foo\\:abc', '/section:abc', { foo: 'section' })
+      matchParams('/:foo\\:abc', '/sectionabc', null)
+    })
+
+    it('param with custom re followed by escaped colon and another param', () => {
+      matchParams('/:foo([^:]+)\\::bar', '/section:aaabbbccc', {
+        foo: 'section',
+        bar: 'aaabbbccc',
       })
     })
 

--- a/packages/router/__tests__/matcher/pathParser.spec.ts
+++ b/packages/router/__tests__/matcher/pathParser.spec.ts
@@ -45,6 +45,50 @@ describe('Path parser', () => {
       ])
     })
 
+    it('escapes ) inside custom re to allow nested groups', () => {
+      expect(tokenizePath('/:id((?:a-[^/]+\\)?)')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'id',
+            regexp: '(?:a-[^/]+)?',
+            repeatable: false,
+            optional: false,
+          },
+        ],
+      ])
+    })
+
+    it('escapes + after empty custom re', () => {
+      expect(tokenizePath('/:p()\\+')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'p',
+            regexp: '',
+            repeatable: false,
+            optional: false,
+          },
+          { type: TokenType.Static, value: '+' },
+        ],
+      ])
+    })
+
+    it('escapes + after param', () => {
+      expect(tokenizePath('/:p\\+')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'p',
+            regexp: '',
+            repeatable: false,
+            optional: false,
+          },
+          { type: TokenType.Static, value: '+' },
+        ],
+      ])
+    })
+
     it('escapes : after optional param with custom re', () => {
       expect(tokenizePath('/:foo([^:]+)?\\:abc')).toEqual([
         [
@@ -900,6 +944,12 @@ describe('Path parser', () => {
         foo: 'section',
         bar: 'aaabbbccc',
       })
+    })
+
+    it('escaped + becomes part of static path, not a repeat modifier', () => {
+      matchParams('/:p\\+', '/abc+', { p: 'abc' })
+      matchParams('/:p\\+', '/abc', null)
+      matchParams('/:p()\\+', '/abc+', { p: 'abc' })
     })
 
     // end of parsing urls

--- a/packages/router/__tests__/matcher/pathParser.spec.ts
+++ b/packages/router/__tests__/matcher/pathParser.spec.ts
@@ -30,6 +30,36 @@ describe('Path parser', () => {
       ])
     })
 
+    it('escapes non-colon char after param', () => {
+      expect(tokenizePath('/:foo\\-abc')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'foo',
+            regexp: '',
+            repeatable: false,
+            optional: false,
+          },
+          { type: TokenType.Static, value: '-abc' },
+        ],
+      ])
+    })
+
+    it('escapes : after optional param with custom re', () => {
+      expect(tokenizePath('/:foo([^:]+)?\\:abc')).toEqual([
+        [
+          {
+            type: TokenType.Param,
+            value: 'foo',
+            regexp: '[^:]+',
+            repeatable: false,
+            optional: true,
+          },
+          { type: TokenType.Static, value: ':abc' },
+        ],
+      ])
+    })
+
     it('escapes : after param', () => {
       expect(tokenizePath('/:foo\\:abc')).toEqual([
         [

--- a/packages/router/src/matcher/pathTokenizer.ts
+++ b/packages/router/src/matcher/pathTokenizer.ts
@@ -118,23 +118,12 @@ export function tokenizePath(path: string): Array<Token[]> {
   while (i < path.length) {
     char = path[i++]
 
-    if (char === '\\' && state !== TokenizerState.ParamRegExp) {
-      if (
-        state === TokenizerState.Param ||
-        state === TokenizerState.ParamRegExpEnd
-      ) {
-        consumeBuffer()
-        customRe = ''
-        state = TokenizerState.Static
-      }
-      previousState = state
-      state = TokenizerState.EscapeNext
-      continue
-    }
-
     switch (state) {
       case TokenizerState.Static:
-        if (char === '/') {
+        if (char === '\\') {
+          previousState = state
+          state = TokenizerState.EscapeNext
+        } else if (char === '/') {
           if (buffer) {
             consumeBuffer()
           }

--- a/packages/router/src/matcher/pathTokenizer.ts
+++ b/packages/router/src/matcher/pathTokenizer.ts
@@ -119,6 +119,14 @@ export function tokenizePath(path: string): Array<Token[]> {
     char = path[i++]
 
     if (char === '\\' && state !== TokenizerState.ParamRegExp) {
+      if (
+        state === TokenizerState.Param ||
+        state === TokenizerState.ParamRegExpEnd
+      ) {
+        consumeBuffer()
+        customRe = ''
+        state = TokenizerState.Static
+      }
       previousState = state
       state = TokenizerState.EscapeNext
       continue


### PR DESCRIPTION
fixes https://github.com/vuejs/router/issues/2517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of escaped special characters in route patterns so characters (e.g., +, -, :) following parameters are treated as literal static text rather than modifiers.

* **Tests**
  * Added extensive tests verifying tokenizer and matcher behavior for escape sequences, ensuring literal characters and parameter boundaries are preserved in URL matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->