### PR TITLE
perf: replace `json5` and `yaml` with `confbox`

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -141,7 +141,7 @@
     "@vue/devtools-api": "^8.1.5",
     "ast-walker-scope": "^0.9.0",
     "chokidar": "^5.0.0",
-    "json5": "^2.2.3",
+    "confbox": "^0.2.4",
     "local-pkg": "^1.2.1",
     "magic-string": "^0.30.21",
     "mlly": "^1.8.2",
@@ -152,8 +152,7 @@
     "scule": "^1.3.0",
     "tinyglobby": "^0.2.17",
     "unplugin": "^3.3.0",
-    "unplugin-utils": "^0.3.2",
-    "yaml": "^2.9.0"
+    "unplugin-utils": "^0.3.2"
   },
   "devDependencies": {
     "@babel/types": "^8.0.0",

--- a/packages/router/src/unplugin/core/customBlock.ts
+++ b/packages/router/src/unplugin/core/customBlock.ts
@@ -1,8 +1,8 @@
 import type { SFCBlock } from '@vue/compiler-sfc'
 import { parse as parseSFC } from '@vue/compiler-sfc'
 import type { ResolvedOptions } from '../options'
-import JSON5 from 'json5'
-import { parse as parseYaml } from 'yaml'
+import { parseJSON5 } from 'confbox/json5'
+import { parseYAML } from 'confbox/yaml'
 import { diagnostics } from '../diagnostics'
 import type { DefinePageQueryParamOptions } from '../../experimental/runtime'
 import type { RouteRecordRaw } from '../../types'
@@ -60,7 +60,7 @@ function parseCustomBlock(
 
   if (lang === 'json5') {
     try {
-      return JSON5.parse(block.content)
+      return parseJSON5(block.content)
     } catch (err: any) {
       diagnostics.VUE_ROUTER_B0012({
         type: block.type,
@@ -80,7 +80,7 @@ function parseCustomBlock(
     }
   } else if (lang === 'yaml' || lang === 'yml') {
     try {
-      return parseYaml(block.content)
+      return parseYAML(block.content)
     } catch (err: any) {
       diagnostics.VUE_ROUTER_B0014({
         type: block.type,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,9 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
-      json5:
-        specifier: ^2.2.3
-        version: 2.2.3
+      confbox:
+        specifier: ^0.2.4
+        version: 0.2.4
       local-pkg:
         specifier: ^1.2.1
         version: 1.2.1
@@ -273,9 +273,6 @@ importers:
       unplugin-utils:
         specifier: ^0.3.2
         version: 0.3.2
-      yaml:
-        specifier: ^2.9.0
-        version: 2.9.0
     devDependencies:
       '@babel/types':
         specifier: ^8.0.0-rc.4
@@ -2636,8 +2633,8 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
-  confbox@0.2.2:
-    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -6980,7 +6977,7 @@ snapshots:
 
   confbox@0.1.8: {}
 
-  confbox@0.2.2: {}
+  confbox@0.2.4: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -8290,7 +8287,7 @@ snapshots:
 
   pkg-types@2.3.0:
     dependencies:
-      confbox: 0.2.2
+      confbox: 0.2.4
       exsolve: 1.0.7
       pathe: 2.0.3
 


### PR DESCRIPTION
in the spirit of [e18e](https://e18e.dev/) (and in the same vein as #2747), the `<route>` custom block parser is the only thing pulling `json5` and `yaml` in.

`confbox` is already in the tree via `local-pkg` -> `pkg-types` and is a more minimal distribution of the same two parsers, so this removes two packages without adding any. parsed output and error messages should be unchanged.

> [!NOTE]
> `json5` is 235 kB unpacked and `yaml` is 686 kB. `confbox` is 137 kB and was being installed either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of JSON5 and YAML route configuration blocks.
  * Preserved existing error handling and diagnostic messages when configuration parsing fails.
  * Updated parsing support for greater consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->