### PR TITLE
feat(matcher): hint at `params: {}` workaround in discarded params warning

### DIFF
--- a/packages/router/__tests__/warnings.spec.ts
+++ b/packages/router/__tests__/warnings.spec.ts
@@ -312,5 +312,44 @@ describe('warnings', () => {
     expect('invalid param(s) "no", "foo" ').toHaveBeenWarned()
     // from the previous location
     expect('"one"').not.toHaveBeenWarned()
+    // explicit params (not inherited) should not trigger the workaround hint
+    expect('catch-all route with a named redirect').not.toHaveBeenWarned()
+  })
+
+  it('hints at the `params: {}` workaround when discarded params are inherited', () => {
+    const record = {
+      path: '/a',
+      name: 'a',
+      components: {},
+    }
+    const matcher = createRouterMatcher([record], {})
+    matcher.resolve(
+      { name: 'a', params: { pathMatch: 'unknown' } },
+      {
+        path: '/unknown',
+        name: undefined,
+        params: { pathMatch: 'unknown' },
+        matched: [] as any,
+        meta: {},
+      }
+    )
+    expect('Discarded invalid param(s)').toHaveBeenWarned()
+    expect('catch-all route with a named redirect').toHaveBeenWarned()
+  })
+
+  it('does not warn for a catch-all redirect using the `params: {}` workaround', async () => {
+    const history = createMemoryHistory()
+    const router = createRouter({
+      history,
+      routes: [
+        { path: '/', name: 'HOME', component },
+        {
+          path: '/:pathMatch(.*)*',
+          redirect: { name: 'HOME', params: {} },
+        },
+      ],
+    })
+    await router.push('/anything')
+    expect('Discarded invalid param(s)').not.toHaveBeenWarned()
   })
 })

--- a/packages/router/src/matcher/index.ts
+++ b/packages/router/src/matcher/index.ts
@@ -265,10 +265,20 @@ export function createRouterMatcher(
         ).filter(paramName => !matcher!.keys.find(k => k.name === paramName))
 
         if (invalidParams.length) {
+          // when the invalid params are inherited from the current location
+          // (e.g. `pathMatch` from a catch-all redirecting to a named route),
+          // suggest the `params: {}` workaround
+          const isInherited =
+            !matcher!.keys.length &&
+            invalidParams.some(name => name in currentLocation.params)
           warn(
             `Discarded invalid param(s) "${invalidParams.join(
               '", "'
-            )}" when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`
+            )}" when navigating.` +
+              (isInherited
+                ? ` If you are using a catch-all route with a named redirect, pass an empty \`params\` object: \`redirect: { name: '...', params: {} }\`.`
+                : '') +
+              ` See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.`
           )
         }
       }


### PR DESCRIPTION
Closes #1617. Supersedes #2662 (credits original author via `Co-authored-by`).

Appends a hint to the dev-only "Discarded invalid param(s)" warning when the params were inherited from the current location and the target matcher has no keys — the classic catch-all → named-redirect case.

Tests: added a matcher-level test for the hint, and a router-level test asserting the `params: {}` workaround silences the warning entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended coverage for parameter validation warnings during route matching
  * Added validation tests for inherited parameters in catch-all redirect scenarios

* **Bug Fixes**
  * Enhanced warning messages for discarded invalid parameters during route navigation
  * Improved guidance for configuring catch-all routes with named redirects using empty parameter workarounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->