### PR TITLE
ci: preview release add pm option

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -42,4 +42,4 @@ jobs:
         run: pnpm -C packages/router build
 
       - name: Release
-        run: pnpm dlx pkg-pr-new publish --compact --pnpm './packages/*'
+        run: pnpm dlx pkg-pr-new publish --compact --pnpm './packages/*' --packageManager=pnpm,npm,yarn


### PR DESCRIPTION
Different developers may use different package management tools. To facilitate copying and execution, commands that satisfy various package management tools are generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing configuration to explicitly support pnpm, npm, and Yarn package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->