### PR TITLE
feat: typed definePage params.path

### DIFF
--- a/packages/playground-file-based/src/pages/a.[b].c.[d].vue
+++ b/packages/playground-file-based/src/pages/a.[b].c.[d].vue
@@ -10,11 +10,6 @@ definePage({
 })
 
 const route = useRoute()
-
-function test() {
-  if (route.params.b === 'ok') {
-  }
-}
 </script>
 
 <template>

--- a/packages/playground-file-based/src/pages/a.[b].c.[d].vue
+++ b/packages/playground-file-based/src/pages/a.[b].c.[d].vue
@@ -10,6 +10,11 @@ definePage({
 })
 
 const route = useRoute()
+
+function test() {
+  if (route.params.b === 'ok') {
+  }
+}
 </script>
 
 <template>

--- a/packages/playground-file-based/src/pages/u[name].vue
+++ b/packages/playground-file-based/src/pages/u[name].vue
@@ -1,4 +1,17 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import { useRoute } from 'vue-router'
+
+definePage({
+  params: {
+    path: {
+      name: 'date',
+    },
+  },
+})
+
+const route = useRoute()
+route.params.name
+</script>
 
 <template>
   <h1>Named param</h1>

--- a/packages/playground-file-based/src/pages/u[name]/24.vue
+++ b/packages/playground-file-based/src/pages/u[name]/24.vue
@@ -1,4 +1,17 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import { useRoute } from 'vue-router'
+
+definePage({
+  params: {
+    path: {
+      // name: 'date',
+    },
+  },
+})
+
+const route = useRoute()
+route.params.name
+</script>
 
 <template>
   <h2>Nested [name] page</h2>

--- a/packages/playground-file-based/src/routes.d.ts
+++ b/packages/playground-file-based/src/routes.d.ts
@@ -36,6 +36,7 @@ declare module 'vue-router' {
       | 'semver'
       | 'version-range'
     RouteNamedMap: import('vue-router/auto-routes').RouteNamedMap
+    _RouteFileInfoMap: import('vue-router/auto-routes')._RouteFileInfoMap
   }
 }
 
