### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/packages/docs/installation.md
+++ b/packages/docs/installation.md
@@ -32,6 +32,10 @@ pnpm add vue-router
 bun add vue-router
 ```
 
+```bash [deno]
+deno add vue-router
+```
+
 :::
 
 If you're starting a new project, you might find it easier to use the [create-vue](https://github.com/vuejs/create-vue) scaffolding tool, which creates a Vite-based project with the option to include Vue Router:


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install `code-group` lists npm / yarn / pnpm / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity:

```sh
deno add vue-router
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Deno as a supported package manager option in installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->