### PR TITLE
refactor: remove `@babel/generator`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "packageManager": "pnpm@10.30.0",
   "pnpm": {
     "overrides": {
-      "@babel/generator": "^8.0.0-rc.4",
       "@babel/types": "^8.0.0-rc.4",
       "@types/node": "^24.10.4",
       "@vue/compiler-sfc": "^3.5.34",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -136,7 +136,6 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@babel/generator": "^8.0.0",
     "@vue-macros/common": "^3.1.3",
     "@vue/devtools-api": "^8.1.5",
     "ast-walker-scope": "^0.9.0",
@@ -164,7 +163,6 @@
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "@standard-schema/spec": "^1.1.0",
-    "@types/babel__generator": "^7.27.0",
     "@types/picomatch": "^4.0.3",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "@vitejs/plugin-vue": "^6.0.7",

--- a/packages/router/src/unplugin/core/definePage.spec.ts
+++ b/packages/router/src/unplugin/core/definePage.spec.ts
@@ -379,6 +379,35 @@ definePage({
     })
   })
 
+  it('preserves the exact source of multiline arrow function defaults', () => {
+    const code = [
+      'definePage({',
+      '  params: {',
+      '    query: {',
+      '      total: {',
+      '        default: () => {',
+      '          // a comment',
+      '          const total: number = 1 + 2',
+      '          return total',
+      '        },',
+      '      },',
+      '    }',
+      '  }',
+      '})',
+    ].join('\n')
+
+    expect(
+      extractDefinePageInfo(code, 'src/pages/test.ts')?.params?.query?.total
+    ).toEqual({
+      default:
+        '() => {\n' +
+        '          // a comment\n' +
+        '          const total: number = 1 + 2\n' +
+        '          return total\n' +
+        '        }',
+    })
+  })
+
   it('extracts alias as a string', () => {
     const code = vue`
 <script setup>

--- a/packages/router/src/unplugin/core/definePage.spec.ts
+++ b/packages/router/src/unplugin/core/definePage.spec.ts
@@ -245,6 +245,140 @@ definePage({
     })
   })
 
+  it('extracts arrow function defaults in query params', () => {
+    const code = vue`
+<script setup lang="ts">
+definePage({
+  params: {
+    query: {
+      page: {
+        parser: 'int',
+        default: () => 1,
+      },
+      token: {
+        parser: 'string',
+        default: async () => 123,
+      },
+      search: {
+        default: (value: string) => value,
+      },
+    }
+  }
+})
+</script>
+`
+    expect(extractDefinePageInfo(code, 'src/pages/test.vue')).toEqual({
+      hasRemainingProperties: false,
+      params: {
+        query: {
+          page: {
+            parser: 'int',
+            default: '() => 1',
+          },
+          token: {
+            parser: 'string',
+            default: 'async () => 123',
+          },
+          search: {
+            default: '(value: string) => value',
+          },
+        },
+      },
+    })
+  })
+
+  it('extracts multiline arrow function defaults in query params', () => {
+    const code = vue`
+<script setup lang="ts">
+definePage({
+  params: {
+    query: {
+      wrapped: {
+        default: (value: string) => ({ value }),
+      },
+      total: {
+        default: () => {
+          // a comment
+          const total = 1 + 2
+          return total
+        },
+      },
+    }
+  }
+})
+</script>
+`
+    // formatting (indentation, semicolons) may differ from the source, so
+    // only assert the parts that are stable
+    expect(extractDefinePageInfo(code, 'src/pages/test.vue')).toMatchObject({
+      params: {
+        query: {
+          wrapped: {
+            default: expect.stringContaining('(value: string) =>'),
+          },
+          total: {
+            default: expect.stringContaining('// a comment'),
+          },
+        },
+      },
+    })
+
+    const totalDefault = extractDefinePageInfo(code, 'src/pages/test.vue')
+      ?.params?.query?.total?.default
+    expect(totalDefault).toContain('() => {')
+    expect(totalDefault).toContain('const total = 1 + 2')
+    expect(totalDefault).toContain('return total')
+  })
+
+  it('extracts arrow function defaults in query params in a ts file', () => {
+    const code = ts`
+definePage({
+  params: {
+    query: {
+      page: {
+        parser: 'int',
+        default: () => 1,
+      },
+      token: {
+        default: async () => 123,
+      },
+      search: {
+        default: (value: string) => value,
+      },
+      total: {
+        default: () => {
+          // a comment
+          const total = 1 + 2
+          return total
+        },
+      },
+    }
+  }
+})
+`
+    expect(extractDefinePageInfo(code, 'src/pages/test.ts')).toMatchObject({
+      hasRemainingProperties: false,
+      params: {
+        query: {
+          page: {
+            parser: 'int',
+            default: '() => 1',
+          },
+          token: {
+            default: 'async () => 123',
+          },
+          search: {
+            default: '(value: string) => value',
+          },
+          total: {
+            // formatting may differ from the source
+            default: expect.stringContaining('// a comment'),
+          },
+        },
+      },
+    })
+  })
+
   it('extracts alias as a string', () => {
     const code = vue`
 <script setup>

--- a/packages/router/src/unplugin/core/definePage.ts
+++ b/packages/router/src/unplugin/core/definePage.ts
@@ -10,13 +10,13 @@ import {
 import type { Thenable, TransformResult } from 'unplugin'
 import type {
   CallExpression,
+  Node,
   ObjectExpression,
   ObjectProperty,
   Program,
   Statement,
   StringLiteral,
 } from '@babel/types'
-import { generate } from '@babel/generator'
 import { walkAST } from 'ast-walker-scope'
 import { diagnostics } from '../diagnostics'
 import type { ParsedStaticImport } from 'mlly'
@@ -57,6 +57,26 @@ function getCodeAst(code: string, id: string) {
     .filter(node => !!node)
 
   return { ast, offset, definePageNodes }
+}
+
+/**
+ * Extract the source text of an ast node from the original code. Works with
+ * SFC and non-SFC files by applying the script block offset.
+ *
+ * @param source - full source code the ast was parsed from
+ * @param node - ast node with source range information
+ * @param offset - offset of the parsed script within the source
+ * @returns the source text of the node or `undefined` if the node has no range
+ */
+function getNodeSource(
+  source: string,
+  node: Node,
+  offset: number
+): string | undefined {
+  if (node.start == null || node.end == null) {
+    return undefined
+  }
+  return source.slice(offset + node.start, offset + node.end)
 }
 
 export function definePageTransform({
@@ -239,11 +259,13 @@ export function extractDefinePageInfo(
   if (!sfcCode.includes(MACRO_DEFINE_PAGE)) return
 
   let ast: Program | undefined
+  let offset: number
   let definePageNodes: CallExpression[]
 
   try {
     const result = getCodeAst(sfcCode, id)
     ast = result.ast
+    offset = result.offset
     definePageNodes = result.definePageNodes
   } catch (error) {
     // Handle any syntax errors or parsing errors gracefully
@@ -301,7 +323,7 @@ export function extractDefinePageInfo(
         routeInfo.alias = extractRouteAlias(prop.value, id)
       } else if (prop.key.name === 'params') {
         if (prop.value.type === 'ObjectExpression') {
-          routeInfo.params = extractParamsInfo(prop.value, id)
+          routeInfo.params = extractParamsInfo(prop.value, id, sfcCode, offset)
         }
       } else {
         routeInfo.hasRemainingProperties = true
@@ -314,14 +336,16 @@ export function extractDefinePageInfo(
 
 function extractParamsInfo(
   paramsObj: ObjectExpression,
-  id: string
+  id: string,
+  source: string,
+  offset: number
 ): DefinePageParamsInfo {
   const params: DefinePageParamsInfo = {}
 
   for (const prop of paramsObj.properties) {
     if (prop.type === 'ObjectProperty' && prop.key.type === 'Identifier') {
       if (prop.key.name === 'query' && prop.value.type === 'ObjectExpression') {
-        params.query = extractQueryParams(prop.value, id)
+        params.query = extractQueryParams(prop.value, id, source, offset)
       } else if (
         prop.key.name === 'path' &&
         prop.value.type === 'ObjectExpression'
@@ -336,7 +360,9 @@ function extractParamsInfo(
 
 function extractQueryParams(
   queryObj: ObjectExpression,
-  _id: string
+  _id: string,
+  source: string,
+  offset: number
 ): NonNullable<DefinePageInfo['params']>['query'] {
   const queryParams: NonNullable<DefinePageInfo['params']>['query'] = {}
 
@@ -395,7 +421,19 @@ function extractQueryParams(
                 // support negative numeric literals: -1, -1.5
                 paramInfo.default = `${paramProp.value.operator}${paramProp.value.argument.value}`
               } else if (paramProp.value.type === 'ArrowFunctionExpression') {
-                paramInfo.default = generate(paramProp.value).code
+                const expression = getNodeSource(
+                  source,
+                  paramProp.value,
+                  offset
+                )
+                if (expression === undefined) {
+                  diagnostics.VUE_ROUTER_B0006({
+                    paramName,
+                    type: paramProp.value.type,
+                  })
+                } else {
+                  paramInfo.default = expression
+                }
               } else {
                 diagnostics.VUE_ROUTER_B0006({
                   paramName,

--- a/packages/router/src/unplugin/core/definePage.ts
+++ b/packages/router/src/unplugin/core/definePage.ts
@@ -426,7 +426,7 @@ function extractQueryParams(
                   paramProp.value,
                   offset
                 )
-                if (expression === undefined) {
+                if (expression == null) {
                   diagnostics.VUE_ROUTER_B0006({
                     paramName,
                     type: paramProp.value.type,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@babel/generator': ^8.0.0-rc.4
   '@babel/types': ^8.0.0-rc.4
   '@types/node': ^24.10.4
   '@vue/compiler-sfc': ^3.5.34
@@ -222,9 +221,6 @@ importers:
 
   packages/router:
     dependencies:
-      '@babel/generator':
-        specifier: ^8.0.0-rc.4
-        version: 8.0.0
       '@vue-macros/common':
         specifier: ^3.1.3
         version: 3.1.3(vue@3.5.39(typescript@6.0.3))
@@ -301,9 +297,6 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
-      '@types/babel__generator':
-        specifier: ^7.27.0
-        version: 7.27.0
       '@types/picomatch':
         specifier: ^4.0.3
         version: 4.0.3
@@ -469,9 +462,9 @@ packages:
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0':
-    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
@@ -551,11 +544,6 @@ packages:
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.4':
-    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-proposal-decorators@7.29.7':
@@ -1828,9 +1816,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -1848,9 +1833,6 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/jsesc@2.5.1':
-    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -5027,7 +5009,7 @@ snapshots:
   '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 8.0.0
+      '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
@@ -5044,13 +5026,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@8.0.0':
+  '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 8.0.4
+      '@babel/parser': 7.29.7
       '@babel/types': 8.0.4
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.29.7':
@@ -5146,10 +5127,6 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.4
 
-  '@babel/parser@8.0.4':
-    dependencies:
-      '@babel/types': 8.0.4
-
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -5206,7 +5183,7 @@ snapshots:
   '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 8.0.0
+      '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -6152,10 +6129,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 8.0.4
-
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6173,8 +6146,6 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/jsesc@2.5.1': {}
 
   '@types/linkify-it@5.0.0': {}
 


### PR DESCRIPTION
> In the spirit of [e18e](https://e18e.dev/), I looked into several popular libraries to identify potential optimization opportunities (this time related to nuxt v5).

`vue-router` depends on `@babel/generator`, despite using it in only one place. Given the package’s download volume, this dependency accounts for more than 1 TB of [package data transferred each month](https://dependents.dev/?package=%40babel%2Fgenerator):

<img width="1363" height="83" alt="Monthly download statistics for @babel/generator" src="https://github.com/user-attachments/assets/5827dc36-ebb8-4bc7-8cd3-2d32d28ae30c" />

The single use case in this project can be safely replaced with a small manual implementation, allowing us to remove `@babel/generator` from the production dependency tree. To make sure that change is safe, I added some additional tests related to that scope.

To be clear, this PR was AI assisted, but I manually reviewed and verified the code and logic.

Note: I removed the manual version override for `@babel/generator` introduced in https://github.com/vuejs/router/commit/8d3e60e7ac9fe52f7e664a7ed21bee322517ce13, since `@babel/generator` is now only a development dependency. It also removes double `babel` dependencies between `vue-router` and `vue` itself. I can restore the override if you would prefer to keep it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of arrow-function defaults in route query parameters.
  * Preserved the original function formatting and TypeScript syntax when extracting defaults, including multiline and commented functions.
  * Added support for synchronous, asynchronous, typed, and block-body arrow functions in Vue and TypeScript route definitions.
* **Tests**
  * Expanded coverage to verify serialized defaults and exact source preservation across supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->