### PR TITLE
docs: fix `@see` link to `MatcherPattern` in param parsers

### DIFF
--- a/packages/router/src/experimental/route-resolver/matchers/param-parsers/types.ts
+++ b/packages/router/src/experimental/route-resolver/matchers/param-parsers/types.ts
@@ -1,6 +1,5 @@
 import type {
   MatcherQueryParamsValue,
-  // @ts-ignore: actually used in jsdoc, sometimes works in TS, sometimes doesn't...
   MatcherPattern,
 } from '../matcher-pattern'
 
@@ -21,7 +20,7 @@ import type {
  * navigating: `router.push({ params: {}})` it's sometimes more permissive than
  * TParam, for example allowing nullish values
  *
- * @see {MatcherPattern}
+ * @see {@link MatcherPattern}
  */
 export interface ParamParser<
   // the final type in route.params


### PR DESCRIPTION
 Use `{@link ...}` so the type reference resolves properly, and drop the `@ts-ignore` that worked around the broken link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation links for parameter parsing.
  * Removed an unnecessary TypeScript suppression comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->