### PR TITLE
docs: document page title updates

### DIFF
--- a/packages/docs/guide/advanced/navigation-guards.md
+++ b/packages/docs/guide/advanced/navigation-guards.md
@@ -136,6 +136,30 @@ router.afterEach((to, from, failure) => {
 
 Learn more about navigation failures on [its guide](./navigation-failures.md).
 
+You can also combine after hooks with [route meta fields](./meta.md) to update
+the page title after a successful navigation. First, add a title to each route
+that needs one:
+
+```js
+const routes = [
+  {
+    path: '/about',
+    component: About,
+    meta: { title: 'About' },
+  },
+]
+```
+
+Then update the document title after navigation finishes:
+
+```js
+router.afterEach((to, from, failure) => {
+  if (!failure && typeof to.meta.title === 'string') {
+    document.title = to.meta.title
+  }
+})
+```
+
 ## Global injections within guards
 
 Since Vue 3.3, it is possible to use `inject()` within navigation guards. This is useful for injecting global properties like the [pinia stores](https://pinia.vuejs.org). Anything that is provided with `app.provide()` is also accessible within `router.beforeEach()`, `router.beforeResolve()`, `router.afterEach()`:


### PR DESCRIPTION
## What changed

- document how to store page titles in route meta fields
- show how to update `document.title` from a global `afterEach` hook
- avoid changing the title when navigation finishes with a failure

## Why

The navigation guard guide mentions page-title updates as an `afterEach` use case but does not show how to implement them. This adds the focused example requested by the maintainer in #1539 without introducing a separate page or implying that Vue Router manages document metadata automatically.

Closes #1539.

## How tested

- `pnpm exec oxfmt --check packages/docs/guide/advanced/navigation-guards.md`
- `pnpm -C packages/router build`
- `pnpm --filter ./packages/docs docs:build`
- verified the VitePress build processed `navigation-guards.md`, rendered all pages, generated the sitemap, and reported no new dead links

## Risk and rollout

- Risk: low; documentation-only change with no runtime or API impact
- Rollback: revert commit `4eea7d24`

## Duplicate check

Searched open, closed, and merged PRs; open and closed issues; issue comments; commits; and the current docs for:

- `1539`
- `page title`, `document.title`, and head metadata
- `afterEach` with route meta
- `navigation-guards.md`

No PR or commit implements this requested example. #2778 only updates Chinese translations and does not add the English source content, so this change intentionally touches only the English guide.

## Notes for reviewers

On Windows, the existing `run-typedoc.mjs` URL-path handling needs local path normalization before it can generate the API reference. That local-only adjustment was reverted before committing; the final diff contains only the requested guide update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for updating the browser document title after successful navigation.
  - Included an example combining global navigation hooks with route metadata.
  - Shows how to apply titles only when navigation succeeds and the metadata is valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->