### PR TITLE
fix(matcher): add workaround hint to invalid params warning

### DIFF
--- a/packages/router/__tests__/warnings.spec.ts
+++ b/packages/router/__tests__/warnings.spec.ts
@@ -314,7 +314,58 @@ describe('warnings', () => {
       }
     )
     expect('invalid param(s) "no", "foo" ').toHaveBeenWarned()
+    // workaround hint should NOT be shown for normal routes
+    expect('catch-all route with a named redirect').not.toHaveBeenWarned()
     // from the previous location
     expect('"one"').not.toHaveBeenWarned()
+  })
+
+  it('warns with workaround hint for catch-all route with named redirect', () => {
+    // This is the actual scenario from issue #1617
+    const record = {
+      path: '/:pathMatch(.*)*',
+      name: 'catch-all',
+      redirect: { name: 'HOME' }, // named redirect
+      components: {},
+    }
+    const matcher = createRouterMatcher([record], {})
+    // Use invalid params (foo, bar) to trigger the warning
+    // pathMatch is valid for catch-all, but foo/bar are not
+    matcher.resolve(
+      { name: 'catch-all', params: { foo: 'bar' } },
+      {
+        path: '/parent/one',
+        name: undefined,
+        params: { old: 'one' }, // has params
+        matched: [] as any,
+        meta: {},
+      }
+    )
+    expect('Discarded invalid param(s)').toHaveBeenWarned()
+    // workaround hint SHOULD be shown for catch-all with named redirect
+    expect('catch-all route with a named redirect').toHaveBeenWarned()
+  })
+
+  it('does not show hint when current location has no params', () => {
+    const record = {
+      path: '/:pathMatch(.*)*',
+      name: 'catch-all',
+      redirect: { name: 'HOME' },
+      components: {},
+    }
+    const matcher = createRouterMatcher([record], {})
+    matcher.resolve(
+      { name: 'catch-all', params: { foo: 'bar' } },
+      {
+        path: '/',
+        name: undefined,
+        params: {}, // no params
+        matched: [] as any,
+        meta: {},
+      }
+    )
+    expect('Discarded invalid param(s)').toHaveBeenWarned()
+    // workaround hint should NOT be shown when no params to suggest
+    expect('catch-all route with a named redirect').not.toHaveBeenWarned()
   })
 })

--- a/packages/router/__tests__/warnings.spec.ts
+++ b/packages/router/__tests__/warnings.spec.ts
@@ -308,54 +308,47 @@ describe('warnings', () => {
       {
         path: '/parent/one',
         name: undefined,
-        params: { old: 'one' },
+        params: { old: 'one' }, // 'no' and 'foo' are not in currentLocation
         matched: [] as any,
         meta: {},
       }
     )
     expect('invalid param(s) "no", "foo" ').toHaveBeenWarned()
-    // workaround hint should NOT be shown for normal routes
+    // workaround hint should NOT be shown for explicitly passed params
     expect('catch-all route with a named redirect').not.toHaveBeenWarned()
-    // from the previous location
-    expect('"one"').not.toHaveBeenWarned()
   })
 
-  it('warns with workaround hint for catch-all route with named redirect', () => {
-    // This is the actual scenario from issue #1617
+  it('warns with workaround hint when discarded params are implicitly passed from previous location', () => {
     const record = {
-      path: '/:pathMatch(.*)*',
-      name: 'catch-all',
-      redirect: { name: 'HOME' }, // named redirect
+      path: '/a',
+      name: 'a',
       components: {},
     }
     const matcher = createRouterMatcher([record], {})
-    // Use invalid params (foo, bar) to trigger the warning
-    // pathMatch is valid for catch-all, but foo/bar are not
     matcher.resolve(
-      { name: 'catch-all', params: { foo: 'bar' } },
+      { name: 'a', params: { pathMatch: 'unknown' } },
       {
-        path: '/parent/one',
+        path: '/parent/unknown',
         name: undefined,
-        params: { old: 'one' }, // has params
+        params: { pathMatch: 'unknown' }, // The discarded param exists here!
         matched: [] as any,
         meta: {},
       }
     )
     expect('Discarded invalid param(s)').toHaveBeenWarned()
-    // workaround hint SHOULD be shown for catch-all with named redirect
+    // workaround hint SHOULD be shown because pathMatch is in currentLocation.params
     expect('catch-all route with a named redirect').toHaveBeenWarned()
   })
 
-  it('does not show hint when current location has no params', () => {
+  it('does not show hint when current location has no params to inherit', () => {
     const record = {
-      path: '/:pathMatch(.*)*',
-      name: 'catch-all',
-      redirect: { name: 'HOME' },
+      path: '/a',
+      name: 'a',
       components: {},
     }
     const matcher = createRouterMatcher([record], {})
     matcher.resolve(
-      { name: 'catch-all', params: { foo: 'bar' } },
+      { name: 'a', params: { foo: 'bar' } },
       {
         path: '/',
         name: undefined,
@@ -365,7 +358,6 @@ describe('warnings', () => {
       }
     )
     expect('Discarded invalid param(s)').toHaveBeenWarned()
-    // workaround hint should NOT be shown when no params to suggest
     expect('catch-all route with a named redirect').not.toHaveBeenWarned()
   })
 })

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -263,17 +263,17 @@ export function createRouterMatcher(
         ).filter(paramName => !matcher!.keys.find(k => k.name === paramName))
 
         if (invalidParams.length) {
-          // Check if this is a catch-all route (contains pathMatch) with a named redirect
-          const isCatchAllWithRedirect =
-            matcher!.record.path.includes('pathMatch') && // catch-all route
-            matcher!.record.redirect && // has redirect config
-            Object.keys(currentLocation.params).length // current location has params
+          // check for params being passed implicitly (e.g. inherited from the initial target location during a redirect)
+          const isImplicitlyPassed = invalidParams.some(
+            paramName => paramName in currentLocation.params
+          )
+          const hasParamsToSuggest = !matcher!.keys.length && isImplicitlyPassed
 
           warn(
             `Discarded invalid param(s) "${invalidParams.join(
               '", "'
             )}" when navigating.` +
-              (isCatchAllWithRedirect
+              (hasParamsToSuggest
                 ? ` If you are using a catch-all route with a named redirect, pass an empty \`params\` object: \`redirect: { name: '...', params: {} }\`.`
                 : '') +
               ` See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -263,10 +263,20 @@ export function createRouterMatcher(
         ).filter(paramName => !matcher!.keys.find(k => k.name === paramName))
 
         if (invalidParams.length) {
+          // Check if this is a catch-all route (contains pathMatch) with a named redirect
+          const isCatchAllWithRedirect =
+            matcher!.record.path.includes('pathMatch') && // catch-all route
+            matcher!.record.redirect && // has redirect config
+            Object.keys(currentLocation.params).length // current location has params
+
           warn(
             `Discarded invalid param(s) "${invalidParams.join(
               '", "'
-            )}" when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`
+            )}" when navigating.` +
+              (isCatchAllWithRedirect
+                ? ` If you are using a catch-all route with a named redirect, pass an empty \`params\` object: \`redirect: { name: '...', params: {} }\`.`
+                : '') +
+              ` See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`
           )
         }
       }


### PR DESCRIPTION
## What is the problem?

When using a catch-all route with a named redirect like:

```ts
{
  path: '/:pathMatch(.*)*',
  redirect: { name: 'HOME' }
}
```

Users see a warning:
`Discarded invalid param(s) "pathMatch" when navigating.`

The warning message doesn't explain how to fix the issue.

## How did I fix it?

Enhanced the warning message to include a helpful workaround hint:
`If you are using a catch-all route with a named redirect, pass an empty params object: redirect: { name: '...', params: {} }.`

This matches the workaround suggested by @posva in the issue comments.

## How was this tested?

- Updated the existing test in `packages/router/__tests__/warnings.spec.ts` to match the new warning format
- The test now also checks for the presence of the workaround hint

Closes #1617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified discarded/invalid route-parameter warning: an extra guidance hint is now appended only for catch-all style routes with named redirects when the previous location contains params; other cases retain the original wording and link.

* **Tests**
  * Added and updated tests to verify the exact warning text and the conditional presence or absence of the workaround hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->