### PR TITLE
chore: move all pnpm settings to `pnpm-workspace.yaml`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-shamefully-hoist=true
 detect_chromedriver_version=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -61,33 +61,5 @@
   "volta": {
     "node": "24.7.0"
   },
-  "packageManager": "pnpm@10.30.0",
-  "pnpm": {
-    "overrides": {
-      "@babel/generator": "^8.0.0-rc.4",
-      "@babel/types": "^8.0.0-rc.4",
-      "@types/node": "^24.10.4",
-      "@vue/compiler-sfc": "^3.5.34",
-      "@vue/runtime-dom": "^3.5.34",
-      "@vue/server-renderer": "^3.5.34",
-      "vite": "^7.3.0",
-      "vue": "^3.5.34"
-    },
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "react",
-        "@types/react",
-        "react-dom"
-      ]
-    },
-    "onlyBuiltDependencies": [
-      "chromedriver",
-      "esbuild",
-      "geckodriver",
-      "simple-git-hooks"
-    ],
-    "ignoredBuiltDependencies": [
-      "@nightwatch/nightwatch-inspector"
-    ]
-  }
+  "packageManager": "pnpm@10.30.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,27 @@
 packages:
   - 'packages/*'
+
+shellEmulator: true
+
+overrides:
+  '@babel/generator': '^8.0.0-rc.4'
+  '@babel/types': '^8.0.0-rc.4'
+  '@types/node': '^24.10.4'
+  '@vue/compiler-sfc': '^3.5.34'
+  '@vue/runtime-dom': '^3.5.34'
+  '@vue/server-renderer': '^3.5.34'
+  'vite': '^7.3.0'
+  'vue': '^3.5.34'
+
+peerDependencyRules:
+  ignoreMissing:
+    - react
+    - react-dom
+    - '@types/react'
+
+allowBuilds:
+  chromedriver: true
+  esbuild: true
+  geckodriver: true
+  simple-git-hooks: true
+  '@nightwatch/nightwatch-inspector': false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - 'packages/*'
 
-shellEmulator: true
+shamefullyHoist: true
 
 overrides:
   '@babel/generator': '^8.0.0-rc.4'


### PR DESCRIPTION
To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more [github.com/orgs/pnpm/discussions/9037](https://github.com/orgs/pnpm/discussions/9037)

The default value for strictPeerDependencies is false, so no further configuration is required.
https://pnpm.io/10.x/settings#strictpeerdependencies

https://pnpm.io/settings#allowbuilds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
- Centralized package manager configuration at the workspace level, including forced versions for key dependencies.
- Updated peer dependency handling rules to better support selected tooling builds.
- Simplified the root package and reduced `.npmrc` to only retain ChromeDriver version detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->