### PR TITLE
docs: drop vue-router 4 references

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -13,7 +13,7 @@ Hi! I'm really excited that you are interested in contributing to Vue Router. Be
 ## Issue Reporting Guidelines
 
 - Always use [https://new-issue.vuejs.org/](https://new-issue.vuejs.org/) to create new issues.
-- Here is a template to report a bug: [https://codesandbox.io/s/vue-router-v4-reproduction-tk1y7](https://codesandbox.io/s/vue-router-v4-reproduction-tk1y7). Please use it when reporting a bug
+- Here is a template to report a bug: [Vue SFC Playground](https://play.vuejs.org/#eNqlVG1v2jAQ/iu3dBJUg5iyTZqyFLWrqnXTXqpu2pdlH0JiIG1iW7ZDqVD++8523ii0XyoEOHfP3T13z8Vbr4gz5t8qL/CyQnCpYQuJpLGm50JABQvJCxisSzqIWAuQvNRUtl6fOEMHMbGNLxbCd/ERazMP8XscMQC/VHTowt1zwUumh4MjDBsceyOvDkd+oaaFyDF+ZoDh6mR2RfOcm2KvQoKP1izsHx6UlpwtZxellJRpxxlErFdBSGofbLfw2jr8RZnn1+iEqrJpiMsTsnjdJLyxLL9l7A40P408EnmzzxzPcMULGpLO/2REPEdLG3ZunvbiQtLUDI02u7n+ZPQeSI2r3SFpB4PzcrP09QFFv9OCy4erTGn8G9VGl7ev9LhVs9XTNGhLN6I2hlrZRnbT0A6utbQrQDcWmnCmalEknO5wGW5NeytHMzjEfXg8MhAbrQL460a0derCgAywOY6UGAofdOQrG9UHWj120V0PDv4PfytcTRxtv2mzjyqRmdCgqC4F5DFbosRaobxGE+fEIz48WtzprMmEazvdU3BnZi+r06Y6WMipNi5igRcAZ1jKTj6qHVghAGsxtm4xjDnyVloLFRBSMnG39HGApEOcvScpKtWz+FQV47nk9wrPt5i5liLyzhBEUrrWnOdqHIvsqfR7wLMP/ok/7Sr1fXv1TDl8sytsWytcvkW2fNS02YEsp/Kn0Bku507zMd4z91+tTcuStuSTFU3uDthv1ca1cS0pMljTXsM6lkuKl4BxX/76QTd4bp0FT8sc0c84b6jieWk4OtinkqVIu4ezbL9YDTO2/K0uN5oy1TRliNppWLwV9uKZ1ju6b/13vSkq/ZBT5SfKXDR4Y43AXEcubs5lSmUAU7EBJJulcDSZTD4aV4HpMjaec615EcDJRGysXcRpimRbC1aJGKaFGcTwBr82cR2d0wW+qX3katqv3KXvCCRJ0iMQwAQ/0zqDV/0H+yxf5Q==). Please use it when reporting a bug
 
 ## Pull Request Guidelines
 

--- a/packages/docs/zh/installation.md
+++ b/packages/docs/zh/installation.md
@@ -1,3 +1,11 @@
+---
+# Updated automatically in Netlify builds: see the VitePress config.
+packageVersions:
+  vue: 3.5.28
+  vue-router: 5.0.2
+  '@vue/devtools-api': 8.0.6
+---
+
 # 安装
 
 <VueMasteryLogoLink></VueMasteryLogoLink>
@@ -9,15 +17,19 @@
 ::: code-group
 
 ```bash [npm]
-npm install vue-router@4
+npm install vue-router
 ```
 
 ```bash [yarn]
-yarn add vue-router@4
+yarn add vue-router
 ```
 
 ```bash [pnpm]
-pnpm add vue-router@4
+pnpm add vue-router
+```
+
+```bash [bun]
+bun add vue-router
 ```
 
 :::
@@ -38,6 +50,10 @@ yarn create vue
 pnpm create vue
 ```
 
+```bash [bun]
+bun create vue
+```
+
 :::
 
 你需要回答一些关于你想创建的项目类型的问题。如果您选择安装 Vue Router，示例应用还将演示 Vue Router 的一些核心特性。
@@ -46,14 +62,53 @@ pnpm create vue
 
 ## 直接下载 / CDN
 
-[https://unpkg.com/vue-router@4](https://unpkg.com/vue-router@4)
+如果你不想使用打包工具，你可以通过 CDN 或下载相关文件自行托管，直接在浏览器中加载 Vue Router。
 
-<!--email_off-->
+Vue Router 提供了多种预构建文件以覆盖不同的使用场景，与 Vue 类似。如果你还不熟悉 Vue 是如何处理这一点的，我们建议先阅读相关文档：
 
-[Unpkg.com](https://unpkg.com) 提供了基于 npm 的 CDN 链接。上述链接将始终指向 npm 上的最新版本。 你也可以通过像 `https://unpkg.com/vue-router@4.0.15/dist/vue-router.global.js` 这样的 URL 来使用特定的版本或 Tag。
+- <https://vuejs.org/guide/quick-start.html#using-vue-from-cdn>
 
-<!--/email_off-->
+Vue Router 同时支持 **_ES module_** 和 **_global_** 构建版本。我们推荐尽可能使用 ES modules。
 
-这将把 Vue Router 暴露在一个全局的 `VueRouter` 对象上，例如 `VueRouter.createRouter(...)`。
+无论选择哪种方式，对于你所使用的库，特别是在生产环境中，固定版本都很重要。这意味着你应该在 CDN URL 中包含你要使用的确切版本，而不是让 CDN 为你选择最新版本。
+
+每个构建都附带了开发版本和生产版本。开发版本明显更大，但包含了有助于调试的额外代码。生产版本的名称中带有 `.prod`。
+
+### 使用 ES modules
+
+```html-vue
+<script type="importmap">
+  {
+    "imports": {
+      "vue": "https://unpkg.com/vue@{{ $frontmatter.packageVersions.vue }}/dist/vue.esm-browser.js",
+      "vue-router": "https://unpkg.com/vue-router@{{ $frontmatter.packageVersions['vue-router'] }}/dist/vue-router.esm-browser.js",
+      "@vue/devtools-api": "https://unpkg.com/@vue/devtools-api@{{ $frontmatter.packageVersions['@vue/devtools-api'] }}/dist/vue-devtools-api.esm-browser.js"
+    }
+  }
+</script>
+<script type="module">
+  import { createApp } from 'vue'
+  import { createRouter } from 'vue-router'
+
+  // ...
+</script>
+```
+
+`@vue/devtools-api` 仅在使用 Vue Router 的开发构建版本时需要。当使用生产构建版本 `vue-router.esm-browser.prod.js` 时可以移除。
+
+### 使用 global 构建
+
+```html-vue
+<script src="https://unpkg.com/vue@{{ $frontmatter.packageVersions.vue }}/dist/vue.global.js"></script>
+<script src="https://unpkg.com/vue-router@{{ $frontmatter.packageVersions['vue-router'] }}/dist/vue-router.global.js"></script>
+<script>
+  const { createApp } = Vue
+  const { createRouter } = VueRouter
+
+  // ...
+</script>
+```
+
+对应的 Vue Router 生产构建版本为 `vue-router.global.prod.js`。
 
 <RuleKitLink />


### PR DESCRIPTION
## Summary
- Upgrade Chinese installation docs to mirror the English version (drop `@4` pinning, add bun, add CDN section with frontmatter package versions)
- Replace the v4 codesandbox reproduction link in contributing guide with the Vue SFC Playground link from README

## Test plan
- [ ] Docs site builds (`pnpm docs:build`)
- [ ] Chinese installation page renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated issue reporting template link for bug submissions
- Refreshed Chinese installation documentation with enhanced CDN setup guidance, including version pinning instructions and build type explanations
- Added Bun package manager installation support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/router/pull/2719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->