### PR TITLE
perf(link): skip reactivity when rendering on the server

### DIFF
--- a/packages/router/__tests__/RouterLink.ssr.spec.ts
+++ b/packages/router/__tests__/RouterLink.ssr.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment node
+ */
+import { createSSRApp, h, type Component } from 'vue'
+import { renderToString } from '@vue/server-renderer'
+import { vi, describe, expect, it } from 'vitest'
+import { START_LOCATION_NORMALIZED } from '../src/location'
+import type { RouteRecordNormalized } from '../src/matcher/types'
+import type {
+  RouteLocationNormalized,
+  RouteLocationResolved,
+} from '../src/typed-routes'
+import type { RouterOptions } from '../src/router'
+
+const records = {
+  home: { path: '/home' } as RouteRecordNormalized,
+  parent: { path: '/parent' } as RouteRecordNormalized,
+  child: { path: '/parent/child' } as RouteRecordNormalized,
+  user: { path: '/users/:id' } as RouteRecordNormalized,
+}
+const homeAlias = {
+  path: '/start',
+  aliasOf: records.home,
+} as RouteRecordNormalized
+
+function createLocation(
+  path: string,
+  matched: RouteRecordNormalized[],
+  params: RouteLocationResolved['params'] = {}
+): RouteLocationResolved {
+  return {
+    fullPath: path,
+    href: path,
+    path,
+    params,
+    meta: {},
+    query: {},
+    hash: '',
+    matched,
+    redirectedFrom: undefined,
+    name: undefined,
+  } as unknown as RouteLocationResolved
+}
+
+const locations = {
+  home: createLocation('/home', [records.home]),
+  homeAlias: createLocation('/start', [homeAlias]),
+  parent: createLocation('/parent', [records.parent]),
+  child: createLocation('/parent/child', [records.parent, records.child]),
+  user1: createLocation('/users/1', [records.user], { id: '1' }),
+  user2: createLocation('/users/2', [records.user], { id: '2' }),
+}
+
+/**
+ * Renders `RouterLink` with `isBrowser` forced to a given value so both the
+ * reactive rendering and the server one can be compared in the same file.
+ */
+async function renderLink(
+  isBrowser: boolean,
+  currentLocation: RouteLocationNormalized,
+  propsData: Record<string, unknown>,
+  resolvedLocation: RouteLocationResolved,
+  options: Partial<RouterOptions> = {},
+  slot?: (link: any) => any
+) {
+  vi.resetModules()
+  vi.doMock('../src/utils/env', () => ({ isBrowser }))
+
+  // all of these must come from the same module registry as the mock above
+  const [{ RouterLink }, { routerKey }, { createMockedRoute }] =
+    await Promise.all([
+      import('../src/RouterLink'),
+      import('../src/injectionSymbols'),
+      import('./mount'),
+    ])
+
+  const route = createMockedRoute(currentLocation)
+  const router = {
+    options,
+    resolve: vi.fn().mockReturnValue(resolvedLocation),
+    push: vi.fn().mockResolvedValue(resolvedLocation),
+    replace: vi.fn().mockResolvedValue(resolvedLocation),
+  }
+
+  const app = createSSRApp({
+    render: () =>
+      h(RouterLink as Component, propsData, slot as unknown as () => any),
+  })
+  app.provide(routerKey, router as any)
+  for (const key of Object.getOwnPropertySymbols(route.provides)) {
+    app.provide(key, (route.provides as any)[key])
+  }
+
+  const html = await renderToString(app)
+  vi.doUnmock('../src/utils/env')
+  return html
+}
+
+describe('RouterLink SSR', () => {
+  const cases: Array<
+    [
+      name: string,
+      currentLocation: RouteLocationNormalized,
+      propsData: Record<string, unknown>,
+      resolvedLocation: RouteLocationResolved,
+      options?: Partial<RouterOptions>,
+      slot?: (link: any) => any,
+    ]
+  > = [
+    [
+      'an inactive link',
+      START_LOCATION_NORMALIZED,
+      { to: '/home' },
+      locations.home,
+    ],
+    [
+      'an exact active link',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home' },
+      locations.home,
+    ],
+    [
+      'an active parent',
+      locations.child as unknown as RouteLocationNormalized,
+      { to: '/parent' },
+      locations.parent,
+    ],
+    [
+      'a nested exact active link',
+      locations.child as unknown as RouteLocationNormalized,
+      { to: '/parent/child' },
+      locations.child,
+    ],
+    [
+      'an aliased record',
+      locations.homeAlias as unknown as RouteLocationNormalized,
+      { to: '/home' },
+      locations.home,
+    ],
+    [
+      'matching params',
+      locations.user1 as unknown as RouteLocationNormalized,
+      { to: { name: 'user', params: { id: '1' } } },
+      locations.user1,
+    ],
+    [
+      'differing params',
+      locations.user1 as unknown as RouteLocationNormalized,
+      { to: { name: 'user', params: { id: '2' } } },
+      locations.user2,
+    ],
+    [
+      'a custom activeClass',
+      locations.child as unknown as RouteLocationNormalized,
+      { to: '/parent', activeClass: 'is-active' },
+      locations.parent,
+    ],
+    [
+      'a custom exactActiveClass',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home', exactActiveClass: 'is-exact' },
+      locations.home,
+    ],
+    [
+      'a custom ariaCurrentValue',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home', ariaCurrentValue: 'step' },
+      locations.home,
+    ],
+    [
+      'global link classes',
+      locations.child as unknown as RouteLocationNormalized,
+      { to: '/parent' },
+      locations.parent,
+      { linkActiveClass: 'g-active', linkExactActiveClass: 'g-exact' },
+    ],
+    [
+      'a fallthrough class',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home', class: 'user-class' },
+      locations.home,
+    ],
+    [
+      'a default slot',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home' },
+      locations.home,
+      {},
+      () => 'Home' as any,
+    ],
+    [
+      'a custom link with one vnode',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home', custom: true },
+      locations.home,
+      {},
+      (link: any) => h('a', { href: link.href }, String(link.isExactActive)),
+    ],
+    [
+      'a custom link with multiple vnodes',
+      locations.home as unknown as RouteLocationNormalized,
+      { to: '/home', custom: true },
+      locations.home,
+      {},
+      (link: any) => [h('span', link.href), h('span', String(link.isActive))],
+    ],
+  ]
+
+  it.each(cases)(
+    'renders %s the same on the server',
+    async (_name, currentLocation, propsData, resolved, options, slot) => {
+      expect(
+        await renderLink(
+          false,
+          currentLocation,
+          propsData,
+          resolved,
+          options,
+          slot
+        )
+      ).toBe(
+        await renderLink(
+          true,
+          currentLocation,
+          propsData,
+          resolved,
+          options,
+          slot
+        )
+      )
+    }
+  )
+
+  it('passes the same slot props', async () => {
+    const received: any[] = []
+    const slot = (link: any) => {
+      received.push({ ...link, navigate: typeof link.navigate })
+      return h('span')
+    }
+    const args = [
+      locations.child as unknown as RouteLocationNormalized,
+      { to: '/parent', custom: true },
+      locations.parent,
+      {},
+      slot,
+    ] as const
+
+    await renderLink(true, ...args)
+    await renderLink(false, ...args)
+
+    const [reactive, eager] = received
+    expect(Object.keys(eager).sort()).toEqual(Object.keys(reactive).sort())
+    expect(eager).toMatchObject({
+      href: reactive.href,
+      isActive: reactive.isActive,
+      isExactActive: reactive.isExactActive,
+      navigate: 'function',
+    })
+    expect(eager.isActive).toBe(true)
+  })
+})

