### PR TITLE
perf: avoid depending on the current route to resolve absolute locations

### DIFF
--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -1111,7 +1111,7 @@ describe('Router', () => {
 
     it('uses an explicitly passed currentLocation', async () => {
       const { router } = await newRouter()
-      const current = router.resolve('/parent/child')
+      const current = await loadRouteLocation(router.resolve('/parent/child'))
       expect(router.resolve('child', current).path).toBe('/parent/child')
       await router.push('/foo')
       expect(router.resolve('child', current).path).toBe('/parent/child')

--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -2,6 +2,7 @@
  * @vitest-environment happy-dom
  */
 import fakePromise from 'faked-promise'
+import { computed, effectScope } from 'vue'
 import type { RouteLocationRaw } from '../src/typed-routes'
 import { createRouter } from '../src/router'
 import { createMemoryHistory } from '../src/history/memory'
@@ -1027,6 +1028,93 @@ describe('Router', () => {
         path: '/foo',
         query: {},
       })
+    })
+  })
+
+  describe('resolve reactivity', () => {
+    it('resolves absolute locations the same regardless of the current location', async () => {
+      const { router } = await newRouter()
+      const locations: RouteLocationRaw[] = [
+        '/',
+        '/foo',
+        '/foo?q=1#h',
+        '/p/abc',
+        { path: '/foo', query: { q: '1' }, hash: '#h' },
+      ]
+      const before = locations.map(to => router.resolve(to))
+      await router.push('/parent/child')
+      const after = locations.map(to => router.resolve(to))
+      expect(after).toStrictEqual(before)
+    })
+
+    it('does not re-run a computed with an absolute location on navigation', async () => {
+      const { router } = await newRouter()
+      const scope = effectScope()
+      let runs = 0
+      const route = scope.run(() =>
+        computed(() => {
+          runs++
+          return router.resolve('/foo')
+        })
+      )!
+      expect(route.value.name).toBe('Foo')
+      expect(runs).toBe(1)
+      await router.push('/search')
+      expect(route.value.name).toBe('Foo')
+      expect(runs).toBe(1)
+      scope.stop()
+    })
+
+    it('re-runs a computed with a relative location on navigation', async () => {
+      const { router } = await newRouter()
+      const scope = effectScope()
+      const route = scope.run(() => computed(() => router.resolve('child')))!
+      expect(route.value.path).toBe('/child')
+      await router.push('/parent/child')
+      expect(route.value.path).toBe('/parent/child')
+      scope.stop()
+    })
+
+    it('re-runs a computed with a named location inheriting params on navigation', async () => {
+      const { router } = await newRouter()
+      await router.push('/p/a')
+      const scope = effectScope()
+      const route = scope.run(() =>
+        computed(() => router.resolve({ name: 'Param' }))
+      )!
+      expect(route.value.path).toBe('/p/a')
+      await router.push('/p/b')
+      expect(route.value.path).toBe('/p/b')
+      scope.stop()
+    })
+
+    it('re-runs a computed when routes are added or removed', async () => {
+      const { router } = await newRouter({ routes: [routes[0]] })
+      const scope = effectScope()
+      const route = scope.run(() => computed(() => router.resolve('/late')))!
+      expect(route.value.matched).toHaveLength(0)
+      expect('No match found').toHaveBeenWarned()
+      const remove = router.addRoute({
+        path: '/late',
+        name: 'late',
+        component: components.Foo,
+      })
+      expect(route.value.matched).toHaveLength(1)
+      remove()
+      expect(route.value.matched).toHaveLength(0)
+      router.addRoute({ path: '/late', component: components.Foo })
+      expect(route.value.matched).toHaveLength(1)
+      router.clearRoutes()
+      expect(route.value.matched).toHaveLength(0)
+      scope.stop()
+    })
+
+    it('uses an explicitly passed currentLocation', async () => {
+      const { router } = await newRouter()
+      const current = router.resolve('/parent/child')
+      expect(router.resolve('child', current).path).toBe('/parent/child')
+      await router.push('/foo')
+      expect(router.resolve('child', current).path).toBe('/parent/child')
     })
   })
 

