### PR TITLE
chore(ci): set explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -16,6 +16,9 @@ on:
       - 'packages/docs/**'
       - 'packages/playground/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'vuejs/router'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
       - 'packages/docs/**'
       - 'packages/playground/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit workflow `permissions` blocks to CI-related workflows
- set `GITHUB_TOKEN` scope to `contents: read`
- leave build/test/release-preview logic unchanged

## Why
Declaring token permissions explicitly reduces accidental over-privileging and aligns CI workflows with least-privilege defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to explicitly define job-level permissions, enhancing access control across build, test, and end-to-end testing workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/router/pull/2708)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->