### PR TITLE
fix(router): avoid unnecessary update of reused view components (fix #1701)

### DIFF
--- a/packages/router/__tests__/RouterView.spec.ts
+++ b/packages/router/__tests__/RouterView.spec.ts
@@ -5,11 +5,11 @@ import { RouterView } from '../src/RouterView'
 import type { RouteLocationNormalizedLoose } from './utils'
 import { components } from './utils'
 import { START_LOCATION_NORMALIZED } from '../src/location'
-import { markRaw } from 'vue'
+import { h, markRaw } from 'vue'
 import { createMockedRoute } from './mount'
 import { mount } from '@vue/test-utils'
 import type { RouteLocationNormalized } from '../src/typed-routes'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mockWarn } from './vitest-mock-warn'
 
 // to have autocompletion
@@ -285,6 +285,70 @@ describe('RouterView', () => {
     expect(wrapper.html()).toBe(`<div>Home</div>`)
     await route.set(routes.foo)
     expect(wrapper.html()).toBe(`<div>Foo</div>`)
+  })
+
+  it('does not update the parent view component when a child route changes', async () => {
+    const parentRender = vi.fn(() =>
+      h('div', [h('h2', {}, 'parent'), h(RouterView)])
+    )
+    const childRenderA = vi.fn(() => h('div', {}, 'child a'))
+    const childRenderB = vi.fn(() => h('div', {}, 'child b'))
+    const parentRecord = {
+      components: { default: { name: 'Parent', render: parentRender } },
+      instances: {},
+      enterCallbacks: {},
+      path: '/parent',
+      props,
+    }
+    const nested = createRoutes({
+      childA: {
+        fullPath: '/parent/a',
+        name: undefined,
+        path: '/parent/a',
+        query: {},
+        params: {},
+        hash: '',
+        meta: {},
+        matched: [
+          parentRecord,
+          {
+            components: { default: { name: 'ChildA', render: childRenderA } },
+            instances: {},
+            enterCallbacks: {},
+            path: 'a',
+            props,
+          },
+        ],
+      },
+      childB: {
+        fullPath: '/parent/b',
+        name: undefined,
+        path: '/parent/b',
+        query: {},
+        params: {},
+        hash: '',
+        meta: {},
+        matched: [
+          parentRecord,
+          {
+            components: { default: { name: 'ChildB', render: childRenderB } },
+            instances: {},
+            enterCallbacks: {},
+            path: 'b',
+            props,
+          },
+        ],
+      },
+    })
+    const { route, wrapper } = await factory(nested.childA)
+    expect(wrapper.text()).toContain('child a')
+    expect(parentRender).toHaveBeenCalledTimes(1)
+
+    await route.set(nested.childB)
+    expect(wrapper.text()).toContain('child b')
+    // the parent matched record did not change, so only the child view should
+    // be updated, not the parent component
+    expect(parentRender).toHaveBeenCalledTimes(1)
   })
 
   it('does not pass params as props by default', async () => {

--- a/packages/router/src/RouterView.ts
+++ b/packages/router/src/RouterView.ts
@@ -139,10 +139,21 @@ export const RouterViewImpl = /*#__PURE__*/ defineComponent({
       { flush: 'post' }
     )
 
+    // Cache the unmount hook per matched route and name. The hook must keep a
+    // stable identity so the view component isn't unnecessarily updated when
+    // navigating between child routes (#1701), but its captured values must
+    // still be bound to one route record because the component can unmount
+    // after we navigated elsewhere (e.g. transitions)
+    let unmountHook:
+      | {
+          matchedRoute: RouteLocationMatched
+          name: string
+          hook: VNodeProps['onVnodeUnmounted']
+        }
+      | undefined
+
     return () => {
       const route = routeToDisplay.value
-      // we need the value at the time we render because when we unmount, we
-      // navigated to a different location so the value is different
       const currentName = props.name
       const matchedRoute = matchedRouteRef.value
       const ViewComponent =
@@ -162,17 +173,29 @@ export const RouterViewImpl = /*#__PURE__*/ defineComponent({
             : routePropsOption
         : null
 
-      const onVnodeUnmounted: VNodeProps['onVnodeUnmounted'] = vnode => {
-        // remove the instance reference to prevent leak
-        if (vnode.component!.isUnmounted) {
-          matchedRoute.instances[currentName] = null
+      if (
+        !unmountHook ||
+        unmountHook.matchedRoute !== matchedRoute ||
+        unmountHook.name !== currentName
+      ) {
+        const capturedRoute = matchedRoute
+        const capturedName = currentName
+        unmountHook = {
+          matchedRoute,
+          name: currentName,
+          hook: vnode => {
+            // remove the instance reference to prevent leak
+            if (vnode.component!.isUnmounted) {
+              capturedRoute.instances[capturedName] = null
+            }
+          },
         }
       }
 
       const component = h(
         ViewComponent,
         assign({}, routeProps, attrs, {
-          onVnodeUnmounted,
+          onVnodeUnmounted: unmountHook.hook,
           ref: viewRef,
         })
       )


### PR DESCRIPTION
## Description

`RouterView` recreated its `onVnodeUnmounted` hook inside its render function, so every render generated a new function and passed it as a vnode prop to the view component. Any navigation that re-renders a `RouterView` without changing its matched record (e.g. navigating between child routes) therefore produced a changed prop and forced an unnecessary update of the reused parent view component. In apps with nested routes this can re-render large subtrees on every child navigation (see the search box synced with the query string in #1701).

Fixes #1701.

## Implementation

The hook is now cached per matched route record and view name:

- while the record doesn't change, the same function instance is reused, so the props of the view component are untouched and no update is triggered
- when the record (or the view name) changes, a new hook is created, capturing the values of that specific record

This keeps the capture-at-creation semantics the inline closure provided: a component can unmount after we navigated elsewhere (e.g. with `<Transition>`), so the hook must clean up the instances of the record it was rendered for, not the current one. Simply hoisting a single hook out of the render function loses that and breaks the existing `guardsContext` tests — the cache preserves both the stable identity and the per-record capture.

## Tests

- added a regression test asserting the parent view component's render function runs exactly once when navigating between child routes (it fails on `main`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented parent views from re-rendering unnecessarily when only a child route changes.
  * Improved view cleanup behavior during route transitions by maintaining the correct unmount handling for each route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->