### PR TITLE
feat(unplugin): allow null filePath for editable tree routes

### DIFF
--- a/packages/router/src/unplugin/core/extendRoutes.spec.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.spec.ts
@@ -35,6 +35,15 @@ describe('EditableTreeNode', () => {
     expect(tree.children.get('foo')?.path).toBe('/foo')
   })
 
+  it('allows filePath to be null on a route added in the editable tree', () => {
+    const tree = new PrefixTree(RESOLVED_OPTIONS)
+    const editable = new EditableTreeNode(tree)
+
+    editable.insert('foo', null)
+    expect(editable.children).toHaveLength(1)
+    expect(editable.children[0]?.path).toBe('/foo')
+  })
+
   it('removes parent when deleting last child of a non-matchable node', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
 

--- a/packages/router/src/unplugin/core/extendRoutes.spec.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.spec.ts
@@ -42,6 +42,8 @@ describe('EditableTreeNode', () => {
     editable.insert('foo', null)
     expect(editable.children).toHaveLength(1)
     expect(editable.children[0]?.path).toBe('/foo')
+    // a null filePath registers no component, so the route is a pass-through
+    expect(editable.children[0]?.isPassThrough).toBe(true)
   })
 
   it('removes parent when deleting last child of a non-matchable node', () => {

--- a/packages/router/src/unplugin/core/extendRoutes.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.ts
@@ -37,7 +37,7 @@ export class EditableTreeNode {
    * @param filePath - file path
    * @returns the new editable route node
    */
-  insert(path: string, filePath: string) {
+  insert(path: string, filePath: string | null) {
     // adapt paths as they should match a file system
     let addBackLeadingSlash = false
     if (path.startsWith('/')) {

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -149,9 +149,8 @@ export class TreeNode {
    * @param path - path segment to insert, already parsed (e.g. users/:id)
    * @param filePath - file path, defaults to path for convenience and testing
    */
-  insertParsedPath(path: string, filePath: string = path): TreeNode {
-    // TODO: allow null filePath?
-    const isComponent = true
+  insertParsedPath(path: string, filePath: string | null = path): TreeNode {
+    const isComponent = filePath != null
 
     const node = new TreeNode(
       {


### PR DESCRIPTION
Ported from https://github.com/posva/unplugin-vue-router/pull/607

It seems that, when we only allow `filePath` to be `null` on a route added in an editable tree, that shouldn't cause any problems.

In Nuxt, we don't use file scanning and add routes by modifying the `EditableTreeNode` of the root page in the `beforeWriteFiles` callback. It's possible for a `NuxtPage` not to have a corresponding `file`: modules can push routes through the `pages:extend` hook without one (virtual, grouping, or redirect routes), and Nuxt's own type fixtures do this. So where we run `parent.insert(path, page.file)`, `page.file` can be missing, and we currently use a `@ts-expect-error` before that line to suppress TS errors.

## Nuxt follow-up (not part of this PR)

- [ ] Pass `page.file ?? null` in `addPage`, then remove the `@ts-expect-error`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Route tree entries can now be created without an associated file path.
  - Such entries are correctly recognized as pass-through routes.

- **Bug Fixes**
  - Improved route metadata handling when no component file is provided.

- **Tests**
  - Added coverage verifying pass-through route creation, path assignment, and child node behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->