### PR TITLE
build: include tsdown.config.ts in tsconfig

### DIFF
--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -3,7 +3,9 @@
   "include": [
     // multiline
     "src/**/*.ts",
-    "__tests__/**/*.ts"
+    "__tests__/**/*.ts",
+    "tsdown.config.ts",
+    "package.json"
     // FIXME: use project references maybe to isolate module augmentation
     // "test-dts/**/*.ts"
   ],


### PR DESCRIPTION
tsdown.config.ts was not covered by any tsconfig, so editors compiled it with inferred settings and reported errors (missing node types, unsupported import attributes). Add it and package.json (required by the composite project for the JSON import) to the include list.

<img width="1802" height="332" alt="image" src="https://github.com/user-attachments/assets/98309b78-6eb8-424b-b1ec-50e93094a756" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to include additional TypeScript and package metadata files.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->