### PR TITLE
fix(router): skip scroll saving for unknown pop direction (fix #1431)

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -713,6 +713,34 @@ describe('Router', () => {
       '/p/a': 2000,
     }
 
+    it('does not restore scroll positions for pop navigations with unknown direction', async () => {
+      const scrollBehavior = vi.fn()
+      const history = createMemoryHistory() as ReturnType<
+        typeof createMemoryHistory
+      > & { changeURL(url: string): void }
+      const { router } = await newRouter({ history, scrollBehavior })
+      scrollBehavior.mockClear()
+
+      history.changeURL('/foo')
+      await nextNavigation(router)
+      history.changeURL('/')
+      await nextNavigation(router)
+
+      expect(scrollBehavior).toHaveBeenCalledTimes(2)
+      expect(scrollBehavior).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ path: '/foo' }),
+        expect.objectContaining({ path: '/' }),
+        null
+      )
+      expect(scrollBehavior).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ path: '/' }),
+        expect.objectContaining({ path: '/foo' }),
+        null
+      )
+    })
+
     it('ignores the scroll of navigations superseded before they finish', async () => {
       // scrollBehavior resolves asynchronously, simulating waiting for the DOM
       const scrollBehavior = vi.fn((to: { path: string }) => {

--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -698,6 +698,7 @@ describe('Router', () => {
 
     beforeEach(() => {
       scrollTo.mockClear()
+      window.history.replaceState(null, '', '/')
     })
 
     afterAll(() => {
@@ -715,15 +716,25 @@ describe('Router', () => {
 
     it('does not restore scroll positions for pop navigations with unknown direction', async () => {
       const scrollBehavior = vi.fn()
-      const history = createMemoryHistory() as ReturnType<
-        typeof createMemoryHistory
-      > & { changeURL(url: string): void }
-      const { router } = await newRouter({ history, scrollBehavior })
+      const { router } = await newRouter({
+        history: createWebHashHistory(),
+        scrollBehavior,
+      })
       scrollBehavior.mockClear()
 
-      history.changeURL('/foo')
+      // Plain `<a href="#...">` links and manual `location.hash` writes create
+      // a history entry with no state, so the popstate fires with
+      // `state: null` and the router cannot compute a direction (delta 0).
+      // happy-dom does not fire popstate on hash changes, so dispatch it like
+      // a browser would.
+      function changeHash(hash: string) {
+        window.location.hash = hash
+        window.dispatchEvent(new PopStateEvent('popstate', { state: null }))
+      }
+
+      changeHash('#/foo')
       await nextNavigation(router)
-      history.changeURL('/')
+      changeHash('#/')
       await nextNavigation(router)
 
       expect(scrollBehavior).toHaveBeenCalledTimes(2)
@@ -733,6 +744,8 @@ describe('Router', () => {
         expect.objectContaining({ path: '/' }),
         null
       )
+      // a stale position saved under the unknown-direction key would show up
+      // here as a non-null savedPosition and override the target anchor
       expect(scrollBehavior).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ path: '/' }),

--- a/packages/router/e2e/specs/scroll-behavior.spec.ts
+++ b/packages/router/e2e/specs/scroll-behavior.spec.ts
@@ -23,6 +23,43 @@ const anchorTop = (page: Page, id: string) =>
   )
 
 test.describe('scroll-behavior', () => {
+  test('does not restore saved positions for manual hash changes', async ({
+    page,
+  }) => {
+    await page.goto('/scroll-behavior/bar')
+    await expect(page.locator('.view.bar')).toBeVisible()
+
+    await page.evaluate(() => {
+      window.location.hash = '#anchor'
+    })
+    await expect
+      .poll(() => anchorTop(page, 'anchor'))
+      .toBeLessThan(1)
+
+    await page.evaluate(() => {
+      window.location.hash = '#anchor2'
+    })
+    await expect
+      .poll(() => anchorTop(page, 'anchor2'))
+      .toBeLessThan(101)
+
+    // Make a stale saved position visibly different from the anchor target.
+    await page.evaluate(() => {
+      window.scrollTo(0, 150)
+      window.location.hash = '#anchor'
+    })
+    await expect
+      .poll(() => anchorTop(page, 'anchor'))
+      .toBeLessThan(1)
+
+    await page.evaluate(() => {
+      window.location.hash = '#anchor2'
+    })
+    await expect
+      .poll(() => anchorTop(page, 'anchor2'))
+      .toBeLessThan(101)
+  })
+
   test('scroll behavior', async ({ page }) => {
     await page.goto('/scroll-behavior/')
     await expect(

--- a/packages/router/e2e/specs/scroll-behavior.spec.ts
+++ b/packages/router/e2e/specs/scroll-behavior.spec.ts
@@ -32,32 +32,24 @@ test.describe('scroll-behavior', () => {
     await page.evaluate(() => {
       window.location.hash = '#anchor'
     })
-    await expect
-      .poll(() => anchorTop(page, 'anchor'))
-      .toBeLessThan(1)
+    await expect.poll(() => anchorTop(page, 'anchor')).toBeLessThan(1)
 
     await page.evaluate(() => {
       window.location.hash = '#anchor2'
     })
-    await expect
-      .poll(() => anchorTop(page, 'anchor2'))
-      .toBeLessThan(101)
+    await expect.poll(() => anchorTop(page, 'anchor2')).toBeLessThan(101)
 
     // Make a stale saved position visibly different from the anchor target.
     await page.evaluate(() => {
       window.scrollTo(0, 150)
       window.location.hash = '#anchor'
     })
-    await expect
-      .poll(() => anchorTop(page, 'anchor'))
-      .toBeLessThan(1)
+    await expect.poll(() => anchorTop(page, 'anchor')).toBeLessThan(1)
 
     await page.evaluate(() => {
       window.location.hash = '#anchor2'
     })
-    await expect
-      .poll(() => anchorTop(page, 'anchor2'))
-      .toBeLessThan(101)
+    await expect.poll(() => anchorTop(page, 'anchor2')).toBeLessThan(101)
   })
 
   test('scroll behavior', async ({ page }) => {

--- a/packages/router/src/experimental/router.spec.ts
+++ b/packages/router/src/experimental/router.spec.ts
@@ -1002,6 +1002,7 @@ describe('Experimental Router', () => {
 
     beforeEach(() => {
       scrollTo.mockClear()
+      window.history.replaceState(null, '', '/')
     })
 
     afterAll(() => {
@@ -1019,15 +1020,25 @@ describe('Experimental Router', () => {
 
     it('does not restore scroll positions for pop navigations with unknown direction', async () => {
       const scrollBehavior = vi.fn()
-      const history = createMemoryHistory() as ReturnType<
-        typeof createMemoryHistory
-      > & { changeURL(url: string): void }
-      const { router } = await newRouter({ history, scrollBehavior })
+      const { router } = await newRouter({
+        history: createWebHashHistory(),
+        scrollBehavior,
+      })
       scrollBehavior.mockClear()
 
-      history.changeURL('/foo')
+      // Plain `<a href="#...">` links and manual `location.hash` writes create
+      // a history entry with no state, so the popstate fires with
+      // `state: null` and the router cannot compute a direction (delta 0).
+      // happy-dom does not fire popstate on hash changes, so dispatch it like
+      // a browser would.
+      function changeHash(hash: string) {
+        window.location.hash = hash
+        window.dispatchEvent(new PopStateEvent('popstate', { state: null }))
+      }
+
+      changeHash('#/foo')
       await nextNavigation(router)
-      history.changeURL('/')
+      changeHash('#/')
       await nextNavigation(router)
 
       expect(scrollBehavior).toHaveBeenCalledTimes(2)
@@ -1037,6 +1048,8 @@ describe('Experimental Router', () => {
         expect.objectContaining({ path: '/' }),
         null
       )
+      // a stale position saved under the unknown-direction key would show up
+      // here as a non-null savedPosition and override the target anchor
       expect(scrollBehavior).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ path: '/' }),

--- a/packages/router/src/experimental/router.spec.ts
+++ b/packages/router/src/experimental/router.spec.ts
@@ -1017,6 +1017,34 @@ describe('Experimental Router', () => {
       '/p/a': 2000,
     }
 
+    it('does not restore scroll positions for pop navigations with unknown direction', async () => {
+      const scrollBehavior = vi.fn()
+      const history = createMemoryHistory() as ReturnType<
+        typeof createMemoryHistory
+      > & { changeURL(url: string): void }
+      const { router } = await newRouter({ history, scrollBehavior })
+      scrollBehavior.mockClear()
+
+      history.changeURL('/foo')
+      await nextNavigation(router)
+      history.changeURL('/')
+      await nextNavigation(router)
+
+      expect(scrollBehavior).toHaveBeenCalledTimes(2)
+      expect(scrollBehavior).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ path: '/foo' }),
+        expect.objectContaining({ path: '/' }),
+        null
+      )
+      expect(scrollBehavior).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ path: '/' }),
+        expect.objectContaining({ path: '/foo' }),
+        null
+      )
+    })
+
     it('ignores the scroll of navigations superseded before they finish', async () => {
       // scrollBehavior resolves asynchronously, simulating waiting for the DOM
       const scrollBehavior = vi.fn((to: { path: string }) => {

--- a/packages/router/src/experimental/router.ts
+++ b/packages/router/src/experimental/router.ts
@@ -1107,8 +1107,9 @@ export function experimental_createRouter(
       pendingLocation = toLocation
       const from = currentRoute.value
 
+      // Unknown-direction navigations cannot be tied to a history entry.
       // TODO: should be moved to web history?
-      if (isBrowser) {
+      if (isBrowser && info.delta) {
         saveScrollPosition(getScrollKey(from.fullPath, info.delta))
       }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -814,8 +814,9 @@ export function createRouter(options: RouterOptions): Router {
       pendingLocation = toLocation
       const from = currentRoute.value
 
+      // Unknown-direction navigations cannot be tied to a history entry.
       // TODO: should be moved to web history?
-      if (isBrowser) {
+      if (isBrowser && info.delta) {
         saveScrollPosition(getScrollKey(from.fullPath, info.delta))
       }
 


### PR DESCRIPTION
## What changed

- Skip in-memory scroll-position saving when a pop navigation has `delta === 0`, because an unknown direction cannot be associated with a reliable history entry.
- Keep the stable and experimental router implementations in sync.
- Add regression unit tests for consecutive unknown-direction navigations.
- Add an E2E regression that changes `window.location.hash` between anchors and verifies a stale position cannot override the target anchor.

## Why

Plain anchor links and manual hash changes can emit pop navigations without a usable history direction. The router currently stores the current scroll position under a key derived with `delta === 0`. When the same hash is visited again, that stale entry is supplied to `scrollBehavior` as `savedPosition` and can override the requested anchor.

Before the implementation change, both new unit tests fail on the second unknown-direction navigation: `scrollBehavior` receives `{ left: 0, top: 0 }` instead of `null`.

Fixes #1431.

## How tested

- `pnpm -C packages/router run test:unit` — 71 files passed; 1646 tests passed.
- `pnpm -C packages/router run test:types` — passed.
- `pnpm -C packages/router run build` — passed.
- `pnpm -C packages/router exec vitest run __tests__/router.spec.ts src/experimental/router.spec.ts --reporter=dot` — 134 passed.
- `PORT=4173 pnpm -C packages/router exec playwright test e2e/specs/scroll-behavior.spec.ts --project=chromium` — 2 passed, including the new regression.
- Targeted `oxfmt --check` and `oxlint` — passed (oxlint reports the existing unused `Router` type warning in the experimental router).

Firefox and WebKit were not run locally because those Playwright binaries were unavailable and their download did not complete in this environment. The E2E spec is part of the repository's existing Chromium/Firefox/WebKit project matrix.

`pnpm -C packages/router run build:e2e` is also blocked on this checkout by existing unrelated `TS6307` errors for data-loader Vue fixtures; the targeted E2E dev-server run above passes.

## Risk and rollout

- Risk: unknown-direction pop navigations now receive `null` rather than a potentially stale `savedPosition`. Known back/forward navigations with non-zero deltas are unchanged.
- Rollback: restore unconditional scroll-position saving in the two history listeners.

## Notes for reviewers

- This follows the maintainer's proposed direction in #1431: treat `delta === 0` pop navigations as unable to produce a valid saved scroll position.
- Duplicate search covered open/closed/merged PRs, open/closed issues, comments, and commits using: `#1431`, the issue title, `savedPosition plain links`, `unknown navigation direction`, `delta = 0 scroll`, `invalid scroll key`, `getScrollKey`, `saveScrollPosition`, and the affected router paths.
- No competing or prior implementation was found. #1314 concerns manual-hash history-state semantics, while #1663 concerns delayed scrolling with transitions. PR #2415 only contains the shared identifiers as part of the experimental-router introduction; it does not implement this behavior. PR #2630 is an unrelated numeric search false positive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll restoration when browser navigation direction is unknown.
  * Prevented stale scroll positions after manual hash changes or popstate navigation.
  * Ensured hash navigation scrolls consistently to selected anchors.
  * Corrected absolute and relative route resolution behavior.
  * Improved reactive route resolution when navigating or when routes are added or removed.

* **Tests**
  * Added coverage for route resolution, reactivity, hash navigation, popstate events, and scroll restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->