### PR TITLE
feat(volar): narrow `typeof useRoute` in a type context

### DIFF
--- a/packages/playground-file-based/src/pages/users/sub-[first]-[second].vue
+++ b/packages/playground-file-based/src/pages/users/sub-[first]-[second].vue
@@ -1,5 +1,17 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+type Route = typeof route
+type RouteFromType = ReturnType<typeof useRoute>
+type RouteOther = ReturnType<typeof useRoute<'/about'>>
+
+route.params.first satisfies RouteFromType['params']['first']
+route.params.second satisfies RouteFromType['params']['second']
+</script>
 
 <template>
   <h1>{{ String($route.name) }} - {{ $route.path }}</h1>
+  <p>{{ $route.params.first satisfies RouteFromType['params']['first'] }}</p>
+  <p>{{ $route.params.second satisfies RouteFromType['params']['second'] }}</p>
 </template>

--- a/packages/router/src/volar/entries/sfc-typed-router.spec.ts
+++ b/packages/router/src/volar/entries/sfc-typed-router.spec.ts
@@ -17,11 +17,12 @@ function transform(
   code: string,
   { lang = 'ts', fileName = FILE_NAME } = {}
 ): string {
-  const instance = plugin({
+  const result = plugin({
     compilerOptions: { rootDir: ROOT_DIR },
     modules: { typescript: ts },
     config: { options: { rootDir: ROOT_DIR } },
   } as any)
+  const instance = Array.isArray(result) ? result[0] : result
 
   const ast = ts.createSourceFile(
     fileName,

--- a/packages/router/src/volar/entries/sfc-typed-router.spec.ts
+++ b/packages/router/src/volar/entries/sfc-typed-router.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import ts from 'typescript'
+import { toString, type Segment } from 'muggle-string'
+import plugin from './sfc-typed-router'
+
+const ROOT_DIR = '/app'
+const FILE_NAME = '/app/src/pages/users/sub-[first]-[second].vue'
+// The type param the plugin injects, derived from the file path relative to rootDir.
+const EXPECTED_TYPE_PARAM = `<import('vue-router/auto-routes')._RouteNamesForFilePath<'src/pages/users/sub-[first]-[second].vue'>>`
+
+/**
+ * Runs the plugin's `resolveEmbeddedCode` over a standalone `<script setup>`
+ * body and returns the transformed virtual code. The AST and the muggle-string
+ * segments are both built from `code` at offset 0 so their offsets align.
+ */
+function transform(
+  code: string,
+  { lang = 'ts', fileName = FILE_NAME } = {}
+): string {
+  const instance = plugin({
+    compilerOptions: { rootDir: ROOT_DIR },
+    modules: { typescript: ts },
+    config: { options: { rootDir: ROOT_DIR } },
+  } as any)
+
+  const ast = ts.createSourceFile(
+    fileName,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  )
+  const content: Segment[] = [[code, fileName, 0]]
+  const sfc = { scriptSetup: { ast, name: fileName, lang } }
+
+  instance.resolveEmbeddedCode!(
+    fileName,
+    sfc as any,
+    {
+      id: 'script_ts',
+      content,
+    } as any
+  )
+
+  return toString(content)
+}
+
+describe('sfc-typed-router volar plugin', () => {
+  it('narrows `typeof useRoute` in a type context', () => {
+    const out = transform(`type R = ReturnType<typeof useRoute>`)
+    expect(out).toBe(
+      `type R = ReturnType<typeof useRoute${EXPECTED_TYPE_PARAM}>`
+    )
+  })
+
+  it('leaves an explicit type argument untouched', () => {
+    const code = `type R = ReturnType<typeof useRoute<'/about'>>`
+    expect(transform(code)).toBe(code)
+  })
+
+  it('narrows the `useRoute()` call as well', () => {
+    const out = transform(`const route = useRoute()`)
+    expect(out).toBe(`const route = useRoute${EXPECTED_TYPE_PARAM}()`)
+  })
+
+  it('does not narrow `typeof useRoute` in a js script', () => {
+    const code = `type R = ReturnType<typeof useRoute>`
+    expect(transform(code, { lang: 'js' })).toBe(code)
+  })
+})

--- a/packages/router/src/volar/entries/sfc-typed-router.ts
+++ b/packages/router/src/volar/entries/sfc-typed-router.ts
@@ -100,6 +100,24 @@ const plugin: VueLanguagePlugin<{ options?: { rootDir?: string } }> = ({
             )
           }
         } else if (
+          ts.isTypeQueryNode(node) &&
+          ts.isIdentifier(node.exprName) &&
+          ts.idText(node.exprName) === 'useRoute' &&
+          !node.typeArguments &&
+          !sfc.scriptSetup!.lang.startsWith('js')
+        ) {
+          // Without type arguments, `typeof useRoute` falls back to the generic
+          // default (every route), so `ReturnType<typeof useRoute>` is wider
+          // than what `useRoute()` actually returns in this file. Instantiate
+          // it with this file's routes so both agree.
+          replaceSourceRange(
+            embeddedCode.content,
+            sfc.scriptSetup!.name,
+            node.exprName.end,
+            node.exprName.end,
+            useRouteNameTypeParam
+          )
+        } else if (
           ts.isCallExpression(node) &&
           ts.isIdentifier(node.expression) &&
           ts.idText(node.expression) === 'definePage' &&


### PR DESCRIPTION
Closes #2758 (see issue for reproduction steps)

The `sfc-typed-router` Volar plugin already rewrites `useRoute()` **calls** so their return type is narrowed to the routes the current file can render. This extends the same treatment to `typeof useRoute` in a **type context**.

Before this PR, without type arguments, `typeof useRoute` resolves to the function's generic default (`keyof RouteMap`, i.e. every route):

```ts
const route = useRoute()
//    ^? RouteLocationNormalizedLoadedTyped<RouteNamedMap, '/users/sub-[first]-[second]'>   ✅ was already narrowed

type R = ReturnType<typeof useRoute>
//   ^? RouteLocationNormalizedLoadedTyped<RouteNamedMap, keyof RouteNamedMap>              ❌ every route
```

## Change

Handle the `typeof useRoute` type query the same way as the call expression.
Explicit type arguments are untouched, so `ReturnType<typeof useRoute<'/b'>>` still resolves to `RouteLocationNormalizedLoadedTyped<RouteNamedMap, "/b">`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced typed routing in Vue `<script setup>` by improving how `typeof useRoute` and `useRoute()` return types are inferred for file-based routes.
  - Updated the file-based routing playground to show the route name, path, and dynamic `first`/`second` parameters with stronger type checking.

- **Tests**
  - Added automated coverage to confirm typed-router narrowing behavior in TypeScript, preserves explicitly provided types, and skips narrowing for JavaScript.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->