### PR TITLE
fix(unplugin): do not flag same-url routes as conflicts

### DIFF
--- a/packages/router/src/unplugin/core/tree.spec.ts
+++ b/packages/router/src/unplugin/core/tree.spec.ts
@@ -1739,6 +1739,50 @@ describe('Tree', () => {
       expect(c.children.has('_parent')).toBe(false)
     })
 
+    // https://github.com/vuejs/router/issues/2791
+    it('does not flag intentional same-URL routes as conflicts', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      tree.insert('settings', 'settings.vue')
+      const general = tree.insert('settings/general', 'settings/general.vue')
+      general.setCustomRouteBlock('settings/general.vue', {
+        name: 'settings-general',
+        meta: { full: true },
+      })
+      general.setDefinePageImport('settings/general.vue', true)
+
+      // an overlay version of the same URL, `path` is overridden to /settings
+      const overlay = tree.insert('settings.overlay', 'settings.overlay.vue')
+      overlay.setCustomRouteBlock('settings.overlay.vue', { path: '/settings' })
+      overlay.setDefinePageImport('settings.overlay.vue', true)
+      const overlayGeneral = tree.insert(
+        'settings.overlay/general',
+        'settings.overlay/general.vue'
+      )
+      overlayGeneral.setCustomRouteBlock('settings.overlay/general.vue', {
+        name: 'settings-general-overlay',
+        meta: { overlay: true },
+      })
+      overlayGeneral.setDefinePageImport('settings.overlay/general.vue', true)
+
+      expect(general).not.toBe(overlayGeneral)
+      expect(collectDuplicatedRouteNodes(tree)).toEqual([])
+    })
+
+    it('collects conflicts across route groups', () => {
+      const tree = new PrefixTree(RESOLVED_OPTIONS)
+      const foo = tree.insert('foo', 'foo.vue')
+      const groupedFoo = tree.insert('(group)/foo', '(group)/foo.vue')
+      const overriddenFoo = tree.insert('other/foo', 'other/foo.vue')
+      overriddenFoo.setCustomRouteBlock('other/foo.vue', { path: '/foo' })
+
+      expect(collectDuplicatedRouteNodes(tree)).toEqual([
+        [
+          { filePath: 'foo.vue', node: foo },
+          { filePath: '(group)/foo.vue', node: groupedFoo },
+        ],
+      ])
+    })
+
     it('does not flag named views as conflicts', () => {
       const tree = new PrefixTree(RESOLVED_OPTIONS)
       tree.insert('posts/index', 'posts/index.vue')

--- a/packages/router/src/unplugin/core/tree.ts
+++ b/packages/router/src/unplugin/core/tree.ts
@@ -667,8 +667,6 @@ export function collectDuplicatedRouteNodes(
   tree: PrefixTree
 ): DuplicatedRouteConflict[][] {
   const seen = new Map<string, DuplicatedRouteConflict[]>()
-  // find which nodes take precedence to reorder the list
-  const treeNodes = new Set<TreeNode>(...tree)
 
   // by reading through the map, we get every node that was added to the tree
   for (const [filePath, node] of tree.map) {
@@ -681,27 +679,36 @@ export function collectDuplicatedRouteNodes(
     nodes.push({ filePath, node })
   }
 
-  const dups = Array.from(seen.values())
-    // All entries in a group reference the same TreeNode instance, so
-    // comparing the number of files to components.size tells us if any
-    // file was overwritten (e.g. index.vue vs index@default.vue both
-    // targeting the "default" view). Different named views on the same
-    // node (e.g. index.vue + index@header.vue) are not conflicts.
-    .filter(nodes => nodes.length > nodes[0].node.value.components.size)
-    .map(nodes =>
-      nodes.toSorted(({ node: a }, { node: b }) => {
-        // put the one that takes precedence at the end of the list
-        if (treeNodes.has(a) && !treeNodes.has(b)) {
-          return -1
-        } else if (!treeNodes.has(a) && treeNodes.has(b)) {
-          return 1
-        } else {
-          return 0
-        }
-      })
-    )
+  const hasPathOverride = (node: TreeNode) => {
+    while (!node.isRoot()) {
+      if (node.value.overrides.path != null) return true
+      node = node.parent!
+    }
+    return false
+  }
 
-  return dups
+  // a file still referenced by the node won over the ones it overwrote
+  const takesPrecedence = ({ node, filePath }: DuplicatedRouteConflict) =>
+    Array.from(node.value.components.values()).includes(filePath) ? 1 : 0
+
+  return (
+    Array.from(seen.values())
+      // An explicit path can intentionally create multiple records for the
+      // same URL. Keep detecting convention-based collisions such as groups.
+      .map(nodes =>
+        new Set(nodes.map(({ node }) => node)).size === 1
+          ? nodes
+          : nodes.filter(({ node }) => !hasPathOverride(node))
+      )
+      .filter(
+        nodes =>
+          nodes.length > 0 && nodes.length > nodes[0].node.value.components.size
+      )
+      // put the one that takes precedence at the end of the list
+      .map(nodes =>
+        nodes.toSorted((a, b) => takesPrecedence(a) - takesPrecedence(b))
+      )
+  )
 }
 
 /**


### PR DESCRIPTION
Group duplicated route nodes by node identity instead of `fullPath::toString()`, so two distinct nodes resolving to the same URL (e.g. a `path` override in `definePage()`) are no longer reported as conflicting files.

Fix #2791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-route detection to avoid incorrectly reporting intentional same-URL overlays as conflicts.
  * Correctly identifies conflicts between standard and grouped routes.
  * Preserves valid routes with explicit path overrides while continuing to flag genuine convention-based collisions.
  * Route precedence is now determined more reliably, reducing false positives during routing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->