### PR TITLE
fix(history): use absolute path on http(s) to keep userinfo

### DIFF
--- a/packages/router/__tests__/history/html5.spec.ts
+++ b/packages/router/__tests__/history/html5.spec.ts
@@ -93,13 +93,46 @@ describe('History HTMl5', () => {
     expect(spy).toHaveBeenCalledWith(
       expect.anything(),
       expect.any(String),
-      'http://localhost:3000/foo'
+      '/foo'
     )
     history.push('//foo')
     expect(spy).toHaveBeenLastCalledWith(
       expect.anything(),
       expect.any(String),
       'http://localhost:3000//foo'
+    )
+    spy.mockRestore()
+  })
+
+  it('passes an absolute path when document URL contains userinfo', () => {
+    getWindow().happyDOM.setURL('http://test:test@localhost:3000/')
+    const spy = vi.spyOn(window.history, 'replaceState')
+    createWebHistory()
+    expect(spy).toHaveBeenCalledWith(expect.anything(), expect.any(String), '/')
+    spy.mockRestore()
+  })
+
+  it('keeps userinfo when prepending the host for // urls', () => {
+    getWindow().happyDOM.setURL('http://test:test@localhost:3000/')
+    const history = createWebHistory()
+    const spy = vi.spyOn(window.history, 'pushState')
+    history.push('//foo')
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.any(String),
+      'http://test:test@localhost:3000//foo'
+    )
+    spy.mockRestore()
+  })
+
+  it('prepends the file:// origin on file documents without a hash base', () => {
+    getWindow().happyDOM.setURL('file:///app/index.html')
+    const spy = vi.spyOn(window.history, 'replaceState')
+    createWebHistory()
+    expect(spy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      'file:///app/index.html'
     )
     spy.mockRestore()
   })

--- a/packages/router/src/history/html5.ts
+++ b/packages/router/src/history/html5.ts
@@ -19,7 +19,17 @@ import { assign } from '../utils'
 
 type PopStateListener = (this: Window, ev: PopStateEvent) => any
 
-let createBaseLocation = () => location.protocol + '//' + location.host
+let createBaseLocation = () => {
+  // location.host omits userinfo, but pushState/replaceState on Chromium
+  // requires the URL to match the document URL including userinfo (#2714).
+  // Parse it back via the URL constructor.
+  const { protocol, host } = location
+  const { username, password } = new URL(location.href)
+  const userinfo = username
+    ? username + (password ? ':' + password : '') + '@'
+    : ''
+  return protocol + '//' + userinfo + host
+}
 
 interface StateEntry extends HistoryState {
   back: HistoryLocation | null
@@ -227,7 +237,14 @@ function useHistoryStateNavigation(base: string) {
         ? (location.host && document.querySelector('base')
             ? base
             : base.slice(hashIndex)) + to
-        : createBaseLocation() + base + to
+        : // pass an absolute path on http(s) so the browser resolves it
+          // against the document URL — preserves userinfo and avoids
+          // Chromium's SecurityError on basic-auth URLs (#2714). The explicit
+          // origin is still needed for file:// (no host) and protocol-relative
+          // `//` paths (#261).
+          location.protocol === 'file:' || (base + to).startsWith('//')
+          ? createBaseLocation() + base + to
+          : base + to
     try {
       // BROWSER QUIRK
       // NOTE: Safari throws a SecurityError when calling this function 100 times in 30 seconds


### PR DESCRIPTION
Refs #2714

## Problem
On Chromium, when the document URL contains userinfo (e.g.
`http://user:pass@host/` from an HTTP Basic-Auth challenge),
`createWebHistory()`'s initial `history.replaceState` throws
`SecurityError`. Chromium enforces userinfo equality on
`pushState`/`replaceState`, not just origin equality.

`changeLocation` builds the URL via
`createBaseLocation() + base + to`, where
`createBaseLocation = () => location.protocol + '//' + location.host`.
`location.host` is `hostname[:port]` by spec, so userinfo is dropped.
The resulting `replaceState` URL `http://host/` mismatches the
document URL `http://user:pass@host/` → `SecurityError` → the
surrounding try/catch falls back to `location.replace(url)`, which
silently reloads the page to the userinfo-less URL on the user's
first basic-auth visit, losing client-side state.

Live repro (Chromium, docker compose + nginx basic-auth):
https://github.com/gluebi/vue-router-5-basic-auth-repro

## Fix
Per your hint in #2714, skip `createBaseLocation()` for non-`file:`
protocols. Pass an absolute path (`base + to`) and let the browser
resolve it against the document URL — that preserves scheme +
userinfo + host + port automatically.

For the remaining branches (`file://` and protocol-relative `//`
paths), `createBaseLocation()` is still used. To keep userinfo there
as well, `createBaseLocation()` now reads it from `location.href`
via the URL constructor (since `location.host` strips it). file://
is unaffected in practice (no userinfo), but `push('//foo')` on a
credentialed document URL no longer hits the same `SecurityError`.

The protocol-relative `//` branch is preserved so the defense from
#261 isn't regressed.

## Tests
- New `passes an absolute path when document URL contains userinfo`
  regression for #2714 (happy-dom `setURL` simulates userinfo).
- New `keeps userinfo when prepending the host for // urls` covers
  the `createBaseLocation()` userinfo path (push('//foo') on a
  basic-auth URL retains `test:test@`).
- New `prepends the file:// origin on file documents without a hash base`
  covers the `location.protocol === 'file:'` branch (previously no
  file:// test ran without a hash base).
- Existing `prepends the host to support // urls` updated — `/foo`
  now asserts an absolute path; the `//foo` defense path is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed history URL handling so origins and protocol-relative paths are constructed correctly for file:// documents, protocol-relative (//) URLs, and URLs containing userinfo, preventing navigation errors.

* **Tests**
  * Expanded unit coverage for history behavior, including documents with userinfo, protocol-relative URLs, and file:// documents without a hash base; adjusted expectations for relative push/replace behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/router/pull/2717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->