### PR TITLE
fix(unplugin): reject invalid hex digits in [x+hh] character codes

### DIFF
--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -225,6 +225,14 @@ describe('Tree', () => {
       )
     })
 
+    it('throws when only the second digit is not hex', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+
+      expect(() => tree.insert('[x+1g]', '[x+1g].vue')).toThrow(
+        /Invalid hex code "1g"/
+      )
+    })
+
     it('throws on too many digits in hex code', () => {
       const tree = new PrefixTree(RESOLVED_OPTIONS)
 

--- a/packages/router/src/unplugin/core/treeNodeValue.ts
+++ b/packages/router/src/unplugin/core/treeNodeValue.ts
@@ -9,6 +9,8 @@ export const enum TreeNodeType {
   param,
 }
 
+const RE_HEX_CHARS = /^[0-9a-fA-F]{2}$/
+
 /**
  * Internal merged-overrides shape used by tree nodes. Same structure as
  * {@link CustomRouteBlock} (the user-facing `<route>` block / `definePage()`
@@ -687,7 +689,7 @@ function parseFileSegment(
       // `parseInt` stops at the first non-hex character, so a buffer like
       // `1g` would be leniently parsed as `0x1` instead of being rejected.
       // Require both characters to be hex digits before decoding.
-      if (!/^[0-9a-f]{2}$/i.test(buffer)) {
+      if (!RE_HEX_CHARS.test(buffer)) {
         throw new SyntaxError(
           `Invalid hex code "${buffer}" in segment "${segment}"`
         )

--- a/packages/router/src/unplugin/core/treeNodeValue.ts
+++ b/packages/router/src/unplugin/core/treeNodeValue.ts
@@ -684,13 +684,15 @@ function parseFileSegment(
           `Invalid character code in segment "${segment}". Hex code must be exactly 2 digits, got "${buffer}"`
         )
       }
-      const hexCode = parseInt(buffer, 16)
-      if (!Number.isInteger(hexCode) || hexCode < 0 || hexCode > 255) {
+      // `parseInt` stops at the first non-hex character, so a buffer like
+      // `1g` would be leniently parsed as `0x1` instead of being rejected.
+      // Require both characters to be hex digits before decoding.
+      if (!/^[0-9a-f]{2}$/i.test(buffer)) {
         throw new SyntaxError(
           `Invalid hex code "${buffer}" in segment "${segment}"`
         )
       }
-      pathSegment += String.fromCharCode(hexCode)
+      pathSegment += String.fromCharCode(parseInt(buffer, 16))
     }
     buffer = ''
   }


### PR DESCRIPTION
The `[x+hh]` segment encoding checks that the hex buffer is 2 characters long, then decodes it with `parseInt(buffer, 16)`. The problem is `parseInt` stops at the first character that is not a valid hex digit instead of failing, so a buffer where only the second character is invalid is accepted.

For example, `[x+1g]` parses as `0x1` (the `g` is ignored) and silently produces a `U+0001` control character. Meanwhile `[x+ZZ]` and `[x+g1]` are correctly rejected, because there `parseInt` returns `NaN` when the first character is not hex. So the current check only catches cases where the first digit is bad.

This replaces the `NaN`/range check with a `^[0-9a-f]{2}$` test so both characters must be hex digits. The length is already guaranteed to be 2 at that point, and two hex digits are always within `0x00..0xFF`, so the explicit range check is no longer needed. The error message is unchanged.

Added a test for `[x+1g]` alongside the existing `[x+ZZ]` case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for hex-encoded route segments so invalid hex values now fail with a clearer error message.
  * Prevents malformed hex codes from being accepted during parsing.
* **Tests**
  * Added coverage to verify invalid hex input is rejected as expected (including stricter handling for non-hex characters).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->