### PR TITLE
fix(unplugin): inherit query params and normalize params in generated types

### DIFF
--- a/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
@@ -283,8 +283,8 @@ describe('generateRouteNamedMap', () => {
         '/[lang]/[id]': RouteRecordInfo<
           '/[lang]/[id]',
           '/:lang/:id',
-          { lang: ParamValue<true>, id: ParamValue<true> },
-          { lang: ParamValue<false>, id: ParamValue<false> },
+          { id: ParamValue<true>, lang: ParamValue<true> },
+          { id: ParamValue<false>, lang: ParamValue<false> },
           | never
         >,
         '/[lang]/a': RouteRecordInfo<
@@ -438,6 +438,24 @@ describe('generateRouteNamedMap', () => {
           '/child',
           Record<never, never>,
           Record<never, never>,
+          | never
+        >,
+      }"
+    `)
+  })
+
+  it('sorts params by name', () => {
+    const tree = new PrefixTree(DEFAULT_OPTIONS)
+    tree.insert('[z]/[b]/[m]', '[z]/[b]/[m].vue')
+    expect(
+      formatExports(generateRouteNamedMap(tree, DEFAULT_OPTIONS, new Map()))
+    ).toMatchInlineSnapshot(`
+      "export interface RouteNamedMap {
+        '/[z]/[b]/[m]': RouteRecordInfo<
+          '/[z]/[b]/[m]',
+          '/:z/:b/:m',
+          { b: ParamValue<true>, m: ParamValue<true>, z: ParamValue<true> },
+          { b: ParamValue<false>, m: ParamValue<false>, z: ParamValue<false> },
           | never
         >,
       }"
@@ -629,8 +647,8 @@ describe('generateRouteNamedMap', () => {
         '/[lang]/[id]': RouteRecordInfo<
           '/[lang]/[id]',
           '/:lang/:id',
-          { lang: ParamValue<true>, id: ParamValue<true> },
-          { lang: ParamValue<false>, id: ParamValue<false> },
+          { id: ParamValue<true>, lang: ParamValue<true> },
+          { id: ParamValue<false>, lang: ParamValue<false> },
           | never
         >,
         '/[lang]/a': RouteRecordInfo<
@@ -1050,8 +1068,8 @@ describe('generateRouteNamedMap', () => {
           '/search': RouteRecordInfo<
             '/search',
             '/search',
-            { q: string, page?: number, sort?: string | undefined, filter?: number | undefined },
-            { q: string, page: number, sort: string | undefined, filter: number | undefined },
+            { filter?: number | undefined, page?: number, q: string, sort?: string | undefined },
+            { filter: number | undefined, page: number, q: string, sort: string | undefined },
             | never
           >,
         }"
@@ -1076,8 +1094,41 @@ describe('generateRouteNamedMap', () => {
           '/search': RouteRecordInfo<
             '/search',
             '/search',
-            { tags?: string[] | undefined, ids: number[] },
-            { tags: string[] | undefined, ids: number[] },
+            { ids: number[], tags?: string[] | undefined },
+            { ids: number[], tags: string[] | undefined },
+            | never
+          >,
+        }"
+      `)
+    })
+
+    it('dedupes a query param declared by a parent and a child', () => {
+      const tree = new PrefixTree(OPTIONS_WITH_PARSERS)
+      const parent = tree.insert('org', 'org.vue')
+      parent.value.setEditOverride('params', { query: { q: {} } })
+      const child = tree.insert('org/list', 'org/list.vue')
+      child.value.setEditOverride('params', { query: { q: { parser: 'int' } } })
+
+      // `q` is declared twice, it must appear once in the type and the child
+      // declaration wins
+      expect(
+        formatExports(
+          generateRouteNamedMap(tree, OPTIONS_WITH_PARSERS, new Map())
+        )
+      ).toMatchInlineSnapshot(`
+        "export interface RouteNamedMap {
+          '/org': RouteRecordInfo<
+            '/org',
+            '/org',
+            { q?: string | undefined },
+            { q: string | undefined },
+            | '/org/list'
+          >,
+          '/org/list': RouteRecordInfo<
+            '/org/list',
+            '/org/list',
+            { q?: number | undefined },
+            { q: number | undefined },
             | never
           >,
         }"

--- a/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { generateRouteNamedMap } from './generateRouteMap'
 import { PrefixTree } from '../core/tree'
 import { resolveOptions } from '../options'
+import { mockWarn } from '../../tests/vitest-mock-warn'
 
 const DEFAULT_OPTIONS = resolveOptions({})
 
@@ -1129,6 +1130,56 @@ describe('generateRouteNamedMap', () => {
             '/org/list',
             { q?: number | undefined },
             { q: number | undefined },
+            | never
+          >,
+        }"
+      `)
+    })
+  })
+
+  describe('unnamed params', () => {
+    mockWarn()
+    const OPTIONS_WITH_PARSERS = resolveOptions({
+      experimental: { paramParsers: true },
+    })
+
+    it('skips unnamed params with param parsers enabled', () => {
+      const tree = new PrefixTree(OPTIONS_WITH_PARSERS)
+      // `[[]]+` produces a param without a name
+      tree.insert('[[]]+', '[[]]+.vue')
+      const routeMap = formatExports(
+        generateRouteNamedMap(tree, OPTIONS_WITH_PARSERS, new Map())
+      )
+      expect('VUE_ROUTER_B0017').toHaveBeenWarnedTimes(1)
+
+      expect(routeMap).toMatchInlineSnapshot(`
+        "export interface RouteNamedMap {
+          '/[[]]+': RouteRecordInfo<
+            '/[[]]+',
+            '/:*',
+            Record<never, never>,
+            Record<never, never>,
+            | never
+          >,
+        }"
+      `)
+    })
+
+    it('skips unnamed params without param parsers', () => {
+      const tree = new PrefixTree(DEFAULT_OPTIONS)
+      tree.insert('[[]]+', '[[]]+.vue')
+      const routeMap = formatExports(
+        generateRouteNamedMap(tree, DEFAULT_OPTIONS, new Map())
+      )
+      expect('VUE_ROUTER_B0017').toHaveBeenWarned()
+
+      expect(routeMap).toMatchInlineSnapshot(`
+        "export interface RouteNamedMap {
+          '/[[]]+': RouteRecordInfo<
+            '/[[]]+',
+            '/:*',
+            Record<never, never>,
+            Record<never, never>,
             | never
           >,
         }"

--- a/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.spec.ts
@@ -1171,7 +1171,7 @@ describe('generateRouteNamedMap', () => {
       const routeMap = formatExports(
         generateRouteNamedMap(tree, DEFAULT_OPTIONS, new Map())
       )
-      expect('VUE_ROUTER_B0017').toHaveBeenWarned()
+      expect('VUE_ROUTER_B0017').toHaveBeenWarnedTimes(1)
 
       expect(routeMap).toMatchInlineSnapshot(`
         "export interface RouteNamedMap {

--- a/packages/router/src/unplugin/codegen/generateRouteMap.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.ts
@@ -5,6 +5,7 @@ import { generateParamsTypes } from './generateParamParsers'
 import {
   EXPERIMENTAL_generateRouteParams,
   generateRouteParams,
+  normalizeParamsForTypes,
 } from './generateRouteParams'
 import { pad, formatMultilineUnion, toStringLiteral } from '../utils'
 
@@ -45,8 +46,9 @@ export function generateRouteRecordInfo(
   paramParsersMap: ParamParsersMap
 ): string {
   let paramParsers: Array<string | null> = []
+  const params = normalizeParamsForTypes(node.params)
   if (options.experimental.paramParsers) {
-    paramParsers = generateParamsTypes(node.params, paramParsersMap)
+    paramParsers = generateParamsTypes(params, paramParsersMap)
   }
 
   const typeParams = [
@@ -54,7 +56,7 @@ export function generateRouteRecordInfo(
     toStringLiteral(node.fullPath),
     options.experimental.paramParsers
       ? EXPERIMENTAL_generateRouteParams(
-          node,
+          params,
           paramParsers,
           true,
           paramParsersMap
@@ -62,7 +64,7 @@ export function generateRouteRecordInfo(
       : generateRouteParams(node, true),
     options.experimental.paramParsers
       ? EXPERIMENTAL_generateRouteParams(
-          node,
+          params,
           paramParsers,
           false,
           paramParsersMap

--- a/packages/router/src/unplugin/codegen/generateRouteMap.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.ts
@@ -45,11 +45,14 @@ export function generateRouteRecordInfo(
   options: ResolvedOptions,
   paramParsersMap: ParamParsersMap
 ): string {
-  let paramParsers: Array<string | null> = []
-  const params = normalizeParamsForTypes(node.params)
-  if (options.experimental.paramParsers) {
-    paramParsers = generateParamsTypes(params, paramParsersMap)
-  }
+  // only the experimental version handles query params and param parsers, the
+  // other one extracts the params from the node itself
+  const params = options.experimental.paramParsers
+    ? normalizeParamsForTypes(node, node.params)
+    : []
+  const paramParsers: Array<string | null> = options.experimental.paramParsers
+    ? generateParamsTypes(params, paramParsersMap)
+    : []
 
   const typeParams = [
     toStringLiteral(node.name),

--- a/packages/router/src/unplugin/codegen/generateRouteMap.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.ts
@@ -40,6 +40,9 @@ ${node
   )
 }
 
+// TODO: split into two functions, one for the experimental version and one for the non-experimental version, to avoid the if/else branching
+// and put the if/else branching in the caller function
+
 export function generateRouteRecordInfo(
   node: TreeNodeNamed,
   options: ResolvedOptions,

--- a/packages/router/src/unplugin/codegen/generateRouteMap.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteMap.ts
@@ -46,10 +46,14 @@ export function generateRouteRecordInfo(
   paramParsersMap: ParamParsersMap
 ): string {
   // only the experimental version handles query params and param parsers, the
-  // other one extracts the params from the node itself
+  // other one only handles path params. Both normalize once so unnamed params
+  // are reported once per route instead of once per generated type
   const params = options.experimental.paramParsers
     ? normalizeParamsForTypes(node, node.params)
     : []
+  const pathParams = options.experimental.paramParsers
+    ? []
+    : normalizeParamsForTypes(node, node.pathParams)
   const paramParsers: Array<string | null> = options.experimental.paramParsers
     ? generateParamsTypes(params, paramParsersMap)
     : []
@@ -64,7 +68,7 @@ export function generateRouteRecordInfo(
           true,
           paramParsersMap
         )
-      : generateRouteParams(node, true),
+      : generateRouteParams(pathParams, true),
     options.experimental.paramParsers
       ? EXPERIMENTAL_generateRouteParams(
           params,
@@ -72,7 +76,7 @@ export function generateRouteRecordInfo(
           false,
           paramParsersMap
         )
-      : generateRouteParams(node, false),
+      : generateRouteParams(pathParams, false),
   ]
 
   const childRouteNames: string[] =

--- a/packages/router/src/unplugin/codegen/generateRouteParams.spec.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteParams.spec.ts
@@ -32,7 +32,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('required path param excludes null', () => {
       const node = createTreeWithParam('[version=semver]')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_semver'],
         false
       )
@@ -44,7 +44,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('optional path param includes null', () => {
       const node = createTreeWithParam('[[version=semver]]')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_semver'],
         false
       )
@@ -56,7 +56,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('repeatable path param uses Extract', () => {
       const node = createTreeWithParam('[version=semver]+')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_semver'],
         false
       )
@@ -66,7 +66,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('optional repeatable path param uses Extract', () => {
       const node = createTreeWithParam('[[version=semver]]+')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_semver'],
         false
       )
@@ -77,21 +77,33 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
   describe('non-parser types', () => {
     it('required path param is string', () => {
       const node = createTreeWithParam('[id]')
-      const result = EXPERIMENTAL_generateRouteParams(node, [null], false)
+      const result = EXPERIMENTAL_generateRouteParams(
+        node.params,
+        [null],
+        false
+      )
       expect(result).toBe('{ id: string }')
     })
 
     it('optional path param includes null', () => {
       const node = createTreeWithParam('[[id]]')
-      const result = EXPERIMENTAL_generateRouteParams(node, [null], false)
+      const result = EXPERIMENTAL_generateRouteParams(
+        node.params,
+        [null],
+        false
+      )
       expect(result).toBe('{ id: string | null }')
     })
 
     it("native 'string' type matches no-parser output for required path", () => {
       const node = createTreeWithParam('[id]')
-      const nullResult = EXPERIMENTAL_generateRouteParams(node, [null], false)
+      const nullResult = EXPERIMENTAL_generateRouteParams(
+        node.params,
+        [null],
+        false
+      )
       const stringResult = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['string'],
         false
       )
@@ -100,9 +112,13 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
 
     it("native 'string' type matches no-parser output for optional path", () => {
       const node = createTreeWithParam('[[id]]')
-      const nullResult = EXPERIMENTAL_generateRouteParams(node, [null], false)
+      const nullResult = EXPERIMENTAL_generateRouteParams(
+        node.params,
+        [null],
+        false
+      )
       const stringResult = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['string'],
         false
       )
@@ -114,7 +130,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('emits Param_X /* raw param parser */ for raw path params', () => {
       const node = createTreeWithParam('[id=raw]')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_raw'],
         false,
         makeParsersMap('raw', true)
@@ -125,7 +141,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('does not append | null for optional raw path params', () => {
       const node = createTreeWithParam('[[id=raw]]')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_raw'],
         false,
         makeParsersMap('raw', true)
@@ -136,7 +152,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('skips Extract for repeatable raw path params', () => {
       const node = createTreeWithParam('[id=raw]+')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_raw'],
         false,
         makeParsersMap('raw', true)
@@ -147,7 +163,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('skips Extract for optional repeatable raw path params', () => {
       const node = createTreeWithParam('[[id=raw]]+')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_raw'],
         false,
         makeParsersMap('raw', true)
@@ -158,7 +174,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('falls back to Exclude/Extract when paramParsersMap is omitted', () => {
       const node = createTreeWithParam('[id=raw]')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_raw'],
         false
       )
@@ -168,7 +184,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('still uses Exclude for non-raw entries in the map', () => {
       const node = createTreeWithParam('[id=plain]')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_plain'],
         false,
         makeParsersMap('plain', false)
@@ -199,7 +215,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
       // route.params side (isRaw=false): runtime always calls the raw parser
       // with the array form, so the value never ends up undefined.
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_set'],
         false,
         makeParsersMap('set', true)
@@ -212,7 +228,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
       // router.push side (isRaw=true): allow users to pass `undefined`
       // explicitly even under exactOptionalPropertyTypes.
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_set'],
         true,
         makeParsersMap('set', true)
@@ -225,7 +241,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('keeps | undefined on route.params for non-raw query parsers', () => {
       const node = createNodeWithQueryParam('test', 'plain')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_plain'],
         false,
         makeParsersMap('plain', false)
@@ -238,7 +254,7 @@ describe('EXPERIMENTAL_generateRouteParams', () => {
     it('adds | undefined on router.push for non-raw query parsers', () => {
       const node = createNodeWithQueryParam('test', 'plain')
       const result = EXPERIMENTAL_generateRouteParams(
-        node,
+        node.params,
         ['Param_plain'],
         true,
         makeParsersMap('plain', false)

--- a/packages/router/src/unplugin/codegen/generateRouteParams.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteParams.ts
@@ -40,10 +40,14 @@ export function normalizeParamsForTypes<
 }
 
 // TODO: simplify the generateRouteParams to not use the type helpers ParamValueOneOrMore, ParamValueZeroOrMore, ParamValueZeroOrOne, and ParamValue, just output raw unions like string | string[]
-export function generateRouteParams(node: TreeNode, isRaw: boolean): string {
-  // node.pathParams is a getter so we compute it once
-  // this version does not support query params
-  const nodeParams = normalizeParamsForTypes(node, node.pathParams)
+/**
+ * @param nodeParams - path params already normalized with `normalizeParamsForTypes()`. This version does not support query params.
+ * @param isRaw - whether to generate the type accepted when pushing
+ */
+export function generateRouteParams(
+  nodeParams: TreePathParam[],
+  isRaw: boolean
+): string {
   return nodeParams.length > 0
     ? `{ ${nodeParams
         .map(

--- a/packages/router/src/unplugin/codegen/generateRouteParams.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteParams.ts
@@ -3,27 +3,51 @@ import {
   isTreeParamOptional,
   isTreeParamRepeatable,
   isTreePathParam,
+  type TreePathParam,
+  type TreeQueryParam,
 } from '../core/treeNodeValue'
 import type { ParamParsersMap } from './generateParamParsers'
 import { diagnostics } from '../diagnostics'
+
+/**
+ * Prepares params to be rendered as a type: a param can be declared more than
+ * once across the chain of records, and duplicated keys are invalid in a type
+ * literal. The deepest declaration wins like at runtime, then params are sorted
+ * by name to keep the generated types stable.
+ *
+ * @internal
+ */
+export function normalizeParamsForTypes<
+  T extends TreePathParam | TreeQueryParam,
+>(params: T[]): T[] {
+  const byName = new Map<string, T>()
+  for (const param of params) {
+    byName.set(param.paramName, param)
+  }
+
+  return Array.from(byName.values()).sort((a, b) =>
+    a.paramName < b.paramName ? -1 : a.paramName > b.paramName ? 1 : 0
+  )
+}
 
 // TODO: simplify the generateRouteParams to not use the type helpers ParamValueOneOrMore, ParamValueZeroOrMore, ParamValueZeroOrOne, and ParamValue, just output raw unions like string | string[]
 export function generateRouteParams(node: TreeNode, isRaw: boolean): string {
   // node.pathParams is a getter so we compute it once
   // this version does not support query params
-  const nodeParams = node.pathParams
+  const nodeParams = normalizeParamsForTypes(
+    node.pathParams.filter(param => {
+      if (!param.paramName) {
+        diagnostics.VUE_ROUTER_B0017({
+          fullPath: node.fullPath,
+          path: node.path,
+        })
+        return false
+      }
+      return true
+    })
+  )
   return nodeParams.length > 0
     ? `{ ${nodeParams
-        .filter(param => {
-          if (!param.paramName) {
-            diagnostics.VUE_ROUTER_B0017({
-              fullPath: node.fullPath,
-              path: node.path,
-            })
-            return false
-          }
-          return true
-        })
         .map(
           param =>
             `${param.paramName}${param.optional ? '?' : ''}: ` +
@@ -47,20 +71,18 @@ export function generateRouteParams(node: TreeNode, isRaw: boolean): string {
  *
  * @internal
  *
- * @param node - The tree node for which to generate the route params type.
+ * @param nodeParams - The params to generate the type for. Must be the same array passed to `generateParamsTypes()` since `types` is aligned with it by index.
  * @param types - An array of types corresponding to the params in the node. The order should match the order of params in the node.
  * @param isLoose - Whether to generate the type that is accepted when pushing (more persmissive)
  * @param paramParsersMap - An optional map of param parsers, used to determine if a param is defined with a raw parser.
  * @returns A string representing the TypeScript type for the route params of the given node.
  */
 export function EXPERIMENTAL_generateRouteParams(
-  node: TreeNode,
+  nodeParams: (TreePathParam | TreeQueryParam)[],
   types: Array<string | null>,
   isLoose: boolean,
   paramParsersMap?: ParamParsersMap
 ) {
-  // node.params is a getter so we compute it once
-  const nodeParams = node.params
   return nodeParams.length > 0
     ? `{ ${nodeParams
         .map((param, i) => {

--- a/packages/router/src/unplugin/codegen/generateRouteParams.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteParams.ts
@@ -10,18 +10,27 @@ import type { ParamParsersMap } from './generateParamParsers'
 import { diagnostics } from '../diagnostics'
 
 /**
- * Prepares params to be rendered as a type: a param can be declared more than
- * once across the chain of records, and duplicated keys are invalid in a type
- * literal. The deepest declaration wins like at runtime, then params are sorted
- * by name to keep the generated types stable.
+ * Prepares params to be rendered as a type: params without a name are dropped
+ * and reported as they would generate invalid types. A param can also be
+ * declared more than once across the chain of records, and duplicated keys are
+ * invalid in a type literal, so the deepest declaration wins like at runtime.
+ * Params are then sorted by name to keep the generated types stable.
  *
  * @internal
  */
 export function normalizeParamsForTypes<
   T extends TreePathParam | TreeQueryParam,
->(params: T[]): T[] {
+>(node: TreeNode, params: T[]): T[] {
   const byName = new Map<string, T>()
   for (const param of params) {
+    // invalid segments like `[[]]+` produce params without a name
+    if (!param.paramName) {
+      diagnostics.VUE_ROUTER_B0017({
+        fullPath: node.fullPath,
+        path: node.path,
+      })
+      continue
+    }
     byName.set(param.paramName, param)
   }
 
@@ -34,18 +43,7 @@ export function normalizeParamsForTypes<
 export function generateRouteParams(node: TreeNode, isRaw: boolean): string {
   // node.pathParams is a getter so we compute it once
   // this version does not support query params
-  const nodeParams = normalizeParamsForTypes(
-    node.pathParams.filter(param => {
-      if (!param.paramName) {
-        diagnostics.VUE_ROUTER_B0017({
-          fullPath: node.fullPath,
-          path: node.path,
-        })
-        return false
-      }
-      return true
-    })
-  )
+  const nodeParams = normalizeParamsForTypes(node, node.pathParams)
   return nodeParams.length > 0
     ? `{ ${nodeParams
         .map(

--- a/packages/router/src/unplugin/codegen/generateRouteParams.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteParams.ts
@@ -21,9 +21,10 @@ import { diagnostics } from '../diagnostics'
 export function normalizeParamsForTypes<
   T extends TreePathParam | TreeQueryParam,
 >(node: TreeNode, params: T[]): T[] {
+  // deduplicate by name, keeps the deepest declaration
   const byName = new Map<string, T>()
   for (const param of params) {
-    // invalid segments like `[[]]+` produce params without a name
+    // warn and skip invalid params without a name
     if (!param.paramName) {
       diagnostics.VUE_ROUTER_B0017({
         fullPath: node.fullPath,
@@ -34,6 +35,7 @@ export function normalizeParamsForTypes<
     byName.set(param.paramName, param)
   }
 
+  // to have cleaner git diffs, sort by paramName
   return Array.from(byName.values()).sort((a, b) =>
     a.paramName < b.paramName ? -1 : a.paramName > b.paramName ? 1 : 0
   )

--- a/packages/router/src/unplugin/codegen/generateRouteResolver.ts
+++ b/packages/router/src/unplugin/codegen/generateRouteResolver.ts
@@ -376,7 +376,9 @@ export function generateRouteRecordQuery({
   importsMap: ImportsMap
   paramParsersMap: ParamParsersMap
 }) {
-  const queryParams = node.queryParams
+  // each record only declares its own query params: the resolver matches the
+  // whole chain of records and merges them
+  const queryParams = node.value.queryParams
   if (queryParams.length === 0) {
     return ''
   }

--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -1177,6 +1177,33 @@ describe('Tree', () => {
       expect(node.queryParams).toEqual([])
     })
 
+    it('node.queryParams includes the query params from the parents', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const parent = tree.insert('org', 'org.vue')
+      parent.setCustomRouteBlock('org.vue', {
+        params: { query: { q: {} } },
+      })
+      const child = tree.insert('org/[orgId]', 'org/[orgId].vue')
+      child.setCustomRouteBlock('org/[orgId].vue', {
+        params: { query: { tab: {} } },
+      })
+
+      // the query is matched for the whole chain of records
+      expect(child.queryParams.map(param => param.paramName)).toEqual([
+        'q',
+        'tab',
+      ])
+      // while `node.value` stays specific to the node
+      expect(child.value.queryParams.map(param => param.paramName)).toEqual([
+        'tab',
+      ])
+      expect(child.params.map(param => param.paramName)).toEqual([
+        'orgId',
+        'q',
+        'tab',
+      ])
+    })
+
     it('params includes both path and query params', () => {
       const tree = new PrefixTree(RESOLVED_OPTIONS)
       const node = tree.insert('posts/[id]', 'posts/[id].vue')

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -373,7 +373,9 @@ export class TreeNode {
   }
 
   /**
-   * Array of route params coming from the path. It includes all the params from the parents as well.
+   * Array of route params coming from the path. It includes all the params
+   * from the parents as well. Use `node.value.pathParams` for the ones
+   * declared by this specific node.
    */
   get pathParams(): TreePathParam[] {
     const params = this.value.isParam() ? [...this.value.pathParams] : []
@@ -391,8 +393,7 @@ export class TreeNode {
 
   /**
    * Array of query params extracted from definePage. It includes all the query
-   * params from the parents as well: unlike the path, the query is matched for
-   * the whole chain of records. Use `node.value.queryParams` for the ones
+   * params from the parents as well. Use `node.value.queryParams` for the ones
    * declared by this specific node.
    */
   get queryParams(): TreeQueryParam[] {

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -369,15 +369,7 @@ export class TreeNode {
    * Array of route params for this node. It includes **all** the params from the parents as well.
    */
   get params(): (TreePathParam | TreeQueryParam)[] {
-    const params = [...this.value.params]
-    let node = this.parent
-    // add all the params from the parents
-    while (node) {
-      params.unshift(...node.value.params)
-      node = node.parent
-    }
-
-    return params
+    return [...this.pathParams, ...this.queryParams]
   }
 
   /**
@@ -398,10 +390,22 @@ export class TreeNode {
   }
 
   /**
-   * Array of query params extracted from definePage. Only returns query params from this specific node.
+   * Array of query params extracted from definePage. It includes all the query
+   * params from the parents as well: unlike the path, the query is matched for
+   * the whole chain of records. Use `node.value.queryParams` for the ones
+   * declared by this specific node.
    */
   get queryParams(): TreeQueryParam[] {
-    return this.value.queryParams
+    const params = [...this.value.queryParams]
+
+    let node = this.parent
+    // add all the query params from the parents
+    while (node) {
+      params.unshift(...node.value.queryParams)
+      node = node.parent
+    }
+
+    return params
   }
 
   /**


### PR DESCRIPTION
Two independent fixes found while reviewing #2646. Neither depends on it, both reproduce on `main`.

## 1. `node.queryParams` did not inherit

The convention is `node.value.*` for what a node declares and `node.*` for what it also inherits. `queryParams` was the exception and returned only the node's own, so a child never saw the query params declared by its parents.

That does not match the runtime: unlike the path, the query is matched for the whole chain of records. `validateMatch()` merges the query matchers of every record returned by `buildMatched()`, so the child does receive them.

- `params` is now `[...pathParams, ...queryParams]`
- `generateRouteRecordQuery()` reads `node.value.queryParams`, so each record keeps declaring only its own query patterns (already covered by `does not includes query params from parent nodes`)

## 2. Duplicated and unstable keys in the generated types

A param can be declared more than once across the chain of records. A parent and a child both declaring the query param `q` emitted a duplicated key, which does not compile:

```ts
// before
'/org/list': RouteRecordInfo<
  '/org/list',
  '/org/list',
  { q?: string | undefined, q?: number | undefined },
  { q: string | undefined, q: number | undefined },
  | never
>,

// after, the child declaration wins
'/org/list': RouteRecordInfo<
  '/org/list',
  '/org/list',
  { q?: number | undefined },
  { q: number | undefined },
  | never
>,
```

`normalizeParamsForTypes()` keeps the deepest declaration, matching runtime where the child matcher is applied last, and sorts params by name so the output no longer depends on path order:

```ts
// '[z]/[b]/[m]'
- { z: ParamValue<true>, b: ParamValue<true>, m: ParamValue<true> }
+ { b: ParamValue<true>, m: ParamValue<true>, z: ParamValue<true> }
```

`EXPERIMENTAL_generateRouteParams()` now takes the params array rather than the node, so it and `generateParamsTypes()` share the exact same array they are index-aligned on.

Normalization is applied only to the generated types. `node.pathParams` is consumed positionally against the matcher regexp capture groups, so it keeps its path order.

## Notes

- Key order in a type literal carries no meaning, so `typed-router.d.ts` will show reordered keys after this without any type changing. Worth a changelog line.
- Tests were written first and confirmed failing: `node.queryParams includes the query params from the parents`, `sorts params by name`, `dedupes a query param declared by a parent and a child`.
- Two commits, one per fix, so this can be split if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated route types now sort parameter names consistently.
  * Nested routes correctly include inherited query parameters.
  * Duplicate query parameters are resolved using child declarations.
  * Array-format query parameters are supported.
  * Unnamed parameters are excluded from generated route definitions, with an appropriate warning.
  * Improved consistency in route metadata and parameter handling.

* **Tests**
  * Added coverage for sorting, query arrays, inheritance, deduplication, and unnamed parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->