### PR TITLE
docs: explain encoded path navigation

### DIFF
--- a/packages/docs/guide/essentials/navigation.md
+++ b/packages/docs/guide/essentials/navigation.md
@@ -56,7 +56,7 @@ router.push({ name: 'user', params: { username } }) // -> /user/eduardo%2Fsan%20
 router.push({ path: '/user', params: { username } }) // -> /user
 ```
 
-When building a string path or an object with `path`, provide an encoded path. Use [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) for each dynamic segment. The same rule applies to `<RouterLink>`:
+When building a string path or an object with `path`, provide an encoded path. Use [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) for each dynamic segment (each section between `/`). Note that `encodeURIComponent` encodes the `/` character. The same rule applies to `<RouterLink>`:
 
 ```vue
 <RouterLink :to="`/user/${encodeURIComponent(username)}`">User</RouterLink>

--- a/packages/docs/guide/essentials/navigation.md
+++ b/packages/docs/guide/essentials/navigation.md
@@ -45,15 +45,26 @@ router.push({ path: '/about', hash: '#team' })
 **Note**: `params` are ignored if a `path` is provided, which is not the case for `query`, as shown in the example above. Instead, you need to provide the `name` of the route or manually specify the whole `path` with any parameter:
 
 ```js
-const username = 'eduardo'
+const username = 'eduardo/san martin'
 // we can manually build the url but we will have to handle the encoding ourselves
-router.push(`/user/${username}`) // -> /user/eduardo
+router.push(`/user/${encodeURIComponent(username)}`) // -> /user/eduardo%2Fsan%20martin
 // same as
-router.push({ path: `/user/${username}` }) // -> /user/eduardo
+router.push({ path: `/user/${encodeURIComponent(username)}` }) // -> /user/eduardo%2Fsan%20martin
 // if possible use `name` and `params` to benefit from automatic URL encoding
-router.push({ name: 'user', params: { username } }) // -> /user/eduardo
+router.push({ name: 'user', params: { username } }) // -> /user/eduardo%2Fsan%20martin
 // `params` cannot be used alongside `path`
 router.push({ path: '/user', params: { username } }) // -> /user
+```
+
+When building a string path or an object with `path`, provide an encoded path. Use [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) for each dynamic segment. The same rule applies to `<RouterLink>`:
+
+```vue
+<RouterLink :to="`/user/${encodeURIComponent(username)}`">User</RouterLink>
+<RouterLink
+  :to="{ path: `/user/${encodeURIComponent(username)}` }"
+>User</RouterLink>
+<!-- Prefer this form when a matching named route exists -->
+<RouterLink :to="{ name: 'user', params: { username } }">User</RouterLink>
 ```
 
 When specifying `params`, make sure to either provide a `string` or `number` (or an array of these for [repeatable params](./route-matching-syntax.md#Repeatable-params)). **Any other type (like objects, booleans, etc) will be automatically stringified**. For [optional params](./route-matching-syntax.md#Optional-parameters), you can provide an empty string (`""`) or `null` as the value to remove it.

--- a/packages/docs/guide/migration/index.md
+++ b/packages/docs/guide/migration/index.md
@@ -443,6 +443,22 @@ Given any [normalized route location](/api/#RouteLocationNormalized):
 - When using `push`, `resolve`, and `replace` and providing a `string` location or a `path` property in an object, **it must be encoded** (like in the previous version). On the other hand, `params`, `query` and `hash` must be provided in its unencoded version.
 - The slash character (`/`) is now properly decoded inside `params` while still producing an encoded version on the URL: `%2F`.
 
+The same applies to static route record paths that contain characters requiring escaping:
+
+```js
+const routes = [{ path: '/hello%20world', component: HelloWorld }]
+```
+
+When manually building a string or object `path`, encode dynamic segments yourself. Prefer named routes with `params` when possible:
+
+```js
+const username = 'eduardo/san martin'
+
+router.push(`/user/${encodeURIComponent(username)}`)
+router.push({ path: `/user/${encodeURIComponent(username)}` })
+router.push({ name: 'user', params: { username } })
+```
+
 **Reason**: This allows to easily copy existing properties of a location when calling `router.push()` and `router.resolve()`, and make the resulting route location consistent across browsers. `router.push()` is now idempotent, meaning that calling `router.push(route.fullPath)`, `router.push({ hash: route.hash })`, `router.push({ query: route.query })`, and `router.push({ params: route.params })` will not create extra encoding.
 
 ### `$router.push()` and `$router.replace()` - `onComplete` and `onAbort` callbacks

--- a/packages/docs/zh/guide/essentials/navigation.md
+++ b/packages/docs/zh/guide/essentials/navigation.md
@@ -45,15 +45,26 @@ router.push({ path: '/about', hash: '#team' })
 **注意**：如果提供了 `path`，`params` 会被忽略，上述例子中的 `query` 并不属于这种情况。取而代之的是下面例子的做法，你需要提供路由的 `name` 或手写完整的带有参数的 `path` ：
 
 ```js
-const username = 'eduardo'
+const username = 'eduardo/san martin'
 // 我们可以手动建立 url，但我们必须自己处理编码
-router.push(`/user/${username}`) // -> /user/eduardo
+router.push(`/user/${encodeURIComponent(username)}`) // -> /user/eduardo%2Fsan%20martin
 // 同样
-router.push({ path: `/user/${username}` }) // -> /user/eduardo
+router.push({ path: `/user/${encodeURIComponent(username)}` }) // -> /user/eduardo%2Fsan%20martin
 // 如果可能的话，使用 `name` 和 `params` 从自动 URL 编码中获益
-router.push({ name: 'user', params: { username } }) // -> /user/eduardo
+router.push({ name: 'user', params: { username } }) // -> /user/eduardo%2Fsan%20martin
 // `params` 不能与 `path` 一起使用
 router.push({ path: '/user', params: { username } }) // -> /user
+```
+
+构建字符串路径或带有 `path` 的对象时，请提供已编码的路径。使用 [`encodeURIComponent`](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) 编码每个动态片段。同样的规则也适用于 `<RouterLink>`：
+
+```vue
+<RouterLink :to="`/user/${encodeURIComponent(username)}`">User</RouterLink>
+<RouterLink
+  :to="{ path: `/user/${encodeURIComponent(username)}` }"
+>User</RouterLink>
+<!-- 如果存在匹配的命名路由，优先使用这种形式 -->
+<RouterLink :to="{ name: 'user', params: { username } }">User</RouterLink>
 ```
 
 当指定 `params` 时，可提供 `string` 或 `number` 参数（或者对于[可重复的参数](./route-matching-syntax.md#repeatable-params)可提供一个数组）。**任何其他类型（如对象、布尔等）都将被自动字符串化**。对于[可选参数](./route-matching-syntax.md#repeatable-params)，你可以提供一个空字符串（`""`）或 `null` 来移除它。

--- a/packages/docs/zh/guide/migration/index.md
+++ b/packages/docs/zh/guide/migration/index.md
@@ -446,6 +446,22 @@ const routes = [
 - 当使用 `push`、`resolve` 和 `replace` 并在对象中提供 `string` 地址或 `path` 属性时，**必须进行编码**(像以前的版本一样)。另一方面，`params`、`query` 和 `hash` 必须以未编码的版本提供。
 - 斜线字符(`/`)现在已在 `params` 内正确解码，同时仍在 URL 上产生一个编码版本：`%2F`。
 
+包含需要转义字符的静态路由记录路径也遵循同样的规则：
+
+```js
+const routes = [{ path: '/hello%20world', component: HelloWorld }]
+```
+
+手动构建字符串或对象 `path` 时，请自行编码动态片段。可能的话，优先使用带有 `params` 的命名路由：
+
+```js
+const username = 'eduardo/san martin'
+
+router.push(`/user/${encodeURIComponent(username)}`)
+router.push({ path: `/user/${encodeURIComponent(username)}` })
+router.push({ name: 'user', params: { username } })
+```
+
 **原因**：这样，在调用 `router.push()` 和 `router.resolve()` 时，可以很容易地复制一个地址的现有属性，并使产生的路由地址在各浏览器之间保持一致。`router.push()` 现在是幂等的，这意味着调用 `router.push(route.fullPath)`、`router.push({ hash: route.hash })`、`router.push({ query: route.query })` 和`router.push({ params: route.params })` 不会产生额外的编码。
 
 ### TypeScript 变化


### PR DESCRIPTION
## Summary
- documents that string paths and object `path` locations must already be URL-encoded
- adds `router.push` and `<RouterLink>` examples that encode dynamic path segments
- adds migration-guide examples for encoded static route paths and named-route alternatives
- mirrors the docs in the Chinese translation


## Validation
- `corepack pnpm exec oxfmt --check packages/docs/guide/essentials/navigation.md packages/docs/zh/guide/essentials/navigation.md packages/docs/guide/migration/index.md packages/docs/zh/guide/migration/index.md`
- `corepack pnpm --filter ./packages/docs run docs:translation:compare zh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated navigation guides with examples for safely encoding dynamic URL segments containing spaces and slashes.
  * Added equivalent encoded examples for programmatic navigation and router links.
  * Clarified that manually constructed paths require encoding, while named routes with parameters handle encoding automatically.
  * Added migration guidance for escaping static paths and dynamic segments in English and Chinese documentation.
  * Included examples covering encoded static paths and usernames with special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->