### PR TITLE
fix(volar): drop runtime `@vue/language-core` import

### DIFF
--- a/packages/router/src/volar/entries/sfc-route-blocks.ts
+++ b/packages/router/src/volar/entries/sfc-route-blocks.ts
@@ -1,5 +1,15 @@
-import { allCodeFeatures, type VueLanguagePlugin } from '@vue/language-core'
+import type { VueLanguagePlugin, CodeInformation } from '@vue/language-core'
 import { replace, toString } from 'muggle-string'
+
+// inlined from `@vue/language-core` to avoid an implicit dependency
+const allCodeFeatures = {
+  verification: true,
+  completion: true,
+  semantic: true,
+  navigation: true,
+  structure: true,
+  format: true,
+} satisfies CodeInformation
 
 const plugin: VueLanguagePlugin = () => {
   const routeBlockIdPrefix = 'route_'


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/35009

an alternative would be specifying `@vue/language-core` as an optional peer dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization with no impact on user-facing functionality. Plugin behavior and behavior remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/router/pull/2710)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->