### PR TITLE
chore: resolve COMMIT_EDITMSG via git rev-parse --git-path

### DIFF
--- a/scripts/verifyCommit.mjs
+++ b/scripts/verifyCommit.mjs
@@ -3,10 +3,10 @@
 import chalk from 'chalk'
 import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import path from 'node:path'
 
-const gitDir = execSync('git rev-parse --git-dir', { encoding: 'utf-8' }).trim()
-const msgPath = path.resolve(gitDir, 'COMMIT_EDITMSG')
+const msgPath = execSync('git rev-parse --git-path COMMIT_EDITMSG', {
+  encoding: 'utf-8',
+}).trim()
 const msg = readFileSync(msgPath, 'utf-8').trim()
 
 const commitRE =


### PR DESCRIPTION
## Summary
- `scripts/verifyCommit.mjs` joined `git rev-parse --git-dir` with `COMMIT_EDITMSG`, which fails when committing from a git worktree (the path lives under `.git/worktrees/<name>/` and `.git` is a file, not a directory).
- Switch to `git rev-parse --git-path COMMIT_EDITMSG` — git returns the correct absolute/relative path for both regular checkouts and worktrees.

## Test plan
- [x] Commit from a worktree (this PR's commit was made that way — the commit-msg hook runs the updated script).
- [ ] Commit from the main checkout to confirm no regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal script path resolution logic and removed unused dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->