@@ -229,23 +230,23 @@ declare module 'vue-router/auto-routes' {
     '/u[name]': RouteRecordInfo<
       '/u[name]',
       '/u:name',
-      { name: string },
-      { name: string },
+      { name: Exclude<Param_date, unknown[] | null> },
+      { name: Exclude<Param_date, unknown[] | null> },
       | '/u[name]/24'
       | '/u[name]/[userId=int]'
     >,
     '/u[name]/[userId=int]': RouteRecordInfo<
       '/u[name]/[userId=int]',
       '/u:name/:userId',
-      { name: string, userId: number },
-      { name: string, userId: number },
+      { name: Exclude<Param_date, unknown[] | null>, userId: number },
+      { name: Exclude<Param_date, unknown[] | null>, userId: number },
       | never
     >,
     '/u[name]/24': RouteRecordInfo<
       '/u[name]/24',
       '/u:name/24',
-      { name: string },
-      { name: string },
+      { name: Exclude<Param_date, unknown[] | null> },
+      { name: Exclude<Param_date, unknown[] | null> },
       | never
     >,
     '/users/[userId=int]': RouteRecordInfo<
@@ -301,6 +302,8 @@ declare module 'vue-router/auto-routes' {
         | '/(home)'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/(packages)/_parent.vue': {
       routes:
@@ -310,47 +313,72 @@ declare module 'vue-router/auto-routes' {
         | '/(packages)/package/[[org=npm-org]]/[pkgName]/[pkgVersion=semver]'
       views:
         | 'default'
+      pathParamNames:
+        | never
     }
     'src/pages/(packages)/package/[[org=npm-org]]/[pkgName]/[pkgVersion=semver].vue': {
       routes:
         | '/(packages)/package/[[org=npm-org]]/[pkgName]/[pkgVersion=semver]'
       views:
         | never
+      pathParamNames:
+        | 'org'
+        | 'pkgName'
+        | 'pkgVersion'
     }
     'src/pages/(packages)/package-old/[[org]]/[pkgName]/[pkgVersion].vue': {
       routes:
         | '/(packages)/package-old/[[org]]/[pkgName]/[pkgVersion]'
       views:
         | never
+      pathParamNames:
+        | 'org'
+        | 'pkgName'
+        | 'pkgVersion'
     }
     'src/pages/(packages)/package-range/[[org=npm-org]]/[pkgName]/[pkgVersion=version-range].vue': {
       routes:
         | '/(packages)/package-range/[[org=npm-org]]/[pkgName]/[pkgVersion=version-range]'
       views:
         | never
+      pathParamNames:
+        | 'org'
+        | 'pkgName'
+        | 'pkgVersion'
     }
     'src/pages/(packages)/package-zod/[[org=npm-org]]/[pkgName]/[pkgVersion].vue': {
       routes:
         | '/(packages)/package-zod/[[org=npm-org]]/[pkgName]/[pkgVersion]'
       views:
         | never
+      pathParamNames:
+        | 'org'
+        | 'pkgName'
+        | 'pkgVersion'
     }
     'src/pages/[...path].vue': {
       routes:
         | 'not-found'
       views:
         | never
+      pathParamNames:
+        | 'path'
     }
     'src/pages/a.[b].c.[d].vue': {
       routes:
         | '/a.[b].c.[d]'
       views:
         | never
+      pathParamNames:
+        | 'b'
+        | 'd'
     }
     'src/pages/about.vue': {
       routes:
         | '/about'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/b.vue': {
@@ -358,23 +386,31 @@ declare module 'vue-router/auto-routes' {
         | '/b'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/blog/[slug]+.vue': {
       routes:
         | '/blog/[slug]+'
       views:
         | never
+      pathParamNames:
+        | 'slug'
     }
     'src/pages/blog/[[slugOptional]]+.vue': {
       routes:
         | '/blog/[[slugOptional]]+'
       views:
         | never
+      pathParamNames:
+        | 'slugOptional'
     }
     'src/pages/blog/info/(info).vue': {
       routes:
         | '/blog/info/(info)'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/blog/info/[[section]].vue': {
@@ -382,11 +418,15 @@ declare module 'vue-router/auto-routes' {
         | '/blog/info/[[section]]'
       views:
         | never
+      pathParamNames:
+        | 'section'
     }
     'src/pages/emoji-🤡.vue': {
       routes:
         | '/emoji-🤡'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/events/[when=date].vue': {
@@ -394,17 +434,23 @@ declare module 'vue-router/auto-routes' {
         | '/events/[when=date]'
       views:
         | never
+      pathParamNames:
+        | 'when'
     }
     'src/pages/events/repeat/[when=date]+.vue': {
       routes:
         | '/events/repeat/[when=date]+'
       views:
         | never
+      pathParamNames:
+        | 'when'
     }
     'src/pages/it\'s-fine/(lol).vue': {
       routes:
         | '/it\'s-fine/(lol)'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/months/valibot-[month=month-valibot].vue': {
@@ -412,18 +458,25 @@ declare module 'vue-router/auto-routes' {
         | '/months/valibot-[month=month-valibot]'
       views:
         | never
+      pathParamNames:
+        | 'month'
     }
     'src/pages/months/zod-[month=month-zod].vue': {
       routes:
         | '/months/zod-[month=month-zod]'
       views:
         | never
+      pathParamNames:
+        | 'month'
     }
     'src/pages/multi.[a].[b].vue': {
       routes:
         | '/multi.[a].[b]'
       views:
         | never
+      pathParamNames:
+        | 'a'
+        | 'b'
     }
     'src/pages/nested/_parent.vue': {
       routes:
@@ -431,11 +484,15 @@ declare module 'vue-router/auto-routes' {
         | '/nested/other'
       views:
         | 'default'
+      pathParamNames:
+        | never
     }
     'src/pages/nested/index.vue': {
       routes:
         | '/nested/'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/nested/other.vue': {
@@ -443,30 +500,40 @@ declare module 'vue-router/auto-routes' {
         | '/nested/other'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/opt.[[num=int]].vue': {
       routes:
         | '/opt.[[num=int]]'
       views:
         | never
+      pathParamNames:
+        | 'num'
     }
     'src/pages/tests/[[optional]]/end.vue': {
       routes:
         | '/tests/[[optional]]/end'
       views:
         | never
+      pathParamNames:
+        | 'optional'
     }
     'src/pages/tests/users/[username]/(user-home)/(user-home).vue': {
       routes:
         | '/tests/users/[username]/(user-home)/(user-home)'
       views:
         | never
+      pathParamNames:
+        | 'username'
     }
     'src/pages/tests/users/[username]/(user)/profile.vue': {
       routes:
         | '/tests/users/[username]/(user)/profile'
       views:
         | never
+      pathParamNames:
+        | 'username'
     }
     'src/pages/u[name].vue': {
       routes:
@@ -475,35 +542,49 @@ declare module 'vue-router/auto-routes' {
         | '/u[name]/[userId=int]'
       views:
         | 'default'
+      pathParamNames:
+        | 'name'
     }
     'src/pages/u[name]/[userId=int].vue': {
       routes:
         | '/u[name]/[userId=int]'
       views:
         | never
+      pathParamNames:
+        | 'name'
+        | 'userId'
     }
     'src/pages/u[name]/24.vue': {
       routes:
         | '/u[name]/24'
       views:
         | never
+      pathParamNames:
+        | 'name'
     }
     'src/pages/users/[userId=int].vue': {
       routes:
         | '/users/[userId=int]'
       views:
         | never
+      pathParamNames:
+        | 'userId'
     }
     'src/pages/users/sub-[first]-[second].vue': {
       routes:
         | '/users/sub-[first]-[second]'
       views:
         | never
+      pathParamNames:
+        | 'first'
+        | 'second'
     }
     'src/pages/with-layout/(home).vue': {
       routes:
         | '/with-layout/(home)'
       views:
+        | never
+      pathParamNames:
         | never
     }
     'src/pages/with-layout/+layout.vue': {
@@ -511,11 +592,15 @@ declare module 'vue-router/auto-routes' {
         | '/with-layout/+layout'
       views:
         | never
+      pathParamNames:
+        | never
     }
     'src/pages/with-layout/other.vue': {
       routes:
         | '/with-layout/other'
       views:
+        | never
+      pathParamNames:
         | never
     }
   }

--- a/packages/router/src/experimental/index.ts
+++ b/packages/router/src/experimental/index.ts
@@ -62,6 +62,7 @@ export {
   type ParamParserType,
   type ParamParserType_Native,
   type DefinePageQueryParamOptions,
+  type _PathParamNamesForFilePath,
 } from './runtime'
 
 // Data loaders exports

--- a/packages/router/src/experimental/index.ts
+++ b/packages/router/src/experimental/index.ts
@@ -62,7 +62,7 @@ export {
   type ParamParserType,
   type ParamParserType_Native,
   type DefinePageQueryParamOptions,
-  type _PathParamNamesForFilePath,
+  type PathParamNamesForFilePath as _PathParamNamesForFilePath,
 } from './runtime'
 
 // Data loaders exports

--- a/packages/router/src/experimental/runtime.ts
+++ b/packages/router/src/experimental/runtime.ts
@@ -6,11 +6,40 @@ import type { RouteRecordRaw } from '../types'
  * Helper to define page properties with file-based routing.
  * **Doesn't do anything**, used for types only.
  *
+ * The `FilePath` type parameter is injected by the `sfc-typed-router` Volar
+ * plugin so that `params.path` keys are restricted to the file's actual path
+ * params. When omitted, `params.path` falls back to a loose record.
+ *
  * @param route - route information to be added to this page
  *
  * @internal
  */
-export const definePage = (route: DefinePage) => route
+export function definePage<FilePath extends string = string>(
+  route: DefinePage<FilePath>
+): DefinePage<FilePath> {
+  return route
+}
+
+/**
+ * Resolves the union of valid path-param names for a given file path. Falls
+ * back to `string` when no entry is augmented (default Volar-less usage).
+ *
+ * Wired via the `_RouteFileInfoMap` slot in the user's augmented
+ * {@link TypesConfig} so the lookup survives the bundler that otherwise
+ * inlines an empty version of the base interface.
+ *
+ * @internal
+ */
+export type _PathParamNamesForFilePath<FilePath extends string> =
+  TypesConfig extends { _RouteFileInfoMap: infer Map }
+    ? Map extends Record<FilePath, infer Info>
+      ? Info extends { pathParamNames: infer N }
+        ? N extends string
+          ? N
+          : string
+        : string
+      : string
+    : string
 
 /**
  * Merges route records.
@@ -45,8 +74,12 @@ export function _mergeRouteRecord(
 
 /**
  * Type to define a page. Can be augmented to add custom properties.
+ *
+ * @typeParam FilePath - File path of the SFC declaring this page, used to
+ * narrow `params.path` keys to the actual path parameters of the route. When
+ * left as the default `string`, keys are unrestricted.
  */
-export interface DefinePage extends Partial<
+export interface DefinePage<FilePath extends string = string> extends Partial<
   Omit<RouteRecordRaw, 'children' | 'components' | 'component' | 'name'>
 > {
   /**
@@ -61,7 +94,9 @@ export interface DefinePage extends Partial<
    * @experimental
    */
   params?: {
-    path?: Record<string, ParamParserType>
+    path?: string extends FilePath
+      ? Record<string, ParamParserType>
+      : { [K in _PathParamNamesForFilePath<FilePath>]?: ParamParserType }
 
     /**
      * Parameters extracted from the query.

--- a/packages/router/src/experimental/runtime.ts
+++ b/packages/router/src/experimental/runtime.ts
@@ -92,9 +92,10 @@ export interface DefinePage<FilePath extends string = string> extends Partial<
    * @experimental
    */
   params?: {
-    path?: string extends FilePath
-      ? Record<string, ParamParserType>
-      : { [K in PathParamNamesForFilePath<FilePath>]?: ParamParserType }
+    /**
+     * Parameters extracted from the path. Allows to setup custom parsers without changing the filename.
+     */
+    path?: { [K in PathParamNamesForFilePath<FilePath>]?: ParamParserType }
 
     /**
      * Parameters extracted from the query.

--- a/packages/router/src/experimental/runtime.ts
+++ b/packages/router/src/experimental/runtime.ts
@@ -30,15 +30,13 @@ export function definePage<FilePath extends string = string>(
  *
  * @internal
  */
-export type _PathParamNamesForFilePath<FilePath extends string> =
-  TypesConfig extends { _RouteFileInfoMap: infer Map }
-    ? Map extends Record<FilePath, infer Info>
-      ? Info extends { pathParamNames: infer N }
-        ? N extends string
-          ? N
-          : string
-        : string
-      : string
+export type PathParamNamesForFilePath<FilePath extends string> =
+  TypesConfig extends {
+    _RouteFileInfoMap: {
+      [K in FilePath]: { pathParamNames: infer N extends string }
+    }
+  }
+    ? N
     : string
 
 /**
@@ -96,7 +94,7 @@ export interface DefinePage<FilePath extends string = string> extends Partial<
   params?: {
     path?: string extends FilePath
       ? Record<string, ParamParserType>
-      : { [K in _PathParamNamesForFilePath<FilePath>]?: ParamParserType }
+      : { [K in PathParamNamesForFilePath<FilePath>]?: ParamParserType }
 
     /**
      * Parameters extracted from the query.

--- a/packages/router/src/unplugin/codegen/generateDTS.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateDTS.spec.ts
@@ -37,6 +37,7 @@ describe('generateDTS', () => {
           ParamParsers:
 
           RouteNamedMap: import('vue-router/auto-routes').RouteNamedMap
+          _RouteFileInfoMap: import('vue-router/auto-routes')._RouteFileInfoMap
         }
       }
 
@@ -98,5 +99,6 @@ describe('generateDTS', () => {
       "expected a 'declare module \\'vue-router\\'' block"
     ).toBeTruthy()
     expect(vueRouterBlock).toContain('RouteNamedMap:')
+    expect(vueRouterBlock).toContain('_RouteFileInfoMap:')
   })
 })

--- a/packages/router/src/unplugin/codegen/generateDTS.ts
+++ b/packages/router/src/unplugin/codegen/generateDTS.ts
@@ -62,6 +62,7 @@ ${paramsTypesDeclaration}
     ParamParsers:
 ${customParamsTypeList.map(literal => ' '.repeat(6) + '| ' + literal).join('\n')}
     RouteNamedMap: import('${routesModule}').RouteNamedMap
+    _RouteFileInfoMap: import('${routesModule}')._RouteFileInfoMap
   }
 }
 

--- a/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.spec.ts
@@ -522,6 +522,46 @@ describe('generateRouteFileInfoMap', () => {
       `)
   })
 
+  it('excludes both ancestor and descendant path params from each file', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    tree.insert('[a]', 'src/pages/[a].vue')
+    tree.insert('[a]/[b]', 'src/pages/[a]/[b].vue')
+    tree.insert('[a]/[b]/[c]', 'src/pages/[a]/[b]/[c].vue')
+
+    expect(formatExports(generateRouteFileInfoMap(tree, { root: '' })))
+      .toMatchInlineSnapshot(`
+        "export interface _RouteFileInfoMap {
+          'src/pages/[a].vue': {
+            routes:
+              | '/[a]'
+              | '/[a]/[b]'
+              | '/[a]/[b]/[c]'
+            views:
+              | 'default'
+            pathParamNames:
+              | 'a'
+          }
+          'src/pages/[a]/[b].vue': {
+            routes:
+              | '/[a]/[b]'
+              | '/[a]/[b]/[c]'
+            views:
+              | 'default'
+            pathParamNames:
+              | 'b'
+          }
+          'src/pages/[a]/[b]/[c].vue': {
+            routes:
+              | '/[a]/[b]/[c]'
+            views:
+              | never
+            pathParamNames:
+              | 'c'
+          }
+        }"
+      `)
+  })
+
   it('escapes quoites in file paths', () => {
     const tree = new PrefixTree(DEFAULT_OPTIONS)
     tree.insert('path', "src/pages/it's fine.vue")

--- a/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.spec.ts
@@ -480,7 +480,7 @@ describe('generateRouteFileInfoMap', () => {
       `)
   })
 
-  it('lists path param names for the file (including ancestors)', () => {
+  it('lists path param names owned by the file segment only', () => {
     const tree = new PrefixTree(DEFAULT_OPTIONS)
     tree.insert('a.[b].c.[d]', 'src/pages/a.[b].c.[d].vue')
     tree.insert('users/[userId]', 'src/pages/users/[userId].vue')
@@ -517,7 +517,6 @@ describe('generateRouteFileInfoMap', () => {
               | never
             pathParamNames:
               | 'postId'
-              | 'userId'
           }
         }"
       `)

--- a/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.spec.ts
@@ -27,11 +27,15 @@ describe('generateRouteFileInfoMap', () => {
               | '/'
             views:
               | never
+            pathParamNames:
+              | never
           }
           'src/pages/a.vue': {
             routes:
               | '/a'
             views:
+              | never
+            pathParamNames:
               | never
           }
           'src/pages/b.vue': {
@@ -39,11 +43,15 @@ describe('generateRouteFileInfoMap', () => {
               | '/b'
             views:
               | never
+            pathParamNames:
+              | never
           }
           'src/pages/c.vue': {
             routes:
               | '/c'
             views:
+              | never
+            pathParamNames:
               | never
           }
         }"
@@ -109,121 +117,151 @@ describe('generateRouteFileInfoMap', () => {
 
     expect(formatExports(generateRouteFileInfoMap(tree, { root: '' })))
       .toMatchInlineSnapshot(`
-      "export interface _RouteFileInfoMap {
-        '(auth).vue': {
-          routes:
-            | '/(auth)'
-            | '/(auth)/another'
-            | '/(auth)/deposit'
-            | '/(auth)/foo'
-            | '/(auth)/foo/bar'
-            | '/(auth)/foo/foo'
-            | '/(auth)/home'
-            | '/(auth)/login-another'
-            | '/(auth)/settings'
-            | '/(auth)/settings/edit-account'
-            | '/(auth)/settings/edit-email'
-            | '/(auth)/settings/edit-password'
-            | '/(auth)/settings/edit-phone-number'
-            | '/(auth)/settings/two-factor'
-            | '/(auth)/settings/verify-phone-number'
-          views:
-            | 'default'
-        }
-        '(auth)/another/index.vue': {
-          routes:
-            | '/(auth)/another'
-          views:
-            | never
-        }
-        '(auth)/deposit/index.vue': {
-          routes:
-            | '/(auth)/deposit'
-          views:
-            | never
-        }
-        '(auth)/foo/index.vue': {
-          routes:
-            | '/(auth)/foo'
-            | '/(auth)/foo/bar'
-            | '/(auth)/foo/foo'
-          views:
-            | 'default'
-        }
-        '(auth)/foo/bar.vue': {
-          routes:
-            | '/(auth)/foo/bar'
-          views:
-            | never
-        }
-        '(auth)/foo/foo.vue': {
-          routes:
-            | '/(auth)/foo/foo'
-          views:
-            | never
-        }
-        '(auth)/home/index.vue': {
-          routes:
-            | '/(auth)/home'
-          views:
-            | never
-        }
-        '(auth)/login-another/index.vue': {
-          routes:
-            | '/(auth)/login-another'
-          views:
-            | never
-        }
-        '(auth)/settings/index.vue': {
-          routes:
-            | '/(auth)/settings'
-            | '/(auth)/settings/edit-account'
-            | '/(auth)/settings/edit-email'
-            | '/(auth)/settings/edit-password'
-            | '/(auth)/settings/edit-phone-number'
-            | '/(auth)/settings/two-factor'
-            | '/(auth)/settings/verify-phone-number'
-          views:
-            | 'default'
-        }
-        '(auth)/settings/edit-account.vue': {
-          routes:
-            | '/(auth)/settings/edit-account'
-          views:
-            | never
-        }
-        '(auth)/settings/edit-email.vue': {
-          routes:
-            | '/(auth)/settings/edit-email'
-          views:
-            | never
-        }
-        '(auth)/settings/edit-password.vue': {
-          routes:
-            | '/(auth)/settings/edit-password'
-          views:
-            | never
-        }
-        '(auth)/settings/edit-phone-number.vue': {
-          routes:
-            | '/(auth)/settings/edit-phone-number'
-          views:
-            | never
-        }
-        '(auth)/settings/two-factor.vue': {
-          routes:
-            | '/(auth)/settings/two-factor'
-          views:
-            | never
-        }
-        '(auth)/settings/verify-phone-number.vue': {
-          routes:
-            | '/(auth)/settings/verify-phone-number'
-          views:
-            | never
-        }
-      }"
-    `)
+        "export interface _RouteFileInfoMap {
+          '(auth).vue': {
+            routes:
+              | '/(auth)'
+              | '/(auth)/another'
+              | '/(auth)/deposit'
+              | '/(auth)/foo'
+              | '/(auth)/foo/bar'
+              | '/(auth)/foo/foo'
+              | '/(auth)/home'
+              | '/(auth)/login-another'
+              | '/(auth)/settings'
+              | '/(auth)/settings/edit-account'
+              | '/(auth)/settings/edit-email'
+              | '/(auth)/settings/edit-password'
+              | '/(auth)/settings/edit-phone-number'
+              | '/(auth)/settings/two-factor'
+              | '/(auth)/settings/verify-phone-number'
+            views:
+              | 'default'
+            pathParamNames:
+              | never
+          }
+          '(auth)/another/index.vue': {
+            routes:
+              | '/(auth)/another'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/deposit/index.vue': {
+            routes:
+              | '/(auth)/deposit'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/foo/index.vue': {
+            routes:
+              | '/(auth)/foo'
+              | '/(auth)/foo/bar'
+              | '/(auth)/foo/foo'
+            views:
+              | 'default'
+            pathParamNames:
+              | never
+          }
+          '(auth)/foo/bar.vue': {
+            routes:
+              | '/(auth)/foo/bar'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/foo/foo.vue': {
+            routes:
+              | '/(auth)/foo/foo'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/home/index.vue': {
+            routes:
+              | '/(auth)/home'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/login-another/index.vue': {
+            routes:
+              | '/(auth)/login-another'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/index.vue': {
+            routes:
+              | '/(auth)/settings'
+              | '/(auth)/settings/edit-account'
+              | '/(auth)/settings/edit-email'
+              | '/(auth)/settings/edit-password'
+              | '/(auth)/settings/edit-phone-number'
+              | '/(auth)/settings/two-factor'
+              | '/(auth)/settings/verify-phone-number'
+            views:
+              | 'default'
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/edit-account.vue': {
+            routes:
+              | '/(auth)/settings/edit-account'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/edit-email.vue': {
+            routes:
+              | '/(auth)/settings/edit-email'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/edit-password.vue': {
+            routes:
+              | '/(auth)/settings/edit-password'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/edit-phone-number.vue': {
+            routes:
+              | '/(auth)/settings/edit-phone-number'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/two-factor.vue': {
+            routes:
+              | '/(auth)/settings/two-factor'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+          '(auth)/settings/verify-phone-number.vue': {
+            routes:
+              | '/(auth)/settings/verify-phone-number'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+        }"
+      `)
   })
 
   it('produces stable output for sibling group folders with same path', () => {
@@ -263,11 +301,15 @@ describe('generateRouteFileInfoMap', () => {
               | '/parent/child'
             views:
               | 'default'
+            pathParamNames:
+              | never
           }
           'src/pages/parent/child.vue': {
             routes:
               | '/parent/child'
             views:
+              | never
+            pathParamNames:
               | never
           }
         }"
@@ -289,17 +331,23 @@ describe('generateRouteFileInfoMap', () => {
             views:
               | 'default'
               | 'test'
+            pathParamNames:
+              | never
           }
           'src/pages/parent/child.vue': {
             routes:
               | '/parent/child'
             views:
               | never
+            pathParamNames:
+              | never
           }
           'src/pages/parent/child@test.vue': {
             routes:
               | '/parent/child'
             views:
+              | never
+            pathParamNames:
               | never
           }
         }"
@@ -324,12 +372,16 @@ describe('generateRouteFileInfoMap', () => {
               | '/home'
             views:
               | never
+            pathParamNames:
+              | never
           }
           'nested/index.vue': {
             routes:
               | '/nested/path'
               | '/unnested'
             views:
+              | never
+            pathParamNames:
               | never
           }
         }"
@@ -353,18 +405,24 @@ describe('generateRouteFileInfoMap', () => {
               | '/optional/[[id]]'
             views:
               | never
+            pathParamNames:
+              | 'id'
           }
           'optional-repeatable/[[id]]+.vue': {
             routes:
               | '/optional-repeatable/[[id]]+'
             views:
               | never
+            pathParamNames:
+              | 'id'
           }
           'repeatable/[id]+.vue': {
             routes:
               | '/repeatable/[id]+'
             views:
               | never
+            pathParamNames:
+              | 'id'
           }
         }"
       `)
@@ -391,24 +449,75 @@ describe('generateRouteFileInfoMap', () => {
               | '/parent/repeatable/[id]+'
             views:
               | 'default'
+            pathParamNames:
+              | never
           }
           'parent/optional/[[id]].vue': {
             routes:
               | '/parent/optional/[[id]]'
             views:
               | never
+            pathParamNames:
+              | 'id'
           }
           'parent/optional-repeatable/[[id]]+.vue': {
             routes:
               | '/parent/optional-repeatable/[[id]]+'
             views:
               | never
+            pathParamNames:
+              | 'id'
           }
           'parent/repeatable/[id]+.vue': {
             routes:
               | '/parent/repeatable/[id]+'
             views:
               | never
+            pathParamNames:
+              | 'id'
+          }
+        }"
+      `)
+  })
+
+  it('lists path param names for the file (including ancestors)', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    tree.insert('a.[b].c.[d]', 'src/pages/a.[b].c.[d].vue')
+    tree.insert('users/[userId]', 'src/pages/users/[userId].vue')
+    tree.insert(
+      'users/[userId]/posts/[postId]',
+      'src/pages/users/[userId]/posts/[postId].vue'
+    )
+
+    expect(formatExports(generateRouteFileInfoMap(tree, { root: '' })))
+      .toMatchInlineSnapshot(`
+        "export interface _RouteFileInfoMap {
+          'src/pages/a.[b].c.[d].vue': {
+            routes:
+              | '/a.[b].c.[d]'
+            views:
+              | never
+            pathParamNames:
+              | 'b'
+              | 'd'
+          }
+          'src/pages/users/[userId].vue': {
+            routes:
+              | '/users/[userId]'
+              | '/users/[userId]/posts/[postId]'
+            views:
+              | 'default'
+            pathParamNames:
+              | 'userId'
+          }
+          'src/pages/users/[userId]/posts/[postId].vue': {
+            routes:
+              | '/users/[userId]/posts/[postId]'
+            views:
+              | never
+            pathParamNames:
+              | 'postId'
+              | 'userId'
           }
         }"
       `)
@@ -420,14 +529,16 @@ describe('generateRouteFileInfoMap', () => {
 
     expect(formatExports(generateRouteFileInfoMap(tree, { root: '' })))
       .toMatchInlineSnapshot(`
-      "export interface _RouteFileInfoMap {
-        'src/pages/it\\'s fine.vue': {
-          routes:
-            | '/path'
-          views:
-            | never
-        }
-      }"
-    `)
+        "export interface _RouteFileInfoMap {
+          'src/pages/it\\'s fine.vue': {
+            routes:
+              | '/path'
+            views:
+              | never
+            pathParamNames:
+              | never
+          }
+        }"
+      `)
   })
 })

--- a/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.ts
@@ -20,7 +20,10 @@ export function generateRouteFileInfoMap(
     .flatMap(child => generateRouteFileInfoLines(child, root))
 
   // because the same file can be used for multiple routes, we need to group them
-  const routesInfo = new Map<string, { routes: string[]; views: string[] }>()
+  const routesInfo = new Map<
+    string,
+    { routes: string[]; views: string[]; pathParamNames: string[] }
+  >()
   for (const routeInfo of routesInfoList) {
     // ensure we have an entry for the file
     let info = routesInfo.get(routeInfo.key)
@@ -30,23 +33,30 @@ export function generateRouteFileInfoMap(
         (info = {
           routes: [],
           views: [],
+          pathParamNames: [],
         })
       )
     }
 
     info.routes.push(...routeInfo.routeNames)
     info.views.push(...(routeInfo.childrenNamedViews || []))
+    info.pathParamNames.push(...routeInfo.pathParamNames)
   }
 
   const code = Array.from(routesInfo.entries())
     .map(
-      ([file, { routes, views }]) =>
+      ([file, { routes, views, pathParamNames }]) =>
         `
   ${toStringLiteral(file)}: {
     routes:
       ${formatMultilineUnion(routes.sort().map(toStringLiteral), 6)}
     views:
       ${formatMultilineUnion(views.sort().map(toStringLiteral), 6)}
+    pathParamNames:
+      ${formatMultilineUnion(
+        Array.from(new Set(pathParamNames)).sort().map(toStringLiteral),
+        6
+      )}
   }`
     )
     .join('\n')
@@ -66,6 +76,7 @@ function generateRouteFileInfoLines(
   key: string
   routeNames: string[]
   childrenNamedViews: string[] | null
+  pathParamNames: string[]
 }> {
   const deepChildren =
     node.children.size > 0 ? node.getChildrenDeepSorted() : null
@@ -92,6 +103,11 @@ function generateRouteFileInfoLines(
       return acc
     }, [])
 
+  // All path param names visible to this file's own route, including those
+  // contributed by ancestor segments. Children's params live in their own
+  // files and are recursed below.
+  const pathParamNames = node.pathParams.map(p => p.paramName)
+
   // Most of the time we only have one view, but with named views we can have multiple.
   const currentRouteInfo =
     routeNames.length === 0
@@ -100,6 +116,7 @@ function generateRouteFileInfoLines(
           key: relative(rootDir, file).replaceAll('\\', '/'),
           routeNames,
           childrenNamedViews: deepChildrenNamedViews,
+          pathParamNames,
         }))
 
   const childrenRouteInfo = node

--- a/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteFileInfoMap.ts
@@ -103,10 +103,12 @@ function generateRouteFileInfoLines(
       return acc
     }, [])
 
-  // All path param names visible to this file's own route, including those
-  // contributed by ancestor segments. Children's params live in their own
-  // files and are recursed below.
-  const pathParamNames = node.pathParams.map(p => p.paramName)
+  // Only params owned by this node's own segment. Ancestor params belong to
+  // their own files (and cannot be retyped from here via `definePage()`), and
+  // children's params live in their own files and are recursed below.
+  const pathParamNames = node.value.isParam()
+    ? node.value.pathParams.map(p => p.paramName)
+    : []
 
   // Most of the time we only have one view, but with named views we can have multiple.
   const currentRouteInfo =

--- a/packages/router/src/volar/entries/sfc-typed-router.ts
+++ b/packages/router/src/volar/entries/sfc-typed-router.ts
@@ -51,8 +51,16 @@ const plugin: VueLanguagePlugin<{ options?: { rootDir?: string } }> = ({
       // NOTE: this might not work if different from the root passed to VueRouter unplugin
       const relativeFilePath = rootDir ? relative(rootDir, fileName) : fileName
 
-      const useRouteNameType = `import('vue-router/auto-routes')._RouteNamesForFilePath<'${relativeFilePath}'>`
+      // Escape backslashes/apostrophes so we can safely embed the file path
+      // inside a single-quoted TS string literal type argument.
+      const escapedFilePath = relativeFilePath
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+
+      const useRouteNameType = `import('vue-router/auto-routes')._RouteNamesForFilePath<'${escapedFilePath}'>`
       const useRouteNameTypeParam = `<${useRouteNameType}>`
+
+      const definePageFilePathTypeParam = `<'${escapedFilePath}'>`
 
       if (sfc.scriptSetup) {
         visit(sfc.scriptSetup.ast)
@@ -91,6 +99,23 @@ const plugin: VueLanguagePlugin<{ options?: { rootDir?: string } }> = ({
               ` as ReturnType<typeof useRoute${useRouteNameTypeParam}>)`
             )
           }
+        } else if (
+          ts.isCallExpression(node) &&
+          ts.isIdentifier(node.expression) &&
+          ts.idText(node.expression) === 'definePage' &&
+          !node.typeArguments &&
+          node.arguments.length === 1 &&
+          !sfc.scriptSetup!.lang.startsWith('js')
+        ) {
+          // Inject the file path so `definePage`'s `params.path` keys can be
+          // narrowed to this file's actual path params.
+          replaceSourceRange(
+            embeddedCode.content,
+            sfc.scriptSetup!.name,
+            node.expression.end,
+            node.expression.end,
+            definePageFilePathTypeParam
+          )
         } else {
           ts.forEachChild(node, visit)
         }

--- a/packages/router/vue-router-auto-routes.d.mts
+++ b/packages/router/vue-router-auto-routes.d.mts
@@ -37,6 +37,16 @@ export declare function handleHotUpdate(
 // TODO(v6): rename to `RouteMap` and host the interface directly on `vue-router`.
 export interface RouteNamedMap {}
 
+/**
+ * Map of route file paths (relative to the project root) to information about
+ * the routes they declare. Augmented from the user's generated `routes.d.ts`
+ * by the unplugin. Used by the `definePage` macro typing and the
+ * `sfc-typed-router` Volar plugin to type `useRoute()` per file.
+ *
+ * @internal
+ */
+export interface _RouteFileInfoMap {}
+
 // Make the macros globally available
 declare global {
   const definePage: (typeof import('vue-router/experimental'))['definePage']


### PR DESCRIPTION
Make `definePage` generic on the SFC's file path so `params.path` keys are
narrowed to the actual route path-params. The Volar plugin injects the
file path on bare `definePage(...)` calls, mirroring `useRoute()`.

- Codegen emits `pathParamNames` per file in `_RouteFileInfoMap`
- `_RouteFileInfoMap` wired through `TypesConfig` to survive d.ts bundling
- Volar plugin escapes apostrophes/backslashes in injected file paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Route parameters now support custom type parsers for stricter type checking
  * Enhanced route definition with improved type awareness for file-specific parameters

* **Improvements**
  * Strengthened type safety for route parameter validation
  * Better IDE support with improved type inference for route configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/router/pull/2716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->