--- a/packages/router/__tests__/router.spec.ts
+++ b/packages/router/__tests__/router.spec.ts
@@ -499,6 +499,15 @@ describe('Router', () => {
     })
   })
 
+  it('resolves a relative location against a passed currentLocation', async () => {
+    const { router } = await newRouter()
+    const current = await loadRouteLocation(router.resolve('/parent/child'))
+    expect(router.resolve('child', current).path).toBe('/parent/child')
+    // the explicit currentLocation takes precedence over the current route
+    await router.push('/foo')
+    expect(router.resolve('child', current).path).toBe('/parent/child')
+  })
+
   it('resolves relative locations', async () => {
     const { router } = await newRouter()
     await router.push('/users/posva')
@@ -1032,21 +1041,6 @@ describe('Router', () => {
   })
 
   describe('resolve reactivity', () => {
-    it('resolves absolute locations the same regardless of the current location', async () => {
-      const { router } = await newRouter()
-      const locations: RouteLocationRaw[] = [
-        '/',
-        '/foo',
-        '/foo?q=1#h',
-        '/p/abc',
-        { path: '/foo', query: { q: '1' }, hash: '#h' },
-      ]
-      const before = locations.map(to => router.resolve(to))
-      await router.push('/parent/child')
-      const after = locations.map(to => router.resolve(to))
-      expect(after).toStrictEqual(before)
-    })
-
     it('does not re-run a computed with an absolute location on navigation', async () => {
       const { router } = await newRouter()
       const scope = effectScope()
@@ -1061,6 +1055,24 @@ describe('Router', () => {
       expect(runs).toBe(1)
       await router.push('/search')
       expect(route.value.name).toBe('Foo')
+      expect(runs).toBe(1)
+      scope.stop()
+    })
+
+    it('does not re-run a computed with an absolute object location on navigation', async () => {
+      const { router } = await newRouter()
+      const scope = effectScope()
+      let runs = 0
+      const route = scope.run(() =>
+        computed(() => {
+          runs++
+          return router.resolve({ path: '/foo', query: { q: '1' }, hash: '#h' })
+        })
+      )!
+      expect(route.value.fullPath).toBe('/foo?q=1#h')
+      expect(runs).toBe(1)
+      await router.push('/search')
+      expect(route.value.fullPath).toBe('/foo?q=1#h')
       expect(runs).toBe(1)
       scope.stop()
     })
@@ -1107,14 +1119,6 @@ describe('Router', () => {
       router.clearRoutes()
       expect(route.value.matched).toHaveLength(0)
       scope.stop()
-    })
-
-    it('uses an explicitly passed currentLocation', async () => {
-      const { router } = await newRouter()
-      const current = await loadRouteLocation(router.resolve('/parent/child'))
-      expect(router.resolve('child', current).path).toBe('/parent/child')
-      await router.push('/foo')
-      expect(router.resolve('child', current).path).toBe('/parent/child')
     })
   })
 

--- a/packages/router/__tests__/useLink.spec.ts
+++ b/packages/router/__tests__/useLink.spec.ts
@@ -94,6 +94,42 @@ describe('useLink', () => {
     })
   })
 
+  describe('active state', () => {
+    it('updates isActive and isExactActive after navigation', async () => {
+      const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          { path: '/', component: {} },
+          { path: '/a', component: {} },
+          { path: '/b', component: {} },
+        ],
+      })
+      await router.push('/')
+
+      let link!: ReturnType<typeof useLink>
+      mount(
+        {
+          setup() {
+            link = useLink({ to: '/a' })
+            return () => ''
+          },
+        },
+        { global: { plugins: [router] } }
+      )
+
+      expect(link.isActive.value).toBe(false)
+      expect(link.isExactActive.value).toBe(false)
+
+      await router.push('/a')
+      expect(link.isActive.value).toBe(true)
+      expect(link.isExactActive.value).toBe(true)
+
+      await router.push('/b')
+      expect(link.isActive.value).toBe(false)
+      expect(link.isExactActive.value).toBe(false)
+    })
+  })
+
   describe('warnings', () => {
     mockWarn()
 

--- a/packages/router/src/experimental/router.spec.ts
+++ b/packages/router/src/experimental/router.spec.ts
@@ -31,6 +31,7 @@
  */
 
 import fakePromise from 'faked-promise'
+import { computed, effectScope } from 'vue'
 import {
   experimental_createRouter,
   createFixedResolver,
@@ -763,6 +764,15 @@ describe('Experimental Router', () => {
     })
   })
 
+  it('resolves a relative location against a passed currentLocation', async () => {
+    const { router } = await newRouter()
+    const current = await loadRouteLocation(router.resolve('/parent/child'))
+    expect(router.resolve('child', current).path).toBe('/parent/child')
+    // the explicit currentLocation takes precedence over the current route
+    await router.push('/foo')
+    expect(router.resolve('child', current).path).toBe('/parent/child')
+  })
+
   it('resolves relative string locations', async () => {
     const { router } = await newRouter()
     await router.push('/users/posva')
@@ -784,6 +794,54 @@ describe('Experimental Router', () => {
     await router.push('/users/posva')
     await router.push('../')
     expect(router.currentRoute.value.path).toBe('/')
+  })
+
+  describe('resolve reactivity', () => {
+    it('does not re-run a computed with an absolute location on navigation', async () => {
+      const { router } = await newRouter()
+      const scope = effectScope()
+      let runs = 0
+      const route = scope.run(() =>
+        computed(() => {
+          runs++
+          return router.resolve('/foo')
+        })
+      )!
+      expect(route.value.name).toBe('Foo')
+      expect(runs).toBe(1)
+      await router.push('/search')
+      expect(route.value.name).toBe('Foo')
+      expect(runs).toBe(1)
+      scope.stop()
+    })
+
+    it('does not re-run a computed with an absolute object location on navigation', async () => {
+      const { router } = await newRouter()
+      const scope = effectScope()
+      let runs = 0
+      const route = scope.run(() =>
+        computed(() => {
+          runs++
+          return router.resolve({ path: '/foo', query: { q: '1' }, hash: '#h' })
+        })
+      )!
+      expect(route.value.fullPath).toBe('/foo?q=1#h')
+      expect(runs).toBe(1)
+      await router.push('/search')
+      expect(route.value.fullPath).toBe('/foo?q=1#h')
+      expect(runs).toBe(1)
+      scope.stop()
+    })
+
+    it('re-runs a computed with a relative location on navigation', async () => {
+      const { router } = await newRouter()
+      const scope = effectScope()
+      const route = scope.run(() => computed(() => router.resolve('child')))!
+      expect(route.value.path).toBe('/child')
+      await router.push('/parent/child')
+      expect(route.value.path).toBe('/parent/child')
+      scope.stop()
+    })
   })
 
   describe('alias', () => {

--- a/packages/router/src/experimental/router.ts
+++ b/packages/router/src/experimental/router.ts
@@ -683,7 +683,9 @@ export function experimental_createRouter(
       currentLocation ??
         // relative string locations are always valid
         // so this is more of a convenience default
-        (typeof to === 'string' ? currentRoute.value : undefined)
+        (typeof to === 'string' && !to.startsWith('/')
+          ? currentRoute.value
+          : undefined)
     )
     const href = routerHistory.createHref(matchedRoute.fullPath)
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -163,6 +163,9 @@ export function createRouter(options: RouterOptions): Router {
   const currentRoute = shallowRef<RouteLocationNormalizedLoaded>(
     START_LOCATION_NORMALIZED
   )
+  // incremented whenever the route table changes so that `resolve()` can be
+  // used within `computed()` and still pick up added or removed routes
+  const routesVersion = shallowRef(0)
   let pendingLocation: RouteLocation = START_LOCATION_NORMALIZED
 
   // leave the scrollRestoration if no scrollBehavior is provided
@@ -195,16 +198,27 @@ export function createRouter(options: RouterOptions): Router {
       record = parentOrRoute
     }
 
-    return matcher.addRoute(record, parent)
+    const removeRoute = matcher.addRoute(record, parent)
+    routesVersion.value++
+    return () => {
+      removeRoute()
+      routesVersion.value++
+    }
   }
 
   function removeRoute(name: NonNullable<RouteRecordNameGeneric>) {
     const recordMatcher = matcher.getRecordMatcher(name)
     if (recordMatcher) {
       matcher.removeRoute(recordMatcher)
+      routesVersion.value++
     } else if (__DEV__) {
       diagnostics.VUE_ROUTER_R0002({ name: String(name) })
     }
+  }
+
+  function clearRoutes() {
+    matcher.clearRoutes()
+    routesVersion.value++
   }
 
   function getRoutes() {
@@ -221,9 +235,17 @@ export function createRouter(options: RouterOptions): Router {
   ): RouteLocationResolved {
     // const resolve: Router['resolve'] = (rawLocation: RouteLocationRaw, currentLocation) => {
     // const objectLocation = routerLocationAsObject(rawLocation)
-    // we create a copy to modify it later
-    currentLocation = assign({}, currentLocation || currentRoute.value)
+    // depend on the route table so `computed()`s using `resolve()` are
+    // invalidated when routes are added or removed
+    routesVersion.value
     if (typeof rawLocation === 'string') {
+      // absolute locations do not depend on where the user currently is, so
+      // we avoid reading `currentRoute` to not track it as a dependency
+      currentLocation =
+        currentLocation ||
+        (rawLocation.startsWith('/')
+          ? START_LOCATION_NORMALIZED
+          : currentRoute.value)
       const locationNormalized = parseURL(
         parseQuery,
         rawLocation,
@@ -256,6 +278,17 @@ export function createRouter(options: RouterOptions): Router {
       diagnostics.VUE_ROUTER_R0005({ rawLocation })
       return resolve({})
     }
+
+    // we create a copy to modify it later
+    currentLocation = assign(
+      {},
+      currentLocation ||
+        (rawLocation.path != null &&
+        rawLocation.path.startsWith('/') &&
+        !('name' in rawLocation && rawLocation.name)
+          ? START_LOCATION_NORMALIZED
+          : currentRoute.value)
+    )
 
     let matcherLocation: MatcherLocationRaw
 
@@ -995,7 +1028,7 @@ export function createRouter(options: RouterOptions): Router {
 
     addRoute,
     removeRoute,
-    clearRoutes: matcher.clearRoutes,
+    clearRoutes,
     hasRoute,
     getRoutes,
     resolve,


### PR DESCRIPTION
another perf one! 🔥

spotted this whilst profiling `<NuxtLink>`. every mounted `<RouterLink>` fully re-resolves its `to` on every navigation, regex matching and param decoding included, even when it's not relative to the current path

this is because `resolve` always reads `currentRoute`, even though it won't use it, so the `route` computed value ends up tracking `currentRoute` as a dependency

👉 **this means that every navigation triggers a fresh `resolve` call for every mounted `RouterLink`**

the total time for navigation is very small both before and after, but _technically_ this is something like a ~2x faster navigation if you use non-relative links....

<details><summary><strong>results of a quick `happy-dom` benchmark</strong></summary>
<p>

| links | navigate (before) | navigate (after) | resolve calls per nav |
| - | - | - | - |
| 50 | 0.116ms | 0.051ms | 50 -> 0 |
| 300 | 0.722ms | 0.323ms | 300 -> 0 |
| 1000 | 2.429ms | 1.341ms | 1000 -> 0 |

</p>
</details> 

this PR tweaks the implementation to read `currentRoute` only when the location actually depends on it.

I've also had to add a `routesVersion` counter because at the moment `computed(() => router.resolve('/late'))` goes stale after `addRoute('/late')` and only recovers because the next navigation reruns it. (but because we don't rerun `resolve`, we have to _track_ addRoute.)  you may have a better idea...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route links now update their active and exact-active states correctly as navigation changes.
  * Route resolution now refreshes when routes are added, removed, or cleared.
  * Absolute paths remain stable when the current route changes.
  * Explicitly provided locations are respected during route resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->