### PR TITLE
fix(history): remove visibilitychange listener to prevent focus steal…

### DIFF
--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -127,14 +127,12 @@ function useHistoryListeners(
   }
 
   function beforeUnloadListener() {
-    if (document.visibilityState === 'hidden') {
-      const { history } = window
-      if (!history.state) return
-      history.replaceState(
-        assign({}, history.state, { scroll: computeScrollPosition() }),
-        ''
-      )
-    }
+    const { history } = window
+    if (!history.state) return
+    history.replaceState(
+      assign({}, history.state, { scroll: computeScrollPosition() }),
+      ''
+    )
   }
 
   function destroy() {
@@ -142,16 +140,13 @@ function useHistoryListeners(
     teardowns = []
     window.removeEventListener('popstate', popStateHandler)
     window.removeEventListener('pagehide', beforeUnloadListener)
-    document.removeEventListener('visibilitychange', beforeUnloadListener)
   }
 
   // set up the listeners and prepare teardown callbacks
   window.addEventListener('popstate', popStateHandler)
   // https://developer.chrome.com/blog/page-lifecycle-api/
-  // note: iOS safari does not fire beforeunload, so we
-  // use pagehide and visibilitychange instead
+  // note: iOS safari does not fire beforeunload, so we use pagehide instead
   window.addEventListener('pagehide', beforeUnloadListener)
-  document.addEventListener('visibilitychange', beforeUnloadListener)
 
   return {
     pauseListeners,


### PR DESCRIPTION
## Summary

Fixes a regression introduced in Fixes a regression introduced in [#2537](https://github.com/vuejs/router/pull/2537) - discussed in [#2693](https://github.com/vuejs/router/discussions/2693). where adding a `visibilitychange` listener causes Edge on macOS (and Windows) to steal window focus during development.

## Root Cause

`visibilitychange` was firing too broadly even when a tab goes to the background, including during Vite HMR updates on a background tab. When that happens, `history.replaceState()` is called, and Edge on macOS activates the window at the OS level in response. Chrome is unaffected by the same call.

## Fix

Remove the `visibilitychange` listener and rely solely on `pagehide`, which:
- ✅ Fires on iOS Safari (preserves the original fix for #2536)
- ✅ Fires on page refresh, navigation, and bfcache entry
- ✅ Does **not** fire during HMR — eliminating the Edge focus steal

## Testing

- iOS Safari scroll restoration: confirmed working ✅
- Edge focus steal on macOS: confirmed fixed ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll position persistence when navigating away from pages. The router now more reliably saves and restores scroll state during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->