### PR TITLE
docs: access RouterLink spread props via props

### DIFF
--- a/packages/docs/guide/advanced/extending-router-link.md
+++ b/packages/docs/guide/advanced/extending-router-link.md
@@ -32,7 +32,7 @@ const isExternalLink = computed(() => {
 </script>
 
 <template>
-  <a v-if="isExternalLink" v-bind="$attrs" :href="to" target="_blank">
+  <a v-if="isExternalLink" v-bind="$attrs" :href="props.to" target="_blank">
     <slot />
   </a>
   <router-link
@@ -45,13 +45,18 @@ const isExternalLink = computed(() => {
       v-bind="$attrs"
       :href="href"
       @click="navigate"
-      :class="isActive ? activeClass : inactiveClass"
+      :class="isActive ? props.activeClass : props.inactiveClass"
     >
       <slot />
     </a>
   </router-link>
 </template>
 ```
+
+When using `<script setup>` with TypeScript, access props spread from
+`RouterLink.props` through the `props` object in the template, as shown above.
+This avoids relying on the compiler exposing those spread props as individual
+template bindings.
 
 ```vue [Options API]
 <script>

--- a/packages/docs/zh/guide/advanced/extending-router-link.md
+++ b/packages/docs/zh/guide/advanced/extending-router-link.md
@@ -32,7 +32,7 @@ const isExternalLink = computed(() => {
 </script>
 
 <template>
-  <a v-if="isExternalLink" v-bind="$attrs" :href="to" target="_blank">
+  <a v-if="isExternalLink" v-bind="$attrs" :href="props.to" target="_blank">
     <slot />
   </a>
   <router-link
@@ -45,13 +45,17 @@ const isExternalLink = computed(() => {
       v-bind="$attrs"
       :href="href"
       @click="navigate"
-      :class="isActive ? activeClass : inactiveClass"
+      :class="isActive ? props.activeClass : props.inactiveClass"
     >
       <slot />
     </a>
   </router-link>
 </template>
 ```
+
+当你在 TypeScript 中使用 `<script setup>` 时，请像上面的示例一样，通过
+`props` 对象访问从 `RouterLink.props` 展开的 prop。这样可以避免依赖编译器
+将这些展开的 prop 暴露为独立的模板绑定。
 
 ```vue [Options API]
 <script>


### PR DESCRIPTION
## Summary

- update the `<script setup>` RouterLink extension example to use `props.to`, `props.activeClass`, and `props.inactiveClass` in the template
- document why TypeScript users should access spread `RouterLink.props` through the `props` object
- mirror the example and note in the Chinese docs page

Fixes #1429.

## Validation

- `pnpm install --frozen-lockfile --store-dir D:\grand-final prr\.cache\pnpm-store-vue-router`
- `pnpm exec oxfmt --check packages/docs/guide/advanced/extending-router-link.md packages/docs/zh/guide/advanced/extending-router-link.md`
- `pnpm --filter ./packages/docs run docs:translation:compare zh`
- `git diff --check`

## Notes

`pnpm run docs:build` was also attempted. It failed on existing unrelated Twoslash/module-resolution errors in `packages/docs/data-loaders/*` pages (`Cannot find module 'vue-router/experimental'`), after the edited RouterLink docs were processed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English and Chinese router-link extension examples to use the correct `props` access pattern in Composition API templates.
  * Clarified TypeScript template-binding behavior when working with spread router-link properties.
  * Improved examples for external-link targets and active/inactive class bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->