### PR TITLE
fix: preserve encoded hashes when re-resolving routes

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -400,6 +400,31 @@ describe('Router', () => {
     expect(router.currentRoute.value.fullPath).toBe('/#%2526')
   })
 
+  it('keeps an encoded hash when replacing with a string', async () => {
+    const { router } = await newRouter()
+    await router.replace('/#a=1%26b=2')
+    expect(router.currentRoute.value.hash).toBe('#a=1&b=2')
+    expect(router.currentRoute.value.fullPath).toBe('/#a=1%26b=2')
+  })
+
+  it('keeps an encoded hash when re-resolving a resolved route', async () => {
+    const { router } = await newRouter()
+    const resolved = router.resolve('/#a=1%26b=2')
+    expect(resolved.hash).toBe('#a=1&b=2')
+    expect(resolved.fullPath).toBe('/#a=1%26b=2')
+    await router.replace({ ...resolved, force: true })
+    expect(router.currentRoute.value.hash).toBe('#a=1&b=2')
+    expect(router.currentRoute.value.fullPath).toBe('/#a=1%26b=2')
+  })
+
+  it('encodes a hash set explicitly on a resolved route', async () => {
+    const { router } = await newRouter()
+    const resolved = router.resolve('/#a=1%26b=2')
+    await router.replace({ ...resolved, hash: '#c=3&d=4', force: true })
+    expect(router.currentRoute.value.hash).toBe('#c=3&d=4')
+    expect(router.currentRoute.value.fullPath).toBe('/#c=3&d=4')
+  })
+
   it('fails if required params are missing', async () => {
     const { router } = await newRouter()
     expect(() => router.resolve({ name: 'Param', params: {} })).toThrowError(

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -297,6 +297,16 @@ export function createRouter(options: RouterOptions): Router {
       diagnostics.VUE_ROUTER_R0007({ hash })
     }
 
+    let encodedHash = encodeHash(hash)
+    const rawFullPath = (rawLocation as { fullPath?: string }).fullPath
+    if (rawFullPath) {
+      const hashPos = rawFullPath.indexOf('#')
+      const originalHash = hashPos > -1 ? rawFullPath.slice(hashPos) : ''
+      if (decode(originalHash) === hash) {
+        encodedHash = originalHash
+      }
+    }
+
     // the matcher might have merged current location params, so
     // we need to run the decoding again
     matchedRoute.params = normalizeParams(decodeParams(matchedRoute.params))
@@ -304,7 +314,7 @@ export function createRouter(options: RouterOptions): Router {
     const fullPath = stringifyURL(
       stringifyQuery,
       assign({}, rawLocation, {
-        hash: encodeHash(hash),
+        hash: encodedHash,
         path: matchedRoute.path,
       })
     )


### PR DESCRIPTION
Related to https://github.com/nuxt/nuxt/issues/32774, as I wanted to fix this issue.

During startup, Nuxt can resolve the initial URL and then pass the normalized route back to `router.replace()`:

```ts
router.replace({ ...resolvedInitialRoute, force: true })
```
At that point, the route's `hash` is decoded while `fullPath` still contains its original encoding. Re-resolving the route rebuilt `fullPath` from the decoded hash, causing encoded characters such as `%26` to become `&` in the browser URL.

The same encoding loss could happen when calling `router.replace()` with a string.

## Changes

Reuse the encoded hash from `fullPath` when it decodes to the current route hash. If the hash was explicitly changed, it continues to be encoded normally.

This keeps encoded fragments intact when replacing or re-resolving normalized routes.

## Tests
I tried to add some coverage, but this is the part where i'm not so sure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL hash handling in routing.
  * Encoded hash values are now correctly decoded for the active route while preserving their encoded form in the full URL.
  * Preserves hash formatting consistently when re-resolving routes or forcing navigation replacements.
* **Tests**
  * Added coverage for hash encoding/decoding behavior during `router.replace()` scenarios involving `%26` and forced updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->