### PR TITLE
fix(router): ensure scroll position is preserved on page reload

### DIFF
--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -126,14 +126,26 @@ function useHistoryListeners(
     return teardown
   }
 
+  function saveScrollToHistory() {
+    const { history } = window
+    if (!history.state) return
+    history.replaceState(
+      assign({}, history.state, { scroll: computeScrollPosition() }),
+      ''
+    )
+  }
+
+  // pagehide and beforeunload only fire when the page is going away, so we
+  // can save unconditionally.
   function beforeUnloadListener() {
+    saveScrollToHistory()
+  }
+
+  // visibilitychange fires in both directions (hidden and visible), so we
+  // must guard to only save when the page is being hidden.
+  function visibilityChangeListener() {
     if (document.visibilityState === 'hidden') {
-      const { history } = window
-      if (!history.state) return
-      history.replaceState(
-        assign({}, history.state, { scroll: computeScrollPosition() }),
-        ''
-      )
+      saveScrollToHistory()
     }
   }
 
@@ -141,17 +153,20 @@ function useHistoryListeners(
     for (const teardown of teardowns) teardown()
     teardowns = []
     window.removeEventListener('popstate', popStateHandler)
+    window.removeEventListener('beforeunload', beforeUnloadListener)
     window.removeEventListener('pagehide', beforeUnloadListener)
-    document.removeEventListener('visibilitychange', beforeUnloadListener)
+    document.removeEventListener('visibilitychange', visibilityChangeListener)
   }
 
   // set up the listeners and prepare teardown callbacks
   window.addEventListener('popstate', popStateHandler)
   // https://developer.chrome.com/blog/page-lifecycle-api/
-  // note: iOS safari does not fire beforeunload, so we
-  // use pagehide and visibilitychange instead
+  // note: iOS safari does not fire beforeunload, so we use pagehide and
+  // visibilitychange additionally. beforeunload is also needed because Chrome
+  // does not fire pagehide / visibilitychange on a page reload (F5).
+  window.addEventListener('beforeunload', beforeUnloadListener)
   window.addEventListener('pagehide', beforeUnloadListener)
-  document.addEventListener('visibilitychange', beforeUnloadListener)
+  document.addEventListener('visibilitychange', visibilityChangeListener)
 
   return {
     pauseListeners,


### PR DESCRIPTION
Fixes #2681

Since 4.6.0, the scroll position is no longer preserved on a page reload in Chrome and Firefox, caused by #2537. This can be reproduced in the playground of this project (`pnpm play`).

This PR is a regression fix for #2537, where the `beforeunload` event in `packages/router/src/history/html5.ts` was replaced by `pagehide` and `visibilitychange` events to store the scroll position in the browser history. That fixed it for Safari (Desktop and iOS), but broke it in Chrome and Firefox.

There seems to be an inconsistency across browsers in which of the three events are fired on a page reload. I discovered this by logging the events:

## Events fired on a page reload

| Event | Chrome | Firefox | Safari |
| --- | --- | --- | --- |
| `beforeunload` | :white_check_mark: | :white_check_mark: | :x: |
| `pagehide` | :x: | :white_check_mark: | :white_check_mark: |
| `visibilitychange` | :x: | :white_check_mark: | :white_check_mark: |

So to store the scroll position on a page reload consistently across browsers, all three events are needed. This PR restores the `beforeunload` event for that purpose. Additionally, Chrome has set `document.visibilityState` to `visible` during the `beforeunload` event. So the condition that was added had to be removed for that event.

@omnomnomapp FYI

### Steps to reproduce
Run `pnpm play` in Chrome/Firefox, scroll down the page and reload the page.

### What is expected?
Scroll position should be preserved after the reload.

### What is actually happening?
After the reload the page is scrolled back to the top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll position restoration when navigating back/forward and reloading pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->