### PR TITLE
docs(exp): add modfiy vite config for use custom Parser

### DIFF
--- a/packages/docs/experimental/param-parsers.md
+++ b/packages/docs/experimental/param-parsers.md
@@ -44,6 +44,35 @@ A parser is just an object with a _getter_ and a _setter_ but to make things sim
 
 Reach for `defineParamParser` first, it's the most common use case for simple one-to-one transforms. Use `defineParamParserRaw` when you need to collapse multiple input shapes into one output type or you want to reject _nullish_ or array values outright.
 
+::: warning Configuration Required
+To make custom parsers work, you must enable the `experimental.paramParsers`
+option in the Vite plugin. This is what tells the plugin to scan your
+`src/params/` folder and register parsers both at runtime and in the generated
+`typed-router.d.ts`.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import VueRouter from 'vue-router/vite'
+
+export default defineConfig({
+  plugins: [
+    VueRouter({
+      experimental: {
+        paramParsers: true, 
+      },
+    }),
+    vue(),
+    // ....
+  ],
+})
+
+```
+Without this, the router won't find your custom parsers and you'll see errors like:
+[vue-router] Parameter parser "number" not found for route "/users/:id".
+:::
+
+
 ### `defineParamParser`
 
 `defineParamParser` defines a single-value transform. The router wraps it for optional/repeatable usage and handles `null`/arrays for you.

--- a/packages/docs/experimental/param-parsers.md
+++ b/packages/docs/experimental/param-parsers.md
@@ -18,6 +18,31 @@ In the stable router, params and query come in as `string | string[] | null`. Yo
 
 This works but the type system can't help you, every consumer has to know the convention, and query params are even worse.
 
+## Setup
+
+Enable `experimental.paramParsers` in the Vue Router Vite plugin. This tells the plugin where to scan for custom parsers and registers them both at runtime and in the generated `typed-router.d.ts`.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import VueRouter from 'vue-router/vite'
+
+export default defineConfig({
+  plugins: [
+    VueRouter({
+      experimental: {
+        paramParsers: {
+          dir: 'src/params',
+        },
+      },
+    }),
+    vue(),
+  ],
+})
+```
+
+`src/params` is the default directory when setting `paramParsers` to `true`, but you can point `dir` to any project-relative folder, or to an array of folders.
+
 ## Built-in parsers
 
 | Name     | Path | Query | Type      |
@@ -38,40 +63,11 @@ route.params.id // number
 
 ## Defining custom parsers
 
-You define param parsers as modules exporting a `parser` in `src/params/*`. The file name is the parser name you use in routes. For example, `src/params/uuid.ts` exports a `parser` that validates UUIDs and can be used as `[id=uuid]` in route files.
+You define param parsers as modules exporting a `parser` in the configured param parser directory. The file name is the parser name you use in routes. For example, `src/params/uuid.ts` exports a `parser` that validates UUIDs and can be used as `[id=uuid]` in route files.
 
 A parser is just an object with a _getter_ and a _setter_ but to make things simpler to use, Vue Router provides two helpers: [`defineParamParser()`](#defineParamParser) and [`defineParamParserRaw()`](#defineParamParserRaw).
 
 Reach for `defineParamParser` first, it's the most common use case for simple one-to-one transforms. Use `defineParamParserRaw` when you need to collapse multiple input shapes into one output type or you want to reject _nullish_ or array values outright.
-
-::: warning Configuration Required
-To make custom parsers work, you must enable the `experimental.paramParsers`
-option in the Vite plugin. This is what tells the plugin to scan your
-`src/params/` folder and register parsers both at runtime and in the generated
-`typed-router.d.ts`.
-
-```ts [vite.config.ts]
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import VueRouter from 'vue-router/vite'
-
-export default defineConfig({
-  plugins: [
-    VueRouter({
-      experimental: {
-        paramParsers: true, 
-      },
-    }),
-    vue(),
-    // ....
-  ],
-})
-
-```
-Without this, the router won't find your custom parsers and you'll see errors like:
-[vue-router] Parameter parser "number" not found for route "/users/:id".
-:::
-
 
 ### `defineParamParser`
 


### PR DESCRIPTION
## not enable

<img width="430" height="272" alt="image" src="https://github.com/user-attachments/assets/83b96000-3fa4-4f35-a286-8d64c43d6d9e" />

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/d46da857-5d14-4aa3-92b2-ab2385350a3c" />

## enable
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/99db4a06-611f-48a4-b8c8-e8a1c21dd2fa" />

## my codebase
https://github.com/WuMingDao/vue-router-exp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Setup" section explaining how to enable experimental.paramParsers in the Vite plugin and an updated configuration example.
  * Clarified that src/params is the default parser directory but can be customized.
  * Updated examples to reference the configured param parser directory instead of a hardcoded path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->