### PR TITLE
fix(view): implement better context management for loaders

### DIFF
--- a/packages/router/src/experimental/data-loaders/defineLoader.ts
+++ b/packages/router/src/experimental/data-loaders/defineLoader.ts
@@ -424,7 +424,7 @@ export function defineBasicLoader<Data>(
         }
       })
 
-    setCurrentContext(currentContext)
+    setCurrentContext([])
     return Object.assign(promise, useDataLoaderResult)
   }
 

--- a/packages/router/src/experimental/data-loaders/defineLoader.ts
+++ b/packages/router/src/experimental/data-loaders/defineLoader.ts
@@ -250,7 +250,10 @@ export function defineBasicLoader<Data>(
         }
       })
       .finally(() => {
-        setCurrentContext(currentContext)
+        // if this is a nested loader, context will be reset in useDataLoader
+        // if this is a root loader, of if it is called from reload or navigation guard,
+        // context is already reset in sync part
+
         // console.log(
         //   `😩 restored context ${options.key}`,
         //   currentContext?.[2]?.fullPath
@@ -348,13 +351,13 @@ export function defineBasicLoader<Data>(
     if (
       // if the entry doesn't exist, create it with load and ensure it's loading
       !entry ||
-      // the existing pending location isn't good, we need to load again
-      (parentEntry && entry.pendingTo !== route) ||
-      // we could also check for: but that would break nested loaders since they need to be always called to be associated with the parent
-      // && entry.to !== route
       // the user managed to render the router view after a valid navigation + a failed navigation
       // https://github.com/posva/unplugin-vue-router/issues/495
-      !entry.pendingLoad
+      !entry.pendingLoad ||
+      // the existing pending location isn't good, we need to load again
+      (parentEntry && entry.to !== route)
+      // we could also check for: but that would break nested loaders since they need to be always called to be associated with the parent
+      // && entry.to !== route
     ) {
       // console.log(
       //   `🔁 loading from useData for "${options.key}": "${route.fullPath}"`
@@ -383,7 +386,16 @@ export function defineBasicLoader<Data>(
       isLoading,
       reload: (to: RouteLocationNormalizedLoaded = router.currentRoute.value) =>
         router[APP_KEY]
-          .runWithContext(() => load(to, router))
+          .runWithContext(() => {
+            const entry = entries.get(loader)!
+            entry.children.forEach(childEntry => {
+              // for child loaders we usually want to avoid refetching,
+              // that's why we're checking that requested and loaded routes are the same
+              // when reloading, we want to refetch though, and so we make those routes different
+              childEntry.to = null
+            })
+            return load(to, router)
+          })
           .then(() => entry!.commit(to)),
     } satisfies UseDataLoaderResult<Data | undefined, ErrorDefault>
 
@@ -397,9 +409,20 @@ export function defineBasicLoader<Data>(
       // we only want the error if we are nesting the loader
       // otherwise this will end up in "Unhandled promise rejection"
       .catch((e: unknown) => (parentEntry ? Promise.reject(e) : null))
-      // restore the caller's context so that sequential awaits
-      // (e.g. await useOne(); await useTwo()) preserve the parent
-      .finally(() => setCurrentContext(currentContext))
+      .finally(() => {
+        // restore the caller's context so that sequential awaits
+        // (e.g. await useOne(); await useTwo()) preserve the parent
+        // this is only necessary if we were called from inside other loader
+        if (parentEntry) {
+          setCurrentContext(currentContext)
+
+          // when finally finishes, it will first put parent loader back to the job queue
+          // we want to schedule context reset after that task
+          // if we use finally on rejected promise, it will stay rejected and will trigger unhandledpromiserejection
+          const onFinally = () => setCurrentContext([])
+          promise.then(onFinally, onFinally)
+        }
+      })
 
     setCurrentContext(currentContext)
     return Object.assign(promise, useDataLoaderResult)

--- a/packages/router/src/tests/data-loaders/tester.ts
+++ b/packages/router/src/tests/data-loaders/tester.ts
@@ -1477,6 +1477,184 @@ export function testDefineLoader<Context = void>(
     expect(wrapper.text()).toBe('ok,one ok')
   })
 
+  // https://github.com/vuejs/router/issues/2684
+  it(`does not leak a pending nested lazy loader's context into components`, async () => {
+    const parentSpy = vi
+      .fn<(to: RouteLocationNormalizedLoaded) => Promise<string>>()
+      // resolves instantly, like a cache hit
+      .mockImplementation(async () => 'parent')
+    const useParentLoader = loaderFactory({
+      fn: parentSpy,
+      key: 'parent',
+      lazy: true,
+    })
+    const childSpy = vi
+      .fn<(to: RouteLocationNormalizedLoaded) => Promise<string>>()
+      .mockImplementation(async to => {
+        // nested loader awaits the parent loader, then keeps loading. While it
+        // is still pending, the global loader context stays set to this child
+        // entry, so a component rendering meanwhile must not pick it up as a
+        // parent (which would re-run the parent loader and nest loaders under
+        // themselves)
+        const parent = await useParentLoader()
+        await delay(10)
+        return `${parent},${to.query.p}`
+      })
+    const useChildLoader = loaderFactory({
+      fn: childSpy,
+      key: 'child',
+      lazy: true,
+    })
+
+    // child component (like a nested page) reuses the parent loader directly
+    // plus its own nested loader
+    const ChildComp = defineComponent({
+      setup() {
+        const { data: parent } = useParentLoader()
+        const { data: child } = useChildLoader()
+        return { parent, child }
+      },
+      template: `<p id="child">{{ parent }}|{{ child }}</p>`,
+    })
+    // parent component (like a parent page) uses the parent loader and renders
+    // the child component
+    const ParentComp = defineComponent({
+      components: { ChildComp },
+      setup() {
+        const { data } = useParentLoader()
+        return { data }
+      },
+      template: `<div id="parent">{{ data }}<ChildComp /></div>`,
+    })
+
+    const router = getRouter()
+    router.addRoute({
+      name: '_test',
+      path: '/fetch',
+      component: ParentComp,
+      meta: {
+        loaders: [useParentLoader, useChildLoader],
+        nested: { foo: 'bar' },
+      },
+    })
+
+    const wrapper = mount(RouterViewMock, {
+      global: {
+        plugins: [
+          [DataLoaderPlugin, { router }],
+          ...(plugins?.(customContext!) || []),
+          router,
+        ],
+      },
+    })
+
+    // navigation completes while the lazy child loader is still pending, so the
+    // components render with the child loader's context still active
+    await router.push('/fetch?p=one')
+    await flushPromises()
+    // let the child loader finish
+    await vi.advanceTimersByTimeAsync(20)
+    await flushPromises()
+
+    expect('has itself as parent').not.toHaveBeenWarned()
+    expect('a different parent').not.toHaveBeenWarned()
+    expect(parentSpy).toHaveBeenCalledTimes(1)
+    expect(childSpy).toHaveBeenCalledTimes(1)
+    expect(router.currentRoute.value.fullPath).toBe('/fetch?p=one')
+    expect(wrapper.get('#child').text()).toBe('parent|parent,one')
+  })
+
+  it('does not leak context when reloading lazy loader with nested lazy loaders', async () => {
+    const parentSpy = vi
+      .fn<(to: RouteLocationNormalizedLoaded) => Promise<string>>()
+      // resolves instantly, like a cache hit
+      .mockImplementation(async () => 'parent')
+    const useParentLoader = loaderFactory({
+      fn: parentSpy,
+      key: 'parent',
+      lazy: true,
+    })
+    const childSpy = vi
+      .fn<(to: RouteLocationNormalizedLoaded) => Promise<string>>()
+      .mockImplementation(async to => {
+        // nested loader awaits the parent loader, then keeps loading. While it
+        // is still pending, the global loader context stays set to this child
+        // entry, so a component rendering meanwhile must not pick it up as a
+        // parent (which would re-run the parent loader and nest loaders under
+        // themselves)
+        const parent = await useParentLoader()
+        await delay(10)
+        return `${parent},${to.query.p}`
+      })
+    const useChildLoader = loaderFactory({
+      fn: childSpy,
+      key: 'child',
+      lazy: true,
+    })
+
+    // child component (like a nested page) reuses the parent loader directly
+    // plus its own nested loader
+    const ChildComp = defineComponent({
+      setup() {
+        const { data: child, reload } = useChildLoader()
+        return { child, reload }
+      },
+      template: `<p id="child">{{ child }}</p><button id="reload" @click="reload()"></button>`,
+    })
+    // parent component (like a parent page) uses the parent loader and renders
+    // the child component
+    const ParentComp = defineComponent({
+      components: { ChildComp },
+      setup() {
+        const { data } = useParentLoader()
+        return { data }
+      },
+      template: `<div id="parent">{{ data }}<ChildComp /></div>`,
+    })
+
+    const router = getRouter()
+    router.addRoute({
+      name: '_test',
+      path: '/fetch',
+      component: ParentComp,
+      meta: {
+        loaders: [useParentLoader, useChildLoader],
+        nested: { foo: 'bar' },
+      },
+    })
+
+    const wrapper = mount(RouterViewMock, {
+      global: {
+        plugins: [
+          [DataLoaderPlugin, { router }],
+          ...(plugins?.(customContext!) || []),
+          router,
+        ],
+      },
+    })
+
+    // navigation completes while the lazy child loader is still pending, so the
+    // components render with the child loader's context still active
+    await router.push('/fetch?p=one')
+    await flushPromises()
+    // let the child loader finish
+    await vi.advanceTimersByTimeAsync(20)
+    await flushPromises()
+
+    expect('has itself as parent').not.toHaveBeenWarned()
+    expect('a different parent').not.toHaveBeenWarned()
+    expect(parentSpy).toHaveBeenCalledTimes(1)
+    expect(childSpy).toHaveBeenCalledTimes(1)
+    expect(router.currentRoute.value.fullPath).toBe('/fetch?p=one')
+    expect(wrapper.get('#child').text()).toBe('parent,one')
+
+    await wrapper.find('#reload').trigger('click')
+    expect(parentSpy).toHaveBeenCalledTimes(2)
+    expect(childSpy).toHaveBeenCalledTimes(2)
+    expect('has itself as parent').not.toHaveBeenWarned()
+    expect('a different parent').not.toHaveBeenWarned()
+  })
+
   it('keeps the old data until all loaders are resolved', async () => {
     const router = getRouter()
     const l1 = mockedLoader({ commit: 'after-load', key: 'l1' })


### PR DESCRIPTION
close #2684

This PR is in draft, feel free to provide comments, suggestions, critique 

This is my approach to resolve the issue with nested loader's context
I have found another way to reproduce the issue with context and that is by doing reload from component
Since provided solution by posva only updated `useDataLoader` and not `load` function (which is used when doing reload), I was worried that fix will not work for `reload`

[Take a look at this stackblitz](https://stackblitz.com/edit/vitejs-vite-mqc5mpvr?file=src%2FApp.vue). 
There are 4 pages, each page has two loaders that do not depend on each other, and a subpage, that has a loader that depends on those two. Difference between pages is how long it takes for each loader to resolve with a value. 
Open console and navigate between pages, click reload after reloading has finished. While page will not go into infinite loop, it still logs a warning about incorrect context.

[This stackblitz contains vue-router built from this branch](https://stackblitz.com/edit/vitejs-vite-ebt2ibax?file=package.json,.gitignore). Open console and check logs, navigate between pages, reload, try and break it (and I mean it, I want this to be bulletproof)

I've started investigating and trying to follow the context during the different phases of execution. As it turns out, since context is only relevant for nested loaders, we can keep it empty for the most time, and only update on demand.

If our loader has nested loaders, it will call `useDataLoader`. When nested loader is finished, we reach `finally`. Here, we don't know if there are other nested loaders after us, so in case there are, we prepare context for them. We do it only if we're in a nested loader (`parentEntry` is not undefined). Now, context is restored back to original loader's context.
After `finally` finishes, promise is resolved, and two jobs are put into queue original loader and restoration of context back to empty. After doing some sync work, original loader can potentially call other nested loader, which will receive proper context. After that task is done, context is resolved. Any other call will receive empty context

During testing I've spotted a problem with this solution: if you have two nested loaders and second loader resolves before first, when dependent loader reaches second loader it triggers it again. So I've changed the condition on when the loader should be invoked. But now, when doing reload, nested loaders are never triggered. So I force it by resetting their `to` property, so the condition matches and loader is reloaded. I myself am not a fan of this solution, I welcome any suggestion on how to make it better
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested data-loader behavior to prevent context leakage during concurrent loading.
  * Fixed reload handling so child loaders properly refetch their data.
  * Improved recovery and context restoration when loader requests fail.

* **Tests**
  * Added coverage for nested lazy-loader loading and reload scenarios, including warning prevention and expected loader execution counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->