### PR TITLE
docs: update installation guide

### DIFF
--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -52,6 +52,26 @@ const productionHead: HeadConfig[] = [
   ],
 ]
 
+const versionsCache: Record<string, string> = {}
+
+async function getPackageVersion(
+  packageName: string,
+  oldVersion: string | number
+) {
+  const majorVersion = String(oldVersion).replace(/\..*/, '')
+  const packagePath = `${packageName}@${majorVersion}`
+
+  if (!versionsCache[packagePath]) {
+    const url = `https://unpkg.com/${packagePath}/package.json`
+    console.log(`- Loading ${url}`)
+    const { version } = await fetch(url).then(resp => resp.json())
+    versionsCache[packagePath] = version
+    console.log(`- Loaded ${packageName}@${version}`)
+  }
+
+  return versionsCache[packagePath]
+}
+
 export const sharedConfig = defineConfig({
   title: 'Vue Router',
   appearance: 'dark',
@@ -139,6 +159,27 @@ export const sharedConfig = defineConfig({
     // analytics and other prod only head tags
     ...(isProduction ? productionHead : []),
   ],
+
+  async transformPageData(pageData) {
+    if (!process.env.NETLIFY) {
+      return
+    }
+
+    const { packageVersions } = pageData.frontmatter
+
+    if (pageData.frontmatter.packageVersions) {
+      console.log(
+        `Updating frontmatter package versions for ${pageData.filePath}`
+      )
+
+      for (const pkg in packageVersions) {
+        packageVersions[pkg] = await getPackageVersion(
+          pkg,
+          packageVersions[pkg]
+        )
+      }
+    }
+  },
 
   themeConfig: {
     logo: '/logo.svg',

--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -64,7 +64,20 @@ async function getPackageVersion(
   if (!versionsCache[packagePath]) {
     const url = `https://unpkg.com/${packagePath}/package.json`
     console.log(`- Loading ${url}`)
-    const { version } = await fetch(url).then(resp => resp.json())
+    const response = await fetch(url)
+
+    if (!response.ok) {
+      throw new Error(`Failed to load ${url}, status code ${response.status}`)
+    }
+
+    const { version } = await response.json()
+
+    if (!version || typeof version !== 'string') {
+      throw new Error(
+        `Failed to load version for ${packageName}, version ${version}`
+      )
+    }
+
     versionsCache[packagePath] = version
     console.log(`- Loaded ${packageName}@${version}`)
   }
@@ -167,7 +180,7 @@ export const sharedConfig = defineConfig({
 
     const { packageVersions } = pageData.frontmatter
 
-    if (pageData.frontmatter.packageVersions) {
+    if (packageVersions) {
       console.log(
         `Updating frontmatter package versions for ${pageData.filePath}`
       )

--- a/packages/docs/installation.md
+++ b/packages/docs/installation.md
@@ -1,3 +1,11 @@
+---
+# Updated automatically in Netlify builds: see the VitePress config.
+packageVersions:
+  vue: 3.5.28
+  vue-router: 5.0.2
+  '@vue/devtools-api': 8.0.6
+---
+
 # Installation
 
 <VueMasteryLogoLink></VueMasteryLogoLink>
@@ -9,19 +17,19 @@ If you have an existing project that uses a JavaScript package manager, you can 
 ::: code-group
 
 ```bash [npm]
-npm install vue-router@4
+npm install vue-router
 ```
 
 ```bash [yarn]
-yarn add vue-router@4
+yarn add vue-router
 ```
 
 ```bash [pnpm]
-pnpm add vue-router@4
+pnpm add vue-router
 ```
 
 ```bash [bun]
-bun add vue-router@4
+bun add vue-router
 ```
 
 :::
@@ -54,14 +62,53 @@ Projects using package managers will typically use ES modules to access Vue Rout
 
 ## Direct Download / CDN
 
-[https://unpkg.com/vue-router@4](https://unpkg.com/vue-router@4)
+If you don't want to use a bundler, you can instead load Vue Router directly into the browser, either via a CDN or by downloading the relevant files and hosting them yourself.
 
-<!--email_off-->
+Vue Router provides multiple pre-built files to cover a variety of use cases, similar to Vue. If you aren't already familiar with how Vue handles this, we recommend reading about that first:
 
-[Unpkg.com](https://unpkg.com) provides npm-based CDN links. The above link will always point to the latest release on npm. You can also use a specific version/tag via URLs like `https://unpkg.com/vue-router@4.0.15/dist/vue-router.global.js`.
+- <https://vuejs.org/guide/quick-start.html#using-vue-from-cdn>
 
-<!--/email_off-->
+Vue Router supports both **_ES module_** and **_global_** builds. We recommend using ES modules where possible.
 
-This will expose Vue Router via a global `VueRouter` object, e.g. `VueRouter.createRouter(...)`.
+Whichever approach you choose, it's important to pin versions for the libraries you're using, especially in production. This means you should include the exact version you want to use in the CDN URLs, rather than allowing the CDN to choose the latest version for you.
+
+Each build comes with a development and production version. The development versions are significantly larger but include extra code to aid with debugging. The production versions have `.prod` in their names.
+
+### Using ES modules
+
+```html-vue
+<script type="importmap">
+  {
+    "imports": {
+      "vue": "https://unpkg.com/vue@{{ $frontmatter.packageVersions.vue }}/dist/vue.esm-browser.js",
+      "vue-router": "https://unpkg.com/vue-router@{{ $frontmatter.packageVersions['vue-router'] }}/dist/vue-router.esm-browser.js",
+      "@vue/devtools-api": "https://unpkg.com/@vue/devtools-api@{{ $frontmatter.packageVersions['@vue/devtools-api'] }}/dist/vue-devtools-api.esm-browser.js"
+    }
+  }
+</script>
+<script type="module">
+  import { createApp } from 'vue'
+  import { createRouter } from 'vue-router'
+
+  // ...
+</script>
+```
+
+`@vue/devtools-api` is only needed when using the development build of Vue Router. It can be removed when using the production build, `vue-router.esm-browser.prod.js`.
+
+### Using the global build
+
+```html-vue
+<script src="https://unpkg.com/vue@{{ $frontmatter.packageVersions.vue }}/dist/vue.global.js"></script>
+<script src="https://unpkg.com/vue-router@{{ $frontmatter.packageVersions['vue-router'] }}/dist/vue-router.global.js"></script>
+<script>
+  const { createApp } = Vue
+  const { createRouter } = VueRouter
+
+  // ...
+</script>
+```
+
+The corresponding production build of Vue Router is called `vue-router.global.prod.js`.
 
 <RuleKitLink />


### PR DESCRIPTION
Update the **Installation** guide in the docs.

Some key changes:

- Update references to Vue Router 4 to either use version 5 or not explicitly include the version.
- Try to encourage the use of the ESM build for CDN users, rather than the global build.
- Explain the use of `.prod` builds.
- Encourage version pinning with CDNs.

While I wanted to encourage pinning versions, I didn't want to hardcode specific versions in the docs, as those will quickly get out of date. So I added some code to the VitePress config to automatically load the latest versions and inject them into the docs. Some notes on that:

- I wanted to ensure I was always showing the latest stable versions, not betas. To get that information I make requests to `unpkg.com`.
- I only load the latest versions during the Netlify build. Local builds will use fallback values included in the frontmatter of `installation.md`.
- If the docs are deployed immediately after a new version of Vue Router is released it might not yet be on `unpkg.com`, so it might be one version behind.
- I've tied the major version of each package to what's in the frontmatter. So, if any of these package release a new major version, that won't be picked up until we explicitly bump it in the frontmatter. For example, if `@vue/devtools-api` v9.0.0 is released that won't be picked up, which I think is what we'd want.
- The caching isn't strictly necessary, but once these changes are added to the Chinese docs it'll save requesting the versions multiple times.

You can see the relevant logging for this in the Netlify deployment logs for the PR:

- https://app.netlify.com/projects/vue-router/deploys/69b1f368d3d06200086d9e40#L220

The preview includes the latest version for those packages:

- https://deploy-preview-2659--vue-router.netlify.app/installation.html

The docs will fail to build if `unpkg.com` is inaccessible from Netlify, but deploying the docs is rarely urgent so I don't think that's a real concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Docs now auto-resolve and normalize package major versions during site builds on Netlify, ensuring examples reflect matched major releases.

* **Documentation**
  - Enhanced installation guide with improved CDN/direct-download guidance and explanations for ES module vs global builds.
  - Added comprehensive examples for ES modules, global builds, and import maps.
  - Switched package manager examples from pinned to unpinned versions and added best practices for pinning in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->