### PR TITLE
fix(query): use Object.create(null) to prevent prototype pollution

### DIFF
--- a/packages/router/src/experimental/data-loaders/defineColadaLoader.ts
+++ b/packages/router/src/experimental/data-loaders/defineColadaLoader.ts
@@ -43,7 +43,7 @@ import type {
 } from '../../typed-routes'
 import { useRoute, useRouter } from '../../useApi'
 import type { Router } from '../../router'
-import type { LocationQuery } from '../../query'
+import type { LocationQuery } from '../query'
 
 /**
  * Creates a Pinia Colada data loader with `data` is always defined.

--- a/packages/router/src/experimental/data-loaders/utils.ts
+++ b/packages/router/src/experimental/data-loaders/utils.ts
@@ -1,4 +1,4 @@
-import type { LocationQuery } from '../../query'
+import type { LocationQuery } from '../query'
 import type { Router } from '../../router'
 import type { RouteLocationNormalizedLoaded } from '../../typed-routes'
 import type { DataLoaderEntryBase, UseDataLoader } from './createDataLoader'

--- a/packages/router/src/experimental/location.spec.ts
+++ b/packages/router/src/experimental/location.spec.ts
@@ -1,0 +1,244 @@
+import { experimental_parseQuery as parseQuery } from './query'
+import { experimental_parseURL as originalParseURL } from './location'
+import { vi, describe, expect, it } from 'vitest'
+
+describe('parseURL', () => {
+  let parseURL = originalParseURL.bind(null, parseQuery)
+
+  it('works with no query no hash', () => {
+    expect(parseURL('/foo')).toEqual({
+      fullPath: '/foo',
+      path: '/foo',
+      hash: '',
+      query: {},
+    })
+  })
+
+  it('works with partial path with no query', () => {
+    expect(parseURL('foo#hash')).toEqual({
+      fullPath: '/foo#hash',
+      path: '/foo',
+      hash: '#hash',
+      query: {},
+    })
+  })
+
+  it('works with partial path', () => {
+    expect(parseURL('foo?f=foo#hash')).toEqual({
+      fullPath: '/foo?f=foo#hash',
+      path: '/foo',
+      hash: '#hash',
+      query: { f: 'foo' },
+    })
+  })
+
+  it('works with only query', () => {
+    expect(parseURL('?f=foo')).toEqual({
+      fullPath: '/?f=foo',
+      path: '/',
+      hash: '',
+      query: { f: 'foo' },
+    })
+  })
+
+  it('works with only hash', () => {
+    expect(parseURL('#foo')).toEqual({
+      fullPath: '/#foo',
+      path: '/',
+      hash: '#foo',
+      query: {},
+    })
+  })
+
+  it('works with partial path and current location', () => {
+    expect(parseURL('foo', '/parent/bar')).toEqual({
+      fullPath: '/parent/foo',
+      path: '/parent/foo',
+      hash: '',
+      query: {},
+    })
+  })
+
+  it('works with partial path with query and hash and current location', () => {
+    expect(parseURL('foo?f=foo#hash', '/parent/bar')).toEqual({
+      fullPath: '/parent/foo?f=foo#hash',
+      path: '/parent/foo',
+      hash: '#hash',
+      query: { f: 'foo' },
+    })
+  })
+
+  it('works with relative query and current location', () => {
+    expect(parseURL('?f=foo', '/parent/bar')).toEqual({
+      fullPath: '/parent/bar?f=foo',
+      path: '/parent/bar',
+      hash: '',
+      query: { f: 'foo' },
+    })
+  })
+
+  it('works with relative hash and current location', () => {
+    expect(parseURL('#hash', '/parent/bar')).toEqual({
+      fullPath: '/parent/bar#hash',
+      path: '/parent/bar',
+      hash: '#hash',
+      query: {},
+    })
+  })
+
+  it('extracts the query', () => {
+    expect(parseURL('/foo?a=one&b=two')).toEqual({
+      fullPath: '/foo?a=one&b=two',
+      path: '/foo',
+      hash: '',
+      query: {
+        a: 'one',
+        b: 'two',
+      },
+    })
+  })
+
+  it('extracts the hash', () => {
+    expect(parseURL('/foo#bar')).toEqual({
+      fullPath: '/foo#bar',
+      path: '/foo',
+      hash: '#bar',
+      query: {},
+    })
+  })
+
+  it('extracts query and hash', () => {
+    expect(parseURL('/foo?a=one#bar')).toEqual({
+      fullPath: '/foo?a=one#bar',
+      path: '/foo',
+      hash: '#bar',
+      query: { a: 'one' },
+    })
+  })
+
+  it('extracts multiple query parameters as an array', () => {
+    expect(parseURL('/foo?a=one&a=two&a=three')).toEqual({
+      fullPath: '/foo?a=one&a=two&a=three',
+      path: '/foo',
+      hash: '',
+      query: { a: ['one', 'two', 'three'] },
+    })
+  })
+
+  it('correctly parses a ? after the hash', () => {
+    expect(parseURL('/foo#?a=one')).toEqual({
+      fullPath: '/foo#?a=one',
+      path: '/foo',
+      hash: '#?a=one',
+      query: {},
+    })
+    expect(parseURL('/foo/?a=two#?a=one')).toEqual({
+      fullPath: '/foo/?a=two#?a=one',
+      path: '/foo/',
+      hash: '#?a=one',
+      query: { a: 'two' },
+    })
+  })
+
+  it('works with empty query', () => {
+    expect(parseURL('/foo?#hash')).toEqual({
+      fullPath: '/foo?#hash',
+      path: '/foo',
+      hash: '#hash',
+      query: {},
+    })
+    expect(parseURL('/foo#hash')).toEqual({
+      fullPath: '/foo#hash',
+      path: '/foo',
+      hash: '#hash',
+      query: {},
+    })
+    expect(parseURL('/foo?')).toEqual({
+      fullPath: '/foo?',
+      path: '/foo',
+      hash: '',
+      query: {},
+    })
+    expect(parseURL('/foo')).toEqual({
+      fullPath: '/foo',
+      path: '/foo',
+      hash: '',
+      query: {},
+    })
+  })
+
+  it('works with empty hash', () => {
+    expect(parseURL('/foo#')).toEqual({
+      fullPath: '/foo#',
+      path: '/foo',
+      hash: '#',
+      query: {},
+    })
+    expect(parseURL('/foo?#')).toEqual({
+      fullPath: '/foo?#',
+      path: '/foo',
+      hash: '#',
+      query: {},
+    })
+    expect(parseURL('/foo')).toEqual({
+      fullPath: '/foo',
+      path: '/foo',
+      hash: '',
+      query: {},
+    })
+  })
+
+  it('works with a relative paths', () => {
+    expect(parseURL('foo', '/parent/bar')).toEqual({
+      fullPath: '/parent/foo',
+      path: '/parent/foo',
+      hash: '',
+      query: {},
+    })
+    expect(parseURL('./foo', '/parent/bar')).toEqual({
+      fullPath: '/parent/foo',
+      path: '/parent/foo',
+      hash: '',
+      query: {},
+    })
+    expect(parseURL('../foo', '/parent/bar')).toEqual({
+      fullPath: '/foo',
+      path: '/foo',
+      hash: '',
+      query: {},
+    })
+    // cannot go below root
+    expect(parseURL('../../foo', '/parent/bar')).toEqual({
+      fullPath: '/foo',
+      path: '/foo',
+      hash: '',
+      query: {},
+    })
+
+    expect(parseURL('', '/parent/bar')).toEqual({
+      fullPath: '/parent/bar',
+      path: '/parent/bar',
+      hash: '',
+      query: {},
+    })
+    expect(parseURL('#foo', '/parent/bar')).toEqual({
+      fullPath: '/parent/bar#foo',
+      path: '/parent/bar',
+      hash: '#foo',
+      query: {},
+    })
+    expect(parseURL('?o=o', '/parent/bar')).toEqual({
+      fullPath: '/parent/bar?o=o',
+      path: '/parent/bar',
+      hash: '',
+      query: { o: 'o' },
+    })
+  })
+
+  it('calls parseQuery', () => {
+    const parseQuery = vi.fn()
+    originalParseURL(parseQuery, '/?é=é&é=a')
+    expect(parseQuery).toHaveBeenCalledTimes(1)
+    expect(parseQuery).toHaveBeenCalledWith('é=é&é=a')
+  })
+})

--- a/packages/router/src/experimental/location.ts
+++ b/packages/router/src/experimental/location.ts
@@ -1,0 +1,74 @@
+import { decode } from '../encoding'
+import { type LocationNormalized, resolveRelativePath } from '../location'
+import type { LocationQuery } from './query'
+
+// TODO: in next major, merge the two query.ts files and the two location.ts files
+
+/**
+ * Transforms a URI into a normalized history location. Same behavior as the
+ * legacy `parseURL` but uses `Object.create(null)` for the query object so it
+ * cannot be exploited via prototype pollution.
+ *
+ * @param parseQuery
+ * @param location - URI to normalize
+ * @param currentLocation - current absolute location. Allows resolving relative
+ * paths. Must start with `/`. Defaults to `/`
+ * @returns a normalized history location
+ */
+export function experimental_parseURL(
+  parseQuery: (search: string) => LocationQuery,
+  location: string,
+  currentLocation: string = '/'
+): LocationNormalized {
+  let path: string | undefined,
+    query: LocationQuery = Object.create(null),
+    searchString = '',
+    hash = ''
+
+  // NOTE: we could use URL and URLSearchParams but they are 2 to 5 times slower than this method
+  const hashPos = location.indexOf('#')
+  let searchPos = location.indexOf('?')
+
+  // This ensures that the ? is not part of the hash
+  // e.g. /foo#hash?query -> has no query
+  searchPos = hashPos >= 0 && searchPos > hashPos ? -1 : searchPos
+
+  if (searchPos >= 0) {
+    path = location.slice(0, searchPos)
+    // keep the ? char
+    searchString = location.slice(
+      searchPos,
+      // hashPos cannot be 0 because there is a search section in the location
+      hashPos > 0 ? hashPos : location.length
+    )
+
+    query = parseQuery(
+      // remove the leading ?
+      searchString.slice(1)
+    )
+  }
+
+  if (hashPos >= 0) {
+    // TODO(major): path ||=
+    path = path || location.slice(0, hashPos)
+    // keep the # character
+    hash = location.slice(hashPos, location.length)
+  }
+
+  path = resolveRelativePath(
+    // TODO(major): path ?? location
+    path != null
+      ? path
+      : // empty path means a relative query or hash `?foo=f`, `#thing`
+        location,
+    currentLocation
+  )
+
+  return {
+    // we can't directly use the location parameter because it can be a relative path
+    fullPath: path + searchString + hash,
+    path,
+    query,
+    hash: decode(hash),
+  }
+}

--- a/packages/router/src/experimental/query.spec.ts
+++ b/packages/router/src/experimental/query.spec.ts
@@ -89,6 +89,11 @@ describe('parseQuery', () => {
   })
 
   it('does not pollute the prototype with __proto__', () => {
+    expect(Object.getPrototypeOf(parseQuery(''))).toBe(null)
+    expect(Object.getPrototypeOf(parseQuery('?'))).toBe(null)
+  })
+
+  it('does not pollute the prototype with __proto__', () => {
     const result = parseQuery('__proto__=polluted') as Record<string, unknown>
     expect(Object.getPrototypeOf(result)).toBe(null)
     expect(result['__proto__']).toBe('polluted')

--- a/packages/router/src/experimental/query.spec.ts
+++ b/packages/router/src/experimental/query.spec.ts
@@ -1,0 +1,144 @@
+import { mockWarn } from '../../__tests__/vitest-mock-warn'
+import {
+  experimental_parseQuery as parseQuery,
+  experimental_normalizeQuery as normalizeQuery,
+} from './query'
+import { describe, expect, it } from 'vitest'
+
+describe('parseQuery', () => {
+  mockWarn()
+
+  it('works with leading ?', () => {
+    expect(parseQuery('?foo=a')).toEqual({
+      foo: 'a',
+    })
+    expect(parseQuery('foo=a')).toEqual({
+      foo: 'a',
+    })
+    expect(parseQuery('?')).toEqual({})
+  })
+
+  it('works with an empty string', () => {
+    const emptyQuery = parseQuery('')
+    expect(Object.keys(emptyQuery)).toHaveLength(0)
+    expect(emptyQuery).toEqual({})
+    expect(parseQuery('?')).toEqual({})
+  })
+
+  it('decodes values in query', () => {
+    expect(parseQuery('e=%25')).toEqual({
+      e: '%',
+    })
+  })
+
+  it('parses empty string values', () => {
+    expect(parseQuery('e=&c=a')).toEqual({
+      e: '',
+      c: 'a',
+    })
+  })
+
+  it('allows = inside values', () => {
+    expect(parseQuery('e=c=a')).toEqual({
+      e: 'c=a',
+    })
+  })
+
+  it('parses empty values as null', () => {
+    expect(parseQuery('e&b&c=a')).toEqual({
+      e: null,
+      b: null,
+      c: 'a',
+    })
+  })
+
+  it('parses empty values as null in arrays', () => {
+    expect(parseQuery('e&e&e=a')).toEqual({
+      e: [null, null, 'a'],
+    })
+  })
+
+  it('decodes array values in query', () => {
+    expect(parseQuery('e=%25&e=%22')).toEqual({
+      e: ['%', '"'],
+    })
+    expect(parseQuery('e=%25&e=a')).toEqual({
+      e: ['%', 'a'],
+    })
+  })
+
+  it('decodes the + as space', () => {
+    expect(parseQuery('a+b=c+d')).toEqual({
+      'a b': 'c d',
+    })
+  })
+
+  it('decodes the encoded + as +', () => {
+    expect(parseQuery('a%2Bb=c%2Bd')).toEqual({
+      'a+b': 'c+d',
+    })
+  })
+
+  // this is for browsers like IE that allow invalid characters
+  it('keep invalid values as is', () => {
+    expect(parseQuery('e=%&e=%25')).toEqual({
+      e: ['%', '%'],
+    })
+
+    expect('decoding "%"').toHaveBeenWarnedTimes(1)
+  })
+
+  it('does not pollute the prototype with __proto__', () => {
+    const result = parseQuery('__proto__=polluted') as Record<string, unknown>
+    expect(Object.getPrototypeOf(result)).toBe(null)
+    expect(result['__proto__']).toBe('polluted')
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  it('treats constructor as a regular key', () => {
+    const result = parseQuery('constructor=foo')
+    expect(Object.getPrototypeOf(result)).toBe(null)
+    expect(result).toEqual({ constructor: 'foo' })
+    expect(Object.prototype.constructor).toBe(Object)
+  })
+})
+
+describe('normalizeQuery', () => {
+  it('removes keys with undefined values', () => {
+    expect(normalizeQuery({ a: undefined, b: 'x' })).toEqual({ b: 'x' })
+  })
+
+  it('preserves null values', () => {
+    expect(normalizeQuery({ a: null })).toEqual({ a: null })
+  })
+
+  it('coerces numbers to strings', () => {
+    expect(normalizeQuery({ a: 1 })).toEqual({ a: '1' })
+  })
+
+  it('preserves string values', () => {
+    expect(normalizeQuery({ a: 'x' })).toEqual({ a: 'x' })
+  })
+
+  it('coerces values inside arrays', () => {
+    expect(normalizeQuery({ a: [1, 'x', null] })).toEqual({
+      a: ['1', 'x', null],
+    })
+  })
+
+  it('replaces undefined with null inside arrays', () => {
+    expect(normalizeQuery({ a: [undefined, 'x'] })).toEqual({
+      a: [null, 'x'],
+    })
+  })
+
+  it('handles empty / undefined input', () => {
+    expect(normalizeQuery(undefined)).toEqual({})
+    expect(normalizeQuery({})).toEqual({})
+  })
+
+  it('returns a null-prototype object', () => {
+    expect(Object.getPrototypeOf(normalizeQuery({ a: 'x' }))).toBe(null)
+    expect(Object.getPrototypeOf(normalizeQuery(undefined))).toBe(null)
+  })
+})

--- a/packages/router/src/experimental/query.spec.ts
+++ b/packages/router/src/experimental/query.spec.ts
@@ -144,6 +144,7 @@ describe('normalizeQuery', () => {
 
   it('returns a null-prototype object', () => {
     expect(Object.getPrototypeOf(normalizeQuery({ a: 'x' }))).toBe(null)
+    expect(Object.getPrototypeOf(normalizeQuery({}))).toBe(null)
     expect(Object.getPrototypeOf(normalizeQuery(undefined))).toBe(null)
   })
 })

--- a/packages/router/src/experimental/query.ts
+++ b/packages/router/src/experimental/query.ts
@@ -2,6 +2,11 @@ import { decode, PLUS_RE } from '../encoding'
 import { isArray } from '../utils'
 
 /**
+ * NOTE: some types here are duplicated from ../query.ts
+ * because they will change to always have (string | null)[] values
+ */
+
+/**
  * Possible values in normalized {@link LocationQuery}. `null` renders the query
  * param but without an `=`.
  *

--- a/packages/router/src/experimental/query.ts
+++ b/packages/router/src/experimental/query.ts
@@ -1,16 +1,9 @@
-import { decode, encodeQueryKey, encodeQueryValue, PLUS_RE } from './encoding'
-import { isArray } from './utils'
+import { decode, PLUS_RE } from '../encoding'
+import { isArray } from '../utils'
 
 /**
  * Possible values in normalized {@link LocationQuery}. `null` renders the query
  * param but without an `=`.
- *
- * @example
- * ```
- * ?isNull&isEmpty=&other=other
- * gives
- * `{ isNull: null, isEmpty: '', other: 'other' }`.
- * ```
  *
  * @internal
  */
@@ -32,6 +25,7 @@ export type LocationQuery = Record<
   string,
   LocationQueryValue | LocationQueryValue[]
 >
+
 /**
  * Loose {@link LocationQuery} object that can be passed to functions like
  * {@link Router.push} and {@link Router.replace} or anywhere when creating a
@@ -46,34 +40,29 @@ export type LocationQueryRaw = Record<
 
 /**
  * Transforms a queryString into a {@link LocationQuery} object. Accept both, a
- * version with the leading `?` and without Should work as URLSearchParams
-
+ * version with the leading `?` and without. Uses `Object.create(null)` so the
+ * returned object cannot be exploited via prototype pollution.
+ *
  * @internal
  *
  * @param search - search string to parse
  * @returns a query object
  */
-export function parseQuery(search: string): LocationQuery {
-  const query: LocationQuery = {}
-  // avoid creating an object with an empty key and empty value
-  // because of split('&')
+export function experimental_parseQuery(search: string): LocationQuery {
+  const query: LocationQuery = Object.create(null)
   if (search === '' || search === '?') return query
   const searchParams = (search[0] === '?' ? search.slice(1) : search).split('&')
   for (let i = 0; i < searchParams.length; ++i) {
-    // pre decode the + into space
     const searchParam = searchParams[i].replace(PLUS_RE, ' ')
-    // allow the = character
     const eqPos = searchParam.indexOf('=')
     const key = decode(eqPos < 0 ? searchParam : searchParam.slice(0, eqPos))
     const value = eqPos < 0 ? null : decode(searchParam.slice(eqPos + 1))
 
     if (key in query) {
-      // an extra variable for ts types
       let currentValue = query[key]
       if (!isArray(currentValue)) {
         currentValue = query[key] = [currentValue]
       }
-      // we force the modification
       ;(currentValue as LocationQueryValue[]).push(value)
     } else {
       query[key] = value
@@ -83,57 +72,18 @@ export function parseQuery(search: string): LocationQuery {
 }
 
 /**
- * Stringifies a {@link LocationQueryRaw} object. Like `URLSearchParams`, it
- * doesn't prepend a `?`
- *
- * @internal
- *
- * @param query - query object to stringify
- * @returns string version of the query without the leading `?`
- */
-export function stringifyQuery(query: LocationQueryRaw | undefined): string {
-  let search = ''
-  for (let key in query) {
-    const value = query[key]
-    key = encodeQueryKey(key)
-    if (value == null) {
-      // only null adds the value
-      if (value !== undefined) {
-        search += (search.length ? '&' : '') + key
-      }
-      continue
-    }
-    // keep null values
-    const values: LocationQueryValueRaw[] = isArray(value)
-      ? value.map(v => v && encodeQueryValue(v))
-      : [value && encodeQueryValue(value)]
-
-    values.forEach(value => {
-      // skip undefined values in arrays as if they were not present
-      // smaller code than using filter
-      if (value !== undefined) {
-        // only append & with non-empty search
-        search += (search.length ? '&' : '') + key
-        if (value != null) search += '=' + value
-      }
-    })
-  }
-
-  return search
-}
-
-/**
  * Transforms a {@link LocationQueryRaw} into a {@link LocationQuery} by casting
  * numbers into strings, removing keys with an undefined value and replacing
- * undefined with null in arrays
+ * undefined with null in arrays. Uses `Object.create(null)` so the returned
+ * object cannot be exploited via prototype pollution.
  *
  * @param query - query object to normalize
  * @returns a normalized query object
  */
-export function normalizeQuery(
+export function experimental_normalizeQuery(
   query: LocationQueryRaw | undefined
 ): LocationQuery {
-  const normalizedQuery: LocationQuery = {}
+  const normalizedQuery: LocationQuery = Object.create(null)
 
   for (const key in query) {
     const value = query[key]

--- a/packages/router/src/experimental/route-resolver/resolver-abstract.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-abstract.ts
@@ -1,4 +1,4 @@
-import { type LocationQueryRaw } from '../../query'
+import { type LocationQueryRaw } from '../query'
 import { encodeQueryValue as _encodeQueryValue } from '../../encoding'
 import type { MatcherParamsFormatted } from './matchers/matcher-pattern'
 import type { _RouteRecordProps } from '../../typed-routes'

--- a/packages/router/src/experimental/route-resolver/resolver-fixed.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-fixed.ts
@@ -1,8 +1,12 @@
-import { normalizeQuery, parseQuery, stringifyQuery } from '../../query'
+import {
+  experimental_normalizeQuery as normalizeQuery,
+  experimental_parseQuery as parseQuery,
+} from '../query'
+import { stringifyQuery } from '../../query'
+import { experimental_parseURL as parseURL } from '../location'
 import {
   type LocationNormalized,
   NEW_stringifyURL,
-  parseURL,
   resolveRelativePath,
 } from '../../location'
 import type {

--- a/packages/router/src/experimental/router.ts
+++ b/packages/router/src/experimental/router.ts
@@ -21,10 +21,11 @@ import {
   type RouterHistory,
 } from '../history/common'
 import type { PathParserOptions } from '../matcher'
-import type { parseQuery as originalParseQuery } from '../query'
+import type { experimental_parseQuery as originalParseQuery } from './query'
 import { stringifyQuery as originalStringifyQuery } from '../query'
-import type { _ScrollPositionNormalized } from '../scrollBehavior'
+import type { Router } from '../router'
 import {
+  type _ScrollPositionNormalized,
   computeScrollPosition,
   getSavedScrollPosition,
   getScrollKey,

--- a/packages/router/src/experimental/router.ts
+++ b/packages/router/src/experimental/router.ts
@@ -26,12 +26,12 @@ import { stringifyQuery as originalStringifyQuery } from '../query'
 import type { Router } from '../router'
 import {
   type _ScrollPositionNormalized,
+  type RouterScrollBehavior,
   computeScrollPosition,
   getSavedScrollPosition,
   getScrollKey,
   saveScrollPosition,
   scrollToPosition,
-  type RouterScrollBehavior,
 } from '../scrollBehavior'
 import type {
   _NavigationGuardResolved,

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -50,7 +50,7 @@ export function parseURL(
   currentLocation: string = '/'
 ): LocationNormalized {
   let path: string | undefined,
-    query: LocationQuery = {},
+    query: LocationQuery = Object.create(null),
     searchString = '',
     hash = ''
 

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -50,7 +50,8 @@ export function parseURL(
   currentLocation: string = '/'
 ): LocationNormalized {
   let path: string | undefined,
-    query: LocationQuery = Object.create(null),
+    // TODO: in next major, use Object.create(null) and remove src/experimental/location.ts
+    query: LocationQuery = {},
     searchString = '',
     hash = ''
 

--- a/packages/router/src/query.ts
+++ b/packages/router/src/query.ts
@@ -52,7 +52,7 @@ export type LocationQueryRaw = Record<
  * @returns a query object
  */
 export function parseQuery(search: string): LocationQuery {
-  const query: LocationQuery = {}
+  const query: LocationQuery = Object.create(null)
   // avoid creating an object with an empty key and empty value
   // because of split('&')
   if (search === '' || search === '?') return query
@@ -131,7 +131,7 @@ export function stringifyQuery(query: LocationQueryRaw | undefined): string {
 export function normalizeQuery(
   query: LocationQueryRaw | undefined
 ): LocationQuery {
-  const normalizedQuery: LocationQuery = {}
+  const normalizedQuery: LocationQuery = Object.create(null)
 
   for (const key in query) {
     const value = query[key]


### PR DESCRIPTION
## Summary

This PR fixes a security vulnerability where query objects created with `{}` are susceptible to prototype pollution via `__proto__` and `constructor` keys.

## Changes

- `parseQuery()`: Use `Object.create(null)` instead of `{}`
- `normalizeQuery()`: Use `Object.create(null)` instead of `{}`
- `parseURL()`: Use `Object.create(null)` for initial query object

## Security Impact

Before this fix, an attacker could craft a URL like:
- `/?__proto__=evil&foo=bar` - pollutes the query object's prototype
- `/?constructor=test` - leaks internal Object constructor

After this fix, these keys are treated as plain data without affecting the prototype chain.

## Fixes

Fixes #2658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental query parsing and normalization added for more consistent query handling and URL normalization.
* **Bug Fixes**
  * Improved handling of repeated params, decoding edge cases, relative path/query/hash resolution, and safety against prototype-pollution-like issues.
* **Tests**
  * Expanded test coverage for query parsing, normalization, URL parsing, and resolver behavior.
* **Refactor**
  * Internal parsing wiring updated to use the new experimental implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->