### PR TITLE
chore(docs): add robots.txt

### DIFF
--- a/packages/docs/public/robots.txt
+++ b/packages/docs/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
+Disallow:
+
+Sitemap: https://router.vuejs.org/sitemap.xml 


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
## Description of Problem
Fixes: #2762 
https://router.vuejs.org/robots.txt is 404ing 

## Proposed Solution
- Add a robots.txt file to the public docs folder. 

## Testing
- Tested by building and previewing locally. 

## Additional Information
- This robots.txt file is based on [Nuxt's robots.txt](https://nuxt.com/robots.txt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added crawler guidance for search engines and AI services.
  * Linked the documentation site to its sitemap to improve content discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->