### PR TITLE
feat: prevent race condition dev-only error

### DIFF
--- a/packages/router/src/RouterView.ts
+++ b/packages/router/src/RouterView.ts
@@ -196,6 +196,8 @@ export const RouterViewImpl = /*#__PURE__*/ defineComponent({
 
         internalInstances.forEach(instance => {
           // @ts-expect-error
+          // to prevent possible race condition in SSR
+          // https://github.com/vuejs/router/pull/2789
           if (instance) instance.__vrv_devtools = info
         })
       }

--- a/packages/router/src/RouterView.ts
+++ b/packages/router/src/RouterView.ts
@@ -196,7 +196,7 @@ export const RouterViewImpl = /*#__PURE__*/ defineComponent({
 
         internalInstances.forEach(instance => {
           // @ts-expect-error
-          instance.__vrv_devtools = info
+          if (instance) instance.__vrv_devtools = info
         })
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## Did you add tests for your changes?

No. Reliably reproducing the null state inside `@vue/test-utils` + `happy-dom` requires an SSR/hydration timing race that does not occur in the current test harness. The fix is a one-line defensive `null` check that has no impact when `instance` is already defined, so a regression test would only exercise the untouched code path. Happy to add one if a reviewer can suggest a stable reproduction pattern.

## If relevant, did you update the documentation?

No documentation change needed.

## Summary

Under certain rendering conditions — observed in a Nuxt 4 SSR app with `@nuxt/content` — `component.ref.i` in `RouterView.ts` is `null` when the dev-only devtools branch runs. The unguarded `instance.__vrv_devtools = info` assignment then throws:

```
TypeError: null is not an object (evaluating 'instance.__vrv_devtools = info')
```

crashing the app on first render.

## Change

```diff
 internalInstances.forEach(instance => {
   // @ts-expect-error
-  instance.__vrv_devtools = info
+  if (instance) instance.__vrv_devtools = info
 })
```

## Why this is safe

- The block is guarded by `__DEV__ || __FEATURE_PROD_DEVTOOLS__` and `isBrowser`, so production builds are unaffected.
- When `instance` is truthy the behavior is unchanged.
- When `instance` is `null`, the devtools info is simply not attached to that entry. `RouterView` re-runs this code on subsequent renders / re-mounts, so no persistent state is lost.

## Reproduction steps

1. Create a fresh Nuxt 4 project.
2. Install `@nuxt/content` (v3.15.2) and register it in `nuxt.config.ts`:
   ```ts
   export default defineNuxtConfig({
     modules: ['@nuxt/content']
   })
   ```
3. Add a minimal page `app/pages/index.vue`:
   ```vue
   <template><div>hello</div></template>
   ```
4. Run `npm run dev` and open `http://localhost:3000`.
5. The page renders briefly, then the app crashes with the `TypeError` shown above.

Environment: Nuxt 4.5.2, `@nuxt/content` 3.15.2, vue-router 5.2.0, Vue 3.5.41.

---

Non-native English speaker; apologies for any awkward phrasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved devtools metadata handling to prevent errors when an internal component instance is unavailable.
  * Added safeguards for potential server-side rendering timing conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->