### PR TITLE
feat(experimental): never decode the hash, protect-only encoding

### DIFF
--- a/packages/router/src/experimental/encoding.spec.ts
+++ b/packages/router/src/experimental/encoding.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { encodeHash } from './encoding'
+
+describe('encodeHash', () => {
+  it('protects characters that cannot appear in a URL', () => {
+    expect(encodeHash('#a b')).toBe('#a%20b')
+    expect(encodeHash('#"<>`')).toBe('#%22%3C%3E%60')
+    expect(encodeHash('#\\')).toBe('#%5C')
+    expect(encodeHash('#café ¶')).toBe('#caf%C3%A9%20%C2%B6')
+  })
+
+  it('keeps percent encoded sequences as they are', () => {
+    expect(encodeHash('#%26')).toBe('#%26')
+    expect(encodeHash('#a=b%26c&d=e')).toBe('#a=b%26c&d=e')
+    expect(encodeHash('#caf%C3%A9')).toBe('#caf%C3%A9')
+    // double encoded stays double encoded
+    expect(encodeHash('#%2526')).toBe('#%2526')
+  })
+
+  it('keeps a lone % as it is like browsers do', () => {
+    expect(encodeHash('#100%')).toBe('#100%')
+    expect(encodeHash('#50% off')).toBe('#50%%20off')
+  })
+
+  it('keeps reserved and sub-delimiter characters as they are', () => {
+    expect(encodeHash('#a&b=c?d/e:f@g')).toBe('#a&b=c?d/e:f@g')
+    expect(encodeHash("#!$'()*+,;")).toBe("#!$'()*+,;")
+    expect(encodeHash('#{}^|[]')).toBe('#{}^|[]')
+  })
+
+  it('is idempotent', () => {
+    for (const hash of [
+      '#a b',
+      '#"<>`',
+      '#café ¶',
+      '#%26',
+      '#100%',
+      '#50% off',
+      '#a=b%26c&d=e',
+      '#{}^|[]',
+      '#Hell 20% of es¶ña',
+    ]) {
+      const once = encodeHash(hash)
+      expect(encodeHash(once)).toBe(once)
+    }
+  })
+})

--- a/packages/router/src/experimental/encoding.ts
+++ b/packages/router/src/experimental/encoding.ts
@@ -1,0 +1,38 @@
+import { commonEncode } from '../encoding'
+
+// identical to the legacy encoding, re-exported so experimental code has a
+// single entry point and no duplicated code in the bundle
+export {
+  commonEncode,
+  decode,
+  encodeParam,
+  encodePath,
+  encodeQueryKey,
+  encodeQueryValue,
+  PLUS_RE,
+  SLASH_RE,
+} from '../encoding'
+
+const ENC_PERCENT_RE = /%25/g // %
+const ENC_CARET_RE = /%5E/g // ^
+const ENC_CURLY_OPEN_RE = /%7B/g // {
+const ENC_CURLY_CLOSE_RE = /%7D/g // }
+
+/**
+ * Encode characters that need to be encoded on the hash section of the URL.
+ * Like setting `url.hash`: existing percent encoded sequences and lone `%` are
+ * kept as they are, which makes this function idempotent and never decoding.
+ *
+ * @param text - string to encode
+ * @returns encoded string
+ */
+export function encodeHash(text: string): string {
+  return (
+    commonEncode(text)
+      // restore every original %, so pre-encoded sequences pass through
+      .replace(ENC_PERCENT_RE, '%')
+      .replace(ENC_CURLY_OPEN_RE, '{')
+      .replace(ENC_CURLY_CLOSE_RE, '}')
+      .replace(ENC_CARET_RE, '^')
+  )
+}

--- a/packages/router/src/experimental/location.spec.ts
+++ b/packages/router/src/experimental/location.spec.ts
@@ -241,4 +241,30 @@ describe('parseURL', () => {
     expect(parseQuery).toHaveBeenCalledTimes(1)
     expect(parseQuery).toHaveBeenCalledWith('é=é&é=a')
   })
+
+  describe('hash', () => {
+    it('keeps the hash as it appears in the URL, like location.hash', () => {
+      expect(parseURL('/foo#%22%20%25')).toMatchObject({
+        fullPath: '/foo#%22%20%25',
+        hash: '#%22%20%25',
+      })
+      expect(parseURL('/foo#caf%C3%A9')).toMatchObject({
+        fullPath: '/foo#caf%C3%A9',
+        hash: '#caf%C3%A9',
+      })
+      expect(parseURL('/foo#%26')).toMatchObject({
+        fullPath: '/foo#%26',
+        hash: '#%26',
+      })
+      // userland structure like OAuth fragments is preserved
+      expect(parseURL('/foo#a=b%26c&d=e')).toMatchObject({
+        fullPath: '/foo#a=b%26c&d=e',
+        hash: '#a=b%26c&d=e',
+      })
+      expect(parseURL('/foo#100%')).toMatchObject({
+        fullPath: '/foo#100%',
+        hash: '#100%',
+      })
+    })
+  })
 })

--- a/packages/router/src/experimental/location.ts
+++ b/packages/router/src/experimental/location.ts
@@ -1,6 +1,5 @@
-import { decode } from '../encoding'
 import { type LocationNormalized, resolveRelativePath } from '../location'
-import type { LocationQuery } from './query'
+import type { LocationQuery, LocationQueryRaw } from './query'
 
 // TODO: in next major, merge the two query.ts files and the two location.ts files
 
@@ -69,6 +68,27 @@ export function experimental_parseURL(
     fullPath: path + searchString + hash,
     path,
     query,
-    hash: decode(hash),
+    // the hash is kept as it appears in the URL, like location.hash
+    hash,
   }
+}
+
+/**
+ * Stringifies a URL from its parts. The `hash` must already be encoded (as
+ * returned by `encodeHash` or read from a URL), it is appended as is.
+ *
+ * @param stringifyQuery - function to stringify the query object
+ * @param path - path section of the URL
+ * @param query - normalized query object
+ * @param hash - encoded hash section of the URL, with its leading `#`
+ * @returns the URL string
+ */
+export function experimental_stringifyURL(
+  stringifyQuery: (query?: LocationQueryRaw) => string,
+  path: string,
+  query?: LocationQueryRaw,
+  hash: string = ''
+): string {
+  const searchText = stringifyQuery(query)
+  return path + (searchText && '?') + searchText + hash
 }

--- a/packages/router/src/experimental/query.ts
+++ b/packages/router/src/experimental/query.ts
@@ -1,4 +1,4 @@
-import { decode, PLUS_RE } from '../encoding'
+import { decode, PLUS_RE } from './encoding'
 import { isArray } from '../utils'
 
 /**

--- a/packages/router/src/experimental/route-resolver/matchers/matcher-pattern.ts
+++ b/packages/router/src/experimental/route-resolver/matchers/matcher-pattern.ts
@@ -1,5 +1,5 @@
 import { identityFn } from '../../../utils'
-import { decode, encodeParam, encodePath } from '../../../encoding'
+import { decode, encodeParam, encodePath } from '../../encoding'
 import { warn } from '../../../warning'
 import { miss } from './errors'
 import type { ParamParser } from './param-parsers/types'

--- a/packages/router/src/experimental/route-resolver/resolver-abstract.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-abstract.ts
@@ -1,5 +1,5 @@
 import { type LocationQueryRaw } from '../query'
-import { encodeQueryValue as _encodeQueryValue } from '../../encoding'
+import { encodeQueryValue as _encodeQueryValue } from '../encoding'
 import type { MatcherParamsFormatted } from './matchers/matcher-pattern'
 import type { _RouteRecordProps } from '../../typed-routes'
 import type { LocationNormalized } from '../../location'

--- a/packages/router/src/experimental/route-resolver/resolver-fixed.spec.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-fixed.spec.ts
@@ -1018,12 +1018,38 @@ describe('fixed resolver', () => {
           })
         })
 
-        it('decodes hash from a string', () => {
+        it('keeps the hash from a string as it is, like location.hash', () => {
           expect(resolver.resolve('/foo#%22')).toMatchObject({
             path: '/foo',
             fullPath: '/foo#%22',
-            hash: '#"',
+            hash: '#%22',
           })
+        })
+
+        it('keeps encoded reserved characters in the hash', () => {
+          expect(resolver.resolve('/foo#%26')).toMatchObject({
+            fullPath: '/foo#%26',
+            hash: '#%26',
+          })
+          expect(resolver.resolve('/foo#a=b%26c&d=e')).toMatchObject({
+            fullPath: '/foo#a=b%26c&d=e',
+            hash: '#a=b%26c&d=e',
+          })
+        })
+
+        it('resolving the fullPath of a resolved location is idempotent', () => {
+          for (const url of [
+            '/foo#%26',
+            '/foo#a=b%26c&d=e',
+            '/foo#%22%20%25',
+            '/foo#caf%C3%A9',
+            '/foo#100%',
+          ]) {
+            const location = resolver.resolve(url as `/${string}`)
+            const again = resolver.resolve(location.fullPath as `/${string}`)
+            expect(again.hash).toBe(location.hash)
+            expect(again.fullPath).toBe(location.fullPath)
+          }
         })
       })
 
@@ -1037,10 +1063,42 @@ describe('fixed resolver', () => {
           })
         })
 
-        it('encodes the hash', () => {
+        it('protects the hash like setting url.hash', () => {
           expect(resolver.resolve({ path: '/foo', hash: '#"' })).toMatchObject({
             fullPath: '/foo#%22',
-            hash: '#"',
+            hash: '#%22',
+          })
+          expect(
+            resolver.resolve({ path: '/foo', hash: '#a b' })
+          ).toMatchObject({
+            fullPath: '/foo#a%20b',
+            hash: '#a%20b',
+          })
+        })
+
+        it('keeps a pre-encoded hash as it is', () => {
+          expect(
+            resolver.resolve({ path: '/foo', hash: '#a=b%26c&d=e' })
+          ).toMatchObject({
+            fullPath: '/foo#a=b%26c&d=e',
+            hash: '#a=b%26c&d=e',
+          })
+        })
+
+        it('round trips a hash through the URL', () => {
+          const location = resolver.resolve({
+            path: '/foo',
+            hash: '#Hell 20% of es¶ña',
+          })
+          expect(location).toMatchObject({
+            fullPath: '/foo#Hell%2020%%20of%20es%C2%B6%C3%B1a',
+            hash: '#Hell%2020%%20of%20es%C2%B6%C3%B1a',
+          })
+          expect(
+            resolver.resolve(location.fullPath as `/${string}`)
+          ).toMatchObject({
+            fullPath: location.fullPath,
+            hash: location.hash,
           })
         })
       })

--- a/packages/router/src/experimental/route-resolver/resolver-fixed.ts
+++ b/packages/router/src/experimental/route-resolver/resolver-fixed.ts
@@ -3,12 +3,12 @@ import {
   experimental_parseQuery as parseQuery,
 } from '../query'
 import { stringifyQuery } from '../../query'
-import { experimental_parseURL as parseURL } from '../location'
 import {
-  type LocationNormalized,
-  NEW_stringifyURL,
-  resolveRelativePath,
-} from '../../location'
+  experimental_parseURL as parseURL,
+  experimental_stringifyURL as stringifyURL,
+} from '../location'
+import { encodeHash } from '../encoding'
+import { type LocationNormalized, resolveRelativePath } from '../../location'
 import type {
   MatcherPatternPath,
   MatcherPatternHash,
@@ -218,14 +218,14 @@ export function createFixedResolver<
         // @ts-expect-error: to is never
         const query = normalizeQuery(to.query)
         // @ts-expect-error: to is never
-        const hash = to.hash ?? ''
+        const hash = encodeHash(to.hash ?? '')
         // @ts-expect-error: to is never
         const path = to.path ?? '/'
         return {
           // type is never
           ...(to as any),
           ...NO_MATCH_LOCATION,
-          fullPath: NEW_stringifyURL(stringifyQuery, path, query, hash),
+          fullPath: stringifyURL(stringifyQuery, path, query, hash),
           path,
           query,
           hash,
@@ -254,8 +254,10 @@ export function createFixedResolver<
         ...to.params,
       }
       const path = record.path.build(params)
-      const hash =
+      // currentLocation.hash is already encoded, encodeHash is idempotent
+      const hash = encodeHash(
         record.hash?.build(params) ?? to.hash ?? currentLocation?.hash ?? ''
+      )
       let matched = buildMatched(record)
       const query = Object.assign(
         {
@@ -270,7 +272,7 @@ export function createFixedResolver<
       const url: LocationNormalized = {
         // preserve other fields like `state` and `replace`
         ...to,
-        fullPath: NEW_stringifyURL(
+        fullPath: stringifyURL(
           stringifyQuery,
           path,
           query,
@@ -300,13 +302,14 @@ export function createFixedResolver<
       } else {
         const query = normalizeQuery(to.query)
         const path = resolveRelativePath(to.path, currentLocation?.path || '/')
+        const hash = encodeHash(to.hash || '')
         url = {
           // preserve other fields like `state` and `replace`
           ...to,
-          fullPath: NEW_stringifyURL(stringifyQuery, path, query, to.hash),
+          fullPath: stringifyURL(stringifyQuery, path, query, hash),
           path,
           query,
-          hash: to.hash || '',
+          hash,
         }
       }
 

--- a/packages/router/src/experimental/router.spec.ts
+++ b/packages/router/src/experimental/router.spec.ts
@@ -614,16 +614,27 @@ describe('Experimental Router', () => {
     expect(router.currentRoute.value.hash).toBe('#two')
   })
 
-  it('does not double-decode a percent-encoded hash', async () => {
+  it('never decodes nor double-encodes a percent-encoded hash', async () => {
     const { router } = await newRouter()
-    // object push keeps the raw hash, encodes % in fullPath
+    // object push keeps pre-encoded sequences as they are, like url.hash
     await router.push({ path: '/', hash: '#%26' })
     expect(router.currentRoute.value.hash).toBe('#%26')
-    expect(router.currentRoute.value.fullPath).toBe('/#%2526')
-    // string push (what happens on reload) must decode exactly once
+    expect(router.currentRoute.value.fullPath).toBe('/#%26')
+    // string push (what happens on reload) keeps the hash as it is
     await router.push('/#%2526')
-    expect(router.currentRoute.value.hash).toBe('#%26')
+    expect(router.currentRoute.value.hash).toBe('#%2526')
     expect(router.currentRoute.value.fullPath).toBe('/#%2526')
+  })
+
+  // https://github.com/nuxt/nuxt/issues/32774
+  it('keeps an encoded hash when re-resolving a resolved route', async () => {
+    const { router } = await newRouter()
+    const resolved = router.resolve('/#a=1%26b=2')
+    expect(resolved.hash).toBe('#a=1%26b=2')
+    expect(resolved.fullPath).toBe('/#a=1%26b=2')
+    await router.replace({ ...resolved, force: true })
+    expect(router.currentRoute.value.hash).toBe('#a=1%26b=2')
+    expect(router.currentRoute.value.fullPath).toBe('/#a=1%26b=2')
   })
 
   it('throws if required params are missing', async () => {

--- a/packages/router/src/location.ts
+++ b/packages/router/src/location.ts
@@ -3,7 +3,7 @@ import type { RouteParamValue, RouteParamsGeneric } from './types'
 import type { RouteRecord } from './matcher/types'
 import { diagnostics } from './diagnostics'
 import { isArray } from './utils'
-import { decode, encodeHash } from './encoding'
+import { decode } from './encoding'
 import type {
   RouteLocation,
   RouteLocationNormalizedLoaded,
@@ -101,37 +101,6 @@ export function parseURL(
     query,
     hash: decode(hash),
   }
-}
-
-/**
- * Creates a `fullPath` property from the `path`, `query` and `hash` properties
- *
- * @param  stringifyQuery - custom function to stringify the query object. It should handle encoding values
- * @param  path - An encdoded path
- * @param  query - A decoded query object
- * @param  hash - A decoded hash
- * @returns a valid `fullPath`
- */
-export function NEW_stringifyURL(
-  stringifyQuery: (query?: LocationQueryRaw) => string,
-  path: `/${string}`,
-  query?: LocationPartial['query'],
-  hash?: LocationPartial['hash']
-): `/${string}`
-export function NEW_stringifyURL(
-  stringifyQuery: (query?: LocationQueryRaw) => string,
-  path: string,
-  query?: LocationPartial['query'],
-  hash?: LocationPartial['hash']
-): string
-export function NEW_stringifyURL(
-  stringifyQuery: (query?: LocationQueryRaw) => string,
-  path: string,
-  query?: LocationPartial['query'],
-  hash: LocationPartial['hash'] = ''
-): string {
-  const searchText = stringifyQuery(query)
-  return path + (searchText && '?') + searchText + encodeHash(hash)
 }
 
 /**


### PR DESCRIPTION
The experimental router no longer decodes the hash. `route.hash` is exactly what appears in the URL, like `location.hash`.

`encodeHash` only escapes unsafe characters (space, `"`, `<`, `>`, backtick, non-ASCII). Existing percent sequences and lone `%` are kept, so it never double-encodes and resolving a resolved location changes nothing.

This keeps `%26` and `&` distinct and avoids the bug behind nuxt/nuxt#32774 / #2756 (experimental only, v4 unchanged).

- New `src/experimental/encoding.ts`: defines `encodeHash`, re-exports the rest from the legacy module to avoid bundle duplication.
- Query and params are unchanged: they still decode.
- To read a decoded hash, use `decodeURIComponent(route.hash)`.
- Removes the unused `NEW_stringifyURL` from `src/location.ts`.

Size: `webRouter_experimental.js` min 16.43kb -> 16.52kb.