### PR TITLE
fix(types): allow unsetting a route name with `false` in `EditableTreeNode`

### DIFF
--- a/packages/router/src/unplugin/core/extendRoutes.spec.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.spec.ts
@@ -35,6 +35,26 @@ describe('EditableTreeNode', () => {
     expect(tree.children.get('foo')?.path).toBe('/foo')
   })
 
+  it('can unset a route name with false', () => {
+    const tree = new PrefixTree(RESOLVED_OPTIONS)
+    const editable = new EditableTreeNode(tree)
+
+    const node = editable.insert('foo', 'foo.vue')
+    expect(node.name).toBeTruthy()
+
+    // false unsets the name so the route is excluded from the route map
+    node.name = false
+    expect(node.name).toBe(false)
+
+    // a string overrides it
+    node.name = 'bar'
+    expect(node.name).toBe('bar')
+
+    // undefined is ignored: the previously set name is kept (not reset)
+    node.name = undefined
+    expect(node.name).toBe('bar')
+  })
+
   it('removes parent when deleting last child of a non-matchable node', () => {
     const tree = new PrefixTree(RESOLVED_OPTIONS)
 

--- a/packages/router/src/unplugin/core/extendRoutes.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.ts
@@ -92,10 +92,9 @@ export class EditableTreeNode {
   }
 
   /**
-   * Override the name of the route. Pass `false` to unset the name: the route is
-   * then excluded from the generated route map and cannot be navigated to by name.
-   * Note `undefined` is ignored (the existing name, if any, is kept) rather than
-   * resetting to the generated name.
+   * Override the route name. If not provided, the name will be generated based
+   * on the file path. Can be set to `false` to make the route _anonymous_
+   * which removes it from types and make the route unmatchable.
    */
   set name(name: string | undefined | false) {
     this.node.value.addEditOverride({ name })

--- a/packages/router/src/unplugin/core/extendRoutes.ts
+++ b/packages/router/src/unplugin/core/extendRoutes.ts
@@ -92,9 +92,12 @@ export class EditableTreeNode {
   }
 
   /**
-   * Override the name of the route.
+   * Override the name of the route. Pass `false` to unset the name: the route is
+   * then excluded from the generated route map and cannot be navigated to by name.
+   * Note `undefined` is ignored (the existing name, if any, is kept) rather than
+   * resetting to the generated name.
    */
-  set name(name: string | undefined) {
+  set name(name: string | undefined | false) {
     this.node.value.addEditOverride({ name })
   }
 


### PR DESCRIPTION
## Summary
Widen the `EditableTreeNode` `name` setter from `string | undefined` to `string | undefined | false`, so a route name can be unset from `extendRoutes` without a type error.

## Reason
The setter should accept `false`, because `false` is already the canonical "no name" value elsewhere in the package. The public setter is the only place that rejects it:
- The getter is `get name(): string | false`. You can read `false` back but cannot assign it, which seems a bit inconsistent from an outsider perspective.
- The `_parent.vue` convention sets `{ name: false }` internally ("a parent can't be matched, equivalent to name: false").
- `definePage({ name })` accepts `string | false`, and the `<route>` block type `CustomRouteBlock.name` is `string | undefined | false`.
- `isNamed()` (`!!name`) and `isMatchable()` (`name !== false`) are both written around `false` meaning "unnamed" and "not matchable".
- The setter delegates to `addEditOverride(routeBlock: CustomRouteBlock)`, which already accepts `false`. The setter just narrows it away.

The consequence is that there is no type-clean way to unset a name through `extendRoutes`:
- `node.name = false` is a type error (fixed with this PR).
- `node.name = undefined` is silently ignored: the override merge is `b.name ?? a.name`, so it keeps the existing name rather than resetting it.
- `node.name = ''` works via `isNamed()`'s `!!name`, but it is undocumented and, unlike `false`, stays matchable per `isMatchable()`.

So `false` seems the correct value here, and the setter is the only API surface that disallows it at the moment.

## Change
- `set name(name: string | undefined | false)` in `EditableTreeNode`.
- Add to JSDoc comment: `false` unsets the name (route excluded from the map, not navigable by name); `undefined` is ignored, not a reset. (optional, just for clarity)
- Unit test in `extendRoutes.spec.ts`: unset with `false`, override with a string, `undefined` ignored.

Types only, no runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Route names can now be explicitly removed by setting them to `false`, making those routes anonymous and excluding them from name-based navigation.
  * Setting a route name to `undefined` now preserves the previously set name instead of resetting it.
  * Route names can still be replaced by providing a new string value.

* **Tests**
  * Added coverage to verify the route-name override behavior for `false`, `undefined`, and string updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->