### PR TITLE
fix(types): add vite as optional peer dependency

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -202,7 +202,7 @@
     "@pinia/colada": ">=0.21.2",
     "@vue/compiler-sfc": "^3.5.34",
     "pinia": "^3.0.4",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+    "vite": "^7.0.0 || ^8.0.0",
     "vue": "^3.5.34"
   },
   "peerDependenciesMeta": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -202,6 +202,7 @@
     "@pinia/colada": ">=0.21.2",
     "@vue/compiler-sfc": "^3.5.34",
     "pinia": "^3.0.4",
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "vue": "^3.5.34"
   },
   "peerDependenciesMeta": {
@@ -212,6 +213,9 @@
       "optional": true
     },
     "@pinia/colada": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   },


### PR DESCRIPTION
In strict package managers like pnpm with hoist=false, the vite package is not resolvable from vue-router's package directory, causing type errors such as "Cannot find module 'vite'". Adding vite as an optional peerDependency ensures the types are correctly resolved in monorepos.

Closes #2711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Declared Vite 7 and 8 as optional peer dependencies for the router package, allowing compatibility with those Vite versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/router/pull/2712)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->