### PR TITLE
feat(unplugin): don't crash on duplicate definePage() calls

### DIFF
--- a/packages/router/src/unplugin/core/definePage.spec.ts
+++ b/packages/router/src/unplugin/core/definePage.spec.ts
@@ -179,6 +179,52 @@ definePage({
     ).toHaveBeenWarned()
   })
 
+  describe('duplicate definePage()', () => {
+    const duplicateCode = vue`
+<script setup>
+definePage({
+  name: 'first',
+})
+definePage({
+  name: 'second',
+})
+</script>
+`
+
+    it('does not throw and keeps the first call when extracting', async () => {
+      const result = (await definePageTransform({
+        code: duplicateCode,
+        id: 'src/pages/dup.vue?definePage&vue',
+      })) as Exclude<TransformResult, string>
+
+      expect(result).toHaveProperty('code')
+      expect(result?.code).toContain('first')
+      expect(result?.code).not.toContain('second')
+      expect('duplicate definePage() call').toHaveBeenWarned()
+    })
+
+    it('removes every call from the component and does not throw', async () => {
+      const result = (await definePageTransform({
+        code: duplicateCode,
+        id: 'src/pages/dup.vue',
+      })) as Exclude<TransformResult, string>
+
+      expect(result).toHaveProperty('code')
+      expect(result?.code).not.toContain('definePage')
+      expect('duplicate definePage() call').toHaveBeenWarned()
+    })
+
+    it('extracts info from the first call only', () => {
+      expect(extractDefinePageInfo(duplicateCode, 'src/pages/dup.vue')).toEqual(
+        {
+          name: 'first',
+          hasRemainingProperties: false,
+        }
+      )
+      expect('duplicate definePage() call').toHaveBeenWarned()
+    })
+  })
+
   it('extracts name and path', () => {
     expect(extractDefinePageInfo(sampleCode, 'src/pages/basic.vue')).toEqual({
       name: 'custom',

--- a/packages/router/src/unplugin/core/definePage.ts
+++ b/packages/router/src/unplugin/core/definePage.ts
@@ -102,7 +102,8 @@ export function definePageTransform({
       : // e.g. index.vue that contains a commented `definePage()
         null
   } else if (definePageNodes.length > 1) {
-    throw new SyntaxError(`duplicate definePage() call`)
+    // ignore the extra calls and keep only the first one instead of crashing
+    diagnostics.VUE_ROUTER_B0020({ filename: id })
   }
 
   const definePageNode = definePageNodes[0]!
@@ -207,8 +208,10 @@ export function definePageTransform({
 
     const s = new MagicString(code)
 
-    // s.removeNode(definePageNode, { offset })
-    s.remove(offset + definePageNode.start!, offset + definePageNode.end!)
+    // remove every definePage() call so duplicates don't leak into the component
+    for (const node of definePageNodes) {
+      s.remove(offset + node.start!, offset + node.end!)
+    }
 
     return generateTransform(s, id)
   }
@@ -259,7 +262,8 @@ export function extractDefinePageInfo(
   if (!definePageNodes.length) {
     return
   } else if (definePageNodes.length > 1) {
-    throw new SyntaxError(`duplicate definePage() call`)
+    // ignore the extra calls and keep only the first one instead of crashing
+    diagnostics.VUE_ROUTER_B0020({ filename: id })
   }
 
   const definePageNode = definePageNodes[0]!

--- a/packages/router/src/unplugin/diagnostics.ts
+++ b/packages/router/src/unplugin/diagnostics.ts
@@ -55,6 +55,11 @@ export const diagnostics = /*#__PURE__*/ defineDiagnostics({
         `route alias array must only contain string literals. Found "${p.found}" in file "${p.filename}".`,
       fix: 'Only use string literals inside the route `alias` array.',
     },
+    VUE_ROUTER_B0020: {
+      why: (p: { filename: string }) =>
+        `duplicate definePage() call in file "${p.filename}". Only the first one is used, the rest are ignored.`,
+      fix: 'A file can only have one definePage() call. Merge them into a single definePage() call.',
+    },
 
     // --- options.ts ---
     VUE_ROUTER_B0009: {


### PR DESCRIPTION
## Summary

Previously, duplicate `definePage()` calls would crash the Vite dev server with a SyntaxError. Now they report a diagnostic (VUE_ROUTER_B0020) and ignore the extra calls, keeping only the first one.

- Replaces thrown SyntaxError with a reported diagnostic
- First definePage() call is kept; extras are ignored
- Dev server no longer crashes on duplicate definePage() 
- Users receive a fix message guiding them to merge calls into a single statement

## Test plan

- Regression tests added in definePage.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate `definePage()` calls no longer cause build failures.
  * The first call is retained, while additional calls are removed and reported with a warning.
  * Component transformations now consistently remove all `definePage()` calls from generated output.

* **Diagnostics**
  * Added a warning explaining that multiple `definePage()` calls should be combined into one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->