### PR TITLE
build: include nostics in esm

### DIFF
--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -86,6 +86,11 @@ const esmBrowser = {
     __DEV__: 'true',
     __FEATURE_PROD_DEVTOOLS__: 'true',
   },
+  deps: {
+    // left out in prod but not in regular build
+    alwaysBundle: ['nostics'],
+    neverBundle: ['vue', '@vue/devtools-api'],
+  },
 } satisfies InlineConfig
 
 const esmBrowserProd = {
@@ -101,6 +106,11 @@ const esmBrowserProd = {
     ...esmBrowser.define,
     __DEV__: 'false',
     __FEATURE_PROD_DEVTOOLS__: 'false',
+  },
+  deps: {
+    // left out in prod but not in regular build
+    alwaysBundle: ['nostics'],
+    neverBundle: ['vue', '@vue/devtools-api'],
   },
 } satisfies InlineConfig
 


### PR DESCRIPTION
refer to https://github.com/vuejs/router/commit/94dca111469aeea086c4d7b7767d2186c05916d4

Opening the playground link directly in the readme will result in the following error.
`Failed to resolve module specifier "nostics".Tip: edit the "Import Map" tab to specify import paths for dependencies.`