--- a/packages/router/src/RouterLink.ts
+++ b/packages/router/src/RouterLink.ts
@@ -24,6 +24,7 @@ import { isSameRouteLocationParams, isSameRouteRecord } from './location'
 import { routerKey, routeLocationKey } from './injectionSymbols'
 import type { RouteRecord } from './matcher/types'
 import type { NavigationFailure } from './errors'
+import type { Router } from './router'
 import { isArray, isBrowser, noop } from './utils'
 import { diagnostics } from './diagnostics'
 import { isRouteLocation } from './types'
@@ -145,9 +146,7 @@ export function useLink<Name extends keyof RouteMap = keyof RouteMap>(
     const to = unref(props.to)
 
     if (__DEV__ && (!hasPrevious || to !== previousTo)) {
-      if (!isRouteLocation(to)) {
-        diagnostics.VUE_ROUTER_R0050({ to })
-      }
+      checkRouteLocation(to)
 
       previousTo = to
       hasPrevious = true
@@ -156,67 +155,12 @@ export function useLink<Name extends keyof RouteMap = keyof RouteMap>(
     return router.resolve(to)
   })
 
-  const activeRecordIndex = computed<number>(() => {
-    const { matched } = route.value
-    const { length } = matched
-    const routeMatched: RouteRecord | undefined = matched[length - 1]
-    const currentMatched = currentRoute.matched
-    if (!routeMatched || !currentMatched.length) return -1
-    const index = currentMatched.findIndex(
-      isSameRouteRecord.bind(null, routeMatched)
-    )
-    if (index > -1) return index
-    // possible parent record
-    const parentRecordPath = getOriginalPath(
-      matched[length - 2] as RouteRecord | undefined
-    )
-    return (
-      // we are dealing with nested routes
-      length > 1 &&
-        // if the parent and matched route have the same path, this link is
-        // referring to the empty child. Or we currently are on a different
-        // child of the same parent
-        getOriginalPath(routeMatched) === parentRecordPath &&
-        // avoid comparing the child with its parent
-        currentMatched[currentMatched.length - 1].path !== parentRecordPath
-        ? currentMatched.findIndex(
-            isSameRouteRecord.bind(null, matched[length - 2])
-          )
-        : index
-    )
-  })
+  const linkState = computed(() => resolveLinkState(route.value, currentRoute))
 
-  const isActive = computed<boolean>(
-    () =>
-      activeRecordIndex.value > -1 &&
-      includesParams(currentRoute.params, route.value.params)
-  )
-  const isExactActive = computed<boolean>(
-    () =>
-      activeRecordIndex.value > -1 &&
-      activeRecordIndex.value === currentRoute.matched.length - 1 &&
-      isSameRouteLocationParams(currentRoute.params, route.value.params)
-  )
+  const isActive = computed<boolean>(() => linkState.value.isActive)
+  const isExactActive = computed<boolean>(() => linkState.value.isExactActive)
 
-  function navigate(
-    e: MouseEvent = {} as MouseEvent
-  ): Promise<void | NavigationFailure> {
-    if (guardEvent(e)) {
-      const p = router[unref(props.replace) ? 'replace' : 'push'](
-        unref(props.to)
-        // avoid uncaught errors are they are logged anyway
-      ).catch(noop)
-      if (
-        props.viewTransition &&
-        typeof document !== 'undefined' &&
-        'startViewTransition' in document
-      ) {
-        document.startViewTransition(() => p)
-      }
-      return p
-    }
-    return Promise.resolve()
-  }
+  const navigate = createNavigate(router, props)
 
   // devtools only
   if ((__DEV__ || __FEATURE_PROD_DEVTOOLS__) && isBrowser) {
@@ -259,6 +203,88 @@ export function useLink<Name extends keyof RouteMap = keyof RouteMap>(
   }
 }
 
+function createNavigate(
+  router: Router,
+  props: Pick<UseLinkOptions, 'to' | 'replace' | 'viewTransition'>
+) {
+  return function navigate(
+    e: MouseEvent = {} as MouseEvent
+  ): Promise<void | NavigationFailure> {
+    if (guardEvent(e)) {
+      const p = router[unref(props.replace) ? 'replace' : 'push'](
+        unref(props.to)
+        // avoid uncaught errors are they are logged anyway
+      ).catch(noop)
+      if (
+        props.viewTransition &&
+        typeof document !== 'undefined' &&
+        'startViewTransition' in document
+      ) {
+        document.startViewTransition(() => p)
+      }
+      return p
+    }
+    return Promise.resolve()
+  }
+}
+
+function checkRouteLocation(to: unknown) {
+  if (!isRouteLocation(to)) {
+    diagnostics.VUE_ROUTER_R0050({ to })
+  }
+}
+
+/**
+ * Computes the active state of a resolved link location against the current
+ * route location.
+ */
+function resolveLinkState(
+  route: RouteLocationResolved,
+  currentRoute: RouteLocation
+): { isActive: boolean; isExactActive: boolean } {
+  const currentMatched = currentRoute.matched
+  const index = activeRecordIndex(route.matched, currentMatched)
+
+  return {
+    isActive: index > -1 && includesParams(currentRoute.params, route.params),
+    isExactActive:
+      index > -1 &&
+      index === currentMatched.length - 1 &&
+      isSameRouteLocationParams(currentRoute.params, route.params),
+  }
+}
+
+function activeRecordIndex(
+  matched: RouteLocationResolved['matched'],
+  currentMatched: RouteLocation['matched']
+): number {
+  const { length } = matched
+  const routeMatched: RouteRecord | undefined = matched[length - 1]
+  if (!routeMatched || !currentMatched.length) return -1
+  const index = currentMatched.findIndex(
+    isSameRouteRecord.bind(null, routeMatched)
+  )
+  if (index > -1) return index
+  // possible parent record
+  const parentRecordPath = getOriginalPath(
+    matched[length - 2] as RouteRecord | undefined
+  )
+  return (
+    // we are dealing with nested routes
+    length > 1 &&
+      // if the parent and matched route have the same path, this link is
+      // referring to the empty child. Or we currently are on a different
+      // child of the same parent
+      getOriginalPath(routeMatched) === parentRecordPath &&
+      // avoid comparing the child with its parent
+      currentMatched[currentMatched.length - 1].path !== parentRecordPath
+      ? currentMatched.findIndex(
+          isSameRouteRecord.bind(null, matched[length - 2])
+        )
+      : index
+  )
+}
+
 function preferSingleVNode(vnodes: VNode[]) {
   return vnodes.length === 1 ? vnodes[0] : vnodes
 }
@@ -286,8 +312,62 @@ export const RouterLinkImpl = /*#__PURE__*/ defineComponent({
   useLink,
 
   setup(props, { slots }) {
+    const router = inject(routerKey)!
+    const { options } = router
+
+    // on the server the component renders once and nothing can invalidate its
+    // state in between, so the reactive machinery is pure overhead
+    if (!isBrowser) {
+      const currentRoute = inject(routeLocationKey)!
+      const navigate = createNavigate(router, props)
+
+      return () => {
+        const to = props.to
+        if (__DEV__) {
+          checkRouteLocation(to)
+        }
+        const route = router.resolve(to)
+        const { isActive, isExactActive } = resolveLinkState(
+          route,
+          currentRoute
+        )
+        const link = {
+          route,
+          href: route.href,
+          isActive,
+          isExactActive,
+          navigate,
+        }
+
+        const children = slots.default && preferSingleVNode(slots.default(link))
+
+        return props.custom
+          ? children
+          : h(
+              'a',
+              {
+                'aria-current': isExactActive ? props.ariaCurrentValue : null,
+                href: route.href,
+                onClick: navigate,
+                class: {
+                  [getLinkClass(
+                    props.activeClass,
+                    options.linkActiveClass,
+                    'router-link-active'
+                  )]: isActive,
+                  [getLinkClass(
+                    props.exactActiveClass,
+                    options.linkExactActiveClass,
+                    'router-link-exact-active'
+                  )]: isExactActive,
+                },
+              },
+              children
+            )
+      }
+    }
+
     const link = reactive(useLink(props))
-    const { options } = inject(routerKey)!
 
     const elClass = computed(() => ({
       [getLinkClass(


### PR DESCRIPTION
> [!NOTE]
> spotted when doing some benchmarking of `<NuxtLink>` that there was an opportunity to speed up rendering `<RouterLink>` for SSR.

on the server a `<RouterLink>` doesn't need to be reactive, but five computed values are produced by `reactive(useLink(props))`, which has a cost which we can avoid

to avoid two copies of most of the logic, this moves most computed values into plain functions which can be directly executed in the SSR fast-path, or built into computed values for client-side state.

I've done benchmarking locally using 200 links with `renderToString` (note that the mean value here is inflated by GC so the min value is truer unless using with lots of links)

| | min | mean | hz |
| - | - | - | - |
| main | 0.563ms | 0.910ms | 1,100 |
| this pr | 0.384ms | 0.416ms | 2,404 |
| plain `<a>` | 0.147ms | 0.176ms | 5,679 |

my tentative headline is that renders `<RouterLink>` in server environments **~1.5-2.2x faster**. per link that's still tiny: 4.55 μs -> 2.08 μs, but every little helps, right?

(you'll probably want to run your own numbers but I'd be very happy to share my benchmark script if that helps)

let me know if I've missed anything, or you think this is the wrong approach. we can also resolve this in nuxt separately but thought this would be useful to upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered links to match client-rendered behavior, including navigation, active states, CSS classes, and slot content.
  * Ensured links render consistently whether browser detection is enabled or disabled.
  * Improved support for nested, aliased, and parameterized routes during server-side rendering.

* **Tests**
  * Added comprehensive coverage for server-rendered link scenarios and parity with reactive client rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->