### PR TITLE
fix(matcher): only show workaround hint when target route has no params

### DIFF
--- a/packages/router/__tests__/warnings.spec.ts
+++ b/packages/router/__tests__/warnings.spec.ts
@@ -313,7 +313,8 @@ describe('warnings', () => {
         meta: {},
       }
     )
-    expect('invalid param(s) "no", "foo" ').toHaveBeenWarned()
+    expect('invalid param(s) "no", "foo"').toHaveBeenWarned()
+    expect('If you are using a catch-all route').toHaveBeenWarned()
     // from the previous location
     expect('"one"').not.toHaveBeenWarned()
   })

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -263,10 +263,17 @@ export function createRouterMatcher(
         ).filter(paramName => !matcher!.keys.find(k => k.name === paramName))
 
         if (invalidParams.length) {
+          const hasParamsToSuggest =
+            !matcher!.keys.length && Object.keys(currentLocation.params).length
+
           warn(
             `Discarded invalid param(s) "${invalidParams.join(
               '", "'
-            )}" when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`
+            )}" when navigating.` +
+              (hasParamsToSuggest
+                ? ` If you are using a catch-all route with a named redirect, pass an empty \`params\` object: \`redirect: { name: '...', params: {} }\`.`
+                : '') +
+              ` See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`
           )
         }
       }


### PR DESCRIPTION
## Summary

Only show the workaround hint when:
1. The target route has no params (!matcher!.keys.length)
2. The current location has params (Object.keys(currentLocation.params).length)

This prevents showing the hint for all redirect failures, as requested by @posva in https://github.com/vuejs/router/pull/2662#issuecomment-4196756143

Closes #1617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced warning messages when invalid parameters are discarded during navigation. Developers now receive additional guidance specific to catch-all routes to resolve the issue more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->