### PR TITLE
fix(router): filter inherited params on named route redirect

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -77,6 +77,10 @@ const routes: RouteRecordRaw[] = [
     ],
   },
   { path: '/:pathMatch(.*)', component: components.Home, name: 'catch-all' },
+  {
+    path: '/catch-all-redirect/:pathMatch(.*)*',
+    redirect: { name: 'Foo' },
+  },
 ]
 
 async function newRouter(
@@ -792,6 +796,18 @@ describe('Router', () => {
       expect(loc.redirectedFrom).toMatchObject({
         path: '/to-foo-named',
       })
+    })
+
+    it('does not warn when catch-all redirects to a named route', async () => {
+      const { router } = await newRouter()
+      await expect(
+        router.push('/catch-all-redirect/some/path')
+      ).resolves.toEqual(undefined)
+      expect(router.currentRoute.value).toMatchObject({
+        name: 'Foo',
+        path: '/foo',
+      })
+      expect('invalid param').not.toHaveBeenWarned()
     })
 
     it('keeps original replace if redirect', async () => {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -372,6 +372,27 @@ export function createRouter(options: RouterOptions): Router {
     return push(assign(locationAsObject(to), { replace: true }))
   }
 
+  /**
+   * Filters params to only include those accepted by the target named route.
+   * This prevents warnings when redirecting from routes with params (e.g.
+   * catch-all) to named routes that don't accept those params.
+   */
+  function filterParams(
+    params: RouteLocation['params'],
+    targetName: NonNullable<RouteRecordNameGeneric>
+  ): RouteLocation['params'] {
+    const targetMatcher = matcher.getRecordMatcher(targetName)
+    if (!targetMatcher) return params
+    const targetParamNames = targetMatcher.keys.map(k => k.name)
+    const filtered: RouteLocation['params'] = {}
+    for (const key of targetParamNames) {
+      if (key in params) {
+        filtered[key] = params[key]
+      }
+    }
+    return filtered
+  }
+
   function handleRedirectRecord(
     to: RouteLocation,
     from: RouteLocationNormalizedLoaded
@@ -415,7 +436,12 @@ export function createRouter(options: RouterOptions): Router {
           query: to.query,
           hash: to.hash,
           // avoid transferring params if the redirect has a path
-          params: newTargetLocation.path != null ? {} : to.params,
+          params:
+            newTargetLocation.path != null
+              ? {}
+              : 'name' in newTargetLocation && newTargetLocation.name
+                ? filterParams(to.params, newTargetLocation.name)
+                : to.params,
         },
         newTargetLocation
       )


### PR DESCRIPTION
## Summary

Fixes #1617

When a catch-all route (e.g. `/:pathMatch(.*)*`) redirects to a named route via `redirect: { name: 'Home' }`, the `pathMatch` param from the source route was being passed to the target route. Since the target route doesn't accept that param, a spurious "Discarded invalid param(s)" warning was shown.

## Root Cause

In `handleRedirectRecord()`, when redirecting to a named route without an explicit `path`, all params from the source route (`to.params`) were passed through to the redirect target:

```ts
params: newTargetLocation.path != null ? {} : to.params,
```

This meant catch-all params like `pathMatch` were forwarded to the target named route, triggering the warning in `matcher.resolve()`.

## Fix

Added a `filterParams()` helper that uses `matcher.getRecordMatcher()` to look up the target route's accepted param keys and filters out any params that don't belong to the target route. This is only applied when the redirect target is a named route.

## Test

Added a test case that navigates to a catch-all route with a named redirect and verifies:
- Navigation succeeds to the correct target route
- No "invalid param" warning is emitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced redirect parameter handling for named route targets to prevent invalid parameter warnings.

* **Tests**
  * Added test coverage for named route redirect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->