### PR TITLE
fix(data-loaders): don't re-run instantly resolving parents when nested loaders attach

### DIFF
--- a/packages/router/src/experimental/data-loaders/defineColadaLoader.ts
+++ b/packages/router/src/experimental/data-loaders/defineColadaLoader.ts
@@ -153,7 +153,8 @@ export function defineColadaLoader<Data>(
     router: Router,
     from?: RouteLocationNormalizedLoaded,
     parent?: DataLoaderEntryBase,
-    reload?: boolean
+    reload?: boolean,
+    force?: boolean
   ): Promise<void> {
     const entries = router[LOADER_ENTRIES_KEY]! as _DefineLoaderEntryMap<
       DataLoaderColadaEntry<unknown>
@@ -204,8 +205,9 @@ export function defineColadaLoader<Data>(
         diagnostics.VUE_ROUTER_R1001({ key: `[${key.join(',')}]` })
       }
     }
-    // set the current context before loading so nested loaders can use it
-    setCurrentContext([entry, router, to])
+    // set the current context before loading so nested loaders can use it.
+    // `force` is propagated so nested loaders re-run on explicit reloads
+    setCurrentContext([entry, router, to, force])
 
     if (!entry.ext) {
       // console.log(`🚀 creating query for "${key}"`)
@@ -408,20 +410,29 @@ export function defineColadaLoader<Data>(
       | DataLoaderColadaEntry<Data, ErrorDefault>
       | undefined
 
+    // a nested loader whose parent has already committed data for this route
+    // doesn't need to be reloaded, it can reuse the resolved query. Otherwise,
+    // loaders that resolve instantly (committed before nested loaders run)
+    // are wrongly executed twice https://github.com/vuejs/router/issues/2684
+    const force = currentContext.length > 3 && currentContext[3] === true
+    const hasDataForRoute =
+      !!entry && entry.to === route && !!entry.pendingLoad
+
     if (
-      // if the entry doesn't exist, create it with load and ensure it's loading
       !entry ||
-      // we are nested and the parent is loading a different route than us
-      (parentEntry && entry.pendingTo !== route) ||
-      // The user somehow rendered the page without a navigation
-      !entry.pendingLoad
+      (parentEntry && entry.pendingTo !== route && !hasDataForRoute) ||
+      !entry.pendingLoad ||
+      force
     ) {
-      // console.log(
-      //   `🔁 loading from useData for "${options.key}": "${route.fullPath}"`
-      // )
       app.runWithContext(() =>
-        // in this case we always need to run the functions for nested loaders consistency
-        load(route, router, undefined, parentEntry, true)
+        load(
+          route,
+          router,
+          undefined,
+          parentEntry,
+          force || !hasDataForRoute,
+          force
+        )
       )
     }
 
@@ -476,7 +487,9 @@ export function defineColadaLoader<Data>(
       isLoading,
       reload: (to: RouteLocationNormalizedLoaded = router.currentRoute.value) =>
         app
-          .runWithContext(() => load(to, router, undefined, undefined, true))
+          .runWithContext(() =>
+            load(to, router, undefined, undefined, true, true)
+          )
           .then(() => entry!.commit(to)),
       // pinia colada
       refetch: (

--- a/packages/router/src/experimental/data-loaders/defineLoader.spec.ts
+++ b/packages/router/src/experimental/data-loaders/defineLoader.spec.ts
@@ -19,10 +19,16 @@ import {
 } from './entries/index'
 import { getRouter, testDefineLoader } from '../../tests/data-loaders'
 // import { getRouter } from 'vue-router-mock'
-import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import RouterViewMock from '../../tests/data-loaders/RouterViewMock.vue'
 import { mockPromise } from '../../tests/utils'
 import type { RouteLocationNormalizedLoaded } from '../../typed-routes'
+import { createRouter } from '../../router'
+import { createMemoryHistory } from '../../history/memory'
+import { RouterViewImpl } from '../../RouterView'
+import { defineColadaLoader } from './defineColadaLoader'
+import { createPinia, setActivePinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
 
 function mockedLoader<T = string | NavigationResult>(
   // boolean is easier to handle for router mock
@@ -350,6 +356,159 @@ describe(
 
         expect('NavigationResult').toHaveBeenWarned()
         expect('key: "my-key"').toHaveBeenWarned()
+      })
+    })
+
+    // https://github.com/vuejs/router/issues/2684
+    describe('nested loaders with instantly resolved parents', () => {
+      // helper component that resolves a loader and provides a slot, as used in #2684
+      const ParentResolver = defineComponent({
+        setup() {
+          const { data } = useParentLoader()
+          return { data }
+        },
+        template: `<div class="resolver"><slot :data="data" /></div>`,
+      })
+      const ParentPage = defineComponent({
+        components: { ParentResolver, RouterView: RouterViewImpl },
+        template: `<ParentResolver v-slot="{ data }">
+          <div id="parent-page">parent {{ data }}<RouterView /></div>
+        </ParentResolver>`,
+      })
+      const ChildPage = defineComponent({
+        components: { ParentResolver },
+        setup() {
+          const { data } = useChildLoader()
+          return { data }
+        },
+        template: `<ParentResolver v-slot="{ data }">
+          <div id="child-page">child {{ data }}</div>
+        </ParentResolver>`,
+      })
+      let parentCalls: number
+      let childCalls: number
+      let useParentLoader: UseDataLoaderBasic_DefinedData<string>
+      let useChildLoader: UseDataLoaderBasic_DefinedData<string>
+
+      function setupLoaders({
+        cached,
+        lazy,
+        basic,
+      }: { cached?: boolean; lazy?: boolean; basic?: boolean } = {}) {
+        parentCalls = 0
+        childCalls = 0
+        let cache: string | undefined
+        const parentQuery = () => {
+          parentCalls++
+          if (cached && cache) return cache
+          cache = 'parent' + parentCalls
+          return cache
+        }
+        const childQuery = async () => {
+          childCalls++
+          const { data } = await useParentLoader()
+          return `child: ${data}`
+        }
+        if (basic) {
+          useParentLoader = defineBasicLoader(parentQuery, {
+            lazy,
+          }) as typeof useParentLoader
+          useChildLoader = defineBasicLoader(childQuery, {
+            lazy,
+          }) as typeof useChildLoader
+        } else {
+          useParentLoader = defineColadaLoader({
+            query: parentQuery,
+            key: () => ['parent'],
+            lazy,
+          }) as typeof useParentLoader
+          useChildLoader = defineColadaLoader({
+            query: childQuery,
+            key: () => ['child'],
+            lazy,
+          }) as typeof useChildLoader
+        }
+      }
+
+      function mountApp() {
+        const pinia = createPinia()
+        setActivePinia(pinia)
+        const router = createRouter({
+          history: createMemoryHistory(),
+          routes: [
+            {
+              path: '/',
+              component: defineComponent({ template: `<div>home</div>` }),
+            },
+            {
+              path: '/nested',
+              component: ParentPage,
+              meta: { loaders: [useParentLoader] },
+              children: [
+                {
+                  path: 'child',
+                  component: ChildPage,
+                  meta: { loaders: [useChildLoader] },
+                },
+                {
+                  path: 'child2',
+                  component: ChildPage,
+                  meta: { loaders: [useChildLoader] },
+                },
+              ],
+            },
+          ],
+        })
+        const wrapper = mount(App, {
+          global: {
+            plugins: [
+              pinia,
+              PiniaColada,
+              [DataLoaderPlugin, { router }],
+              router,
+            ],
+          },
+        })
+        return { router, wrapper }
+      }
+
+      const App = defineComponent({
+        components: { RouterView: RouterViewImpl },
+        template: `<RouterView />`,
+      })
+
+      it('calls the parent loader once per navigation', async () => {
+        setupLoaders({ lazy: true })
+        const { router } = mountApp()
+
+        await router.push('/nested/child')
+        await flushPromises()
+
+        expect(parentCalls).toBe(1)
+        expect(childCalls).toBe(1)
+      })
+
+      it('calls the parent loader once with the basic loader too', async () => {
+        setupLoaders({ lazy: true, basic: true })
+        const { router } = mountApp()
+
+        await router.push('/nested/child')
+        await flushPromises()
+
+        expect(parentCalls).toBe(1)
+        expect(childCalls).toBe(1)
+      })
+
+      it('does not enter an infinite loop with cached parent loaders', async () => {
+        setupLoaders({ cached: true })
+        const { router } = mountApp()
+
+        await router.push('/nested/child')
+        await flushPromises()
+        await router.push('/nested/child2')
+        await flushPromises()
+
+        expect(router.currentRoute.value.fullPath).toBe('/nested/child2')
       })
     })
   }

--- a/packages/router/src/experimental/data-loaders/defineLoader.ts
+++ b/packages/router/src/experimental/data-loaders/defineLoader.ts
@@ -124,7 +124,8 @@ export function defineBasicLoader<Data>(
     to: RouteLocationNormalizedLoaded,
     router: Router,
     from?: RouteLocationNormalizedLoaded,
-    parent?: DataLoaderEntryBase
+    parent?: DataLoaderEntryBase,
+    force?: boolean
   ): Promise<void> {
     // we cast here because we can manipulate our ownn type of entries
     const entries = router[LOADER_ENTRIES_KEY]! as _DefineLoaderEntryMap<
@@ -198,8 +199,9 @@ export function defineBasicLoader<Data>(
         diagnostics.VUE_ROUTER_R1001({ key: options.key })
       }
     }
-    // set the current context before loading so nested loaders can use it
-    setCurrentContext([entry, router, to])
+    // set the current context before loading so nested loaders can use it.
+    // `force` is propagated so nested loaders re-run on explicit reloads
+    setCurrentContext([entry, router, to, force])
     entry.staged = STAGED_NO_VALUE
     // preserve error until data is committed
     entry.stagedError = error.value
@@ -345,22 +347,22 @@ export function defineBasicLoader<Data>(
     // console.log('is same route', entry?.pendingTo === route)
     // console.log('-- END --')
 
+    // a nested loader whose parent has already committed data for this route
+    // doesn't need to re-run. Otherwise, loaders that resolve instantly
+    // (committed before nested loaders run) are wrongly executed twice
+    // https://github.com/vuejs/router/issues/2684
+    const force =
+      currentContext.length > 3 && currentContext[3] === true
+    const hasDataForRoute =
+      !!entry && entry.to === route && !!entry.pendingLoad
     if (
-      // if the entry doesn't exist, create it with load and ensure it's loading
       !entry ||
-      // the existing pending location isn't good, we need to load again
-      (parentEntry && entry.pendingTo !== route) ||
-      // we could also check for: but that would break nested loaders since they need to be always called to be associated with the parent
-      // && entry.to !== route
-      // the user managed to render the router view after a valid navigation + a failed navigation
-      // https://github.com/posva/unplugin-vue-router/issues/495
-      !entry.pendingLoad
+      (parentEntry && entry.pendingTo !== route && !hasDataForRoute) ||
+      !entry.pendingLoad ||
+      force
     ) {
-      // console.log(
-      //   `🔁 loading from useData for "${options.key}": "${route.fullPath}"`
-      // )
       router[APP_KEY].runWithContext(() =>
-        load(route, router, undefined, parentEntry)
+        load(route, router, undefined, parentEntry, force)
       )
     }
 
@@ -383,7 +385,7 @@ export function defineBasicLoader<Data>(
       isLoading,
       reload: (to: RouteLocationNormalizedLoaded = router.currentRoute.value) =>
         router[APP_KEY]
-          .runWithContext(() => load(to, router))
+          .runWithContext(() => load(to, router, undefined, undefined, true))
           .then(() => entry!.commit(to)),
     } satisfies UseDataLoaderResult<Data | undefined, ErrorDefault>
 

--- a/packages/router/src/experimental/data-loaders/utils.ts
+++ b/packages/router/src/experimental/data-loaders/utils.ts
@@ -21,6 +21,9 @@ export let currentContext:
       entry: DataLoaderEntryBase,
       router: Router,
       route: RouteLocationNormalizedLoaded,
+      // whether the current load was explicitly forced (e.g. `reload()`), so
+      // nested loaders re-execute even if they already have data for this route
+      force?: boolean,
     ]
   | undefined
   | null


### PR DESCRIPTION
fixes #2684

## Context

In #2684, when all loaders are lazy and the parent loader resolves instantly (e.g. a synchronous cache), the parent loader ends up executed twice per navigation — and with a caching helper component the repeated executions can loop forever.

## Root cause

Lazy loaders are executed at component setup, after the navigation has finished. With `commit: 'after-load'` (the default), a loader that resolves instantly commits immediately, nulling `entry.pendingTo`. When a nested loader later calls `useParentLoader()` inside its own query, the `entry.pendingTo !== route` check sees `null` and assumes the entry is stale, forcing a refetch (`reload=true` was hardcoded for nested calls) — running the parent loader a second time.

## What this PR does

- When the entry already committed data for the current route (`entry.to === route` and it has a `pendingLoad`), a nested `useDataLoader()` call reuses the resolved query instead of forcing a refetch.
- An explicit `reload()` still forces nested loaders to re-run: the force flag travels through the loader context (new optional 4th slot) so nested calls inherit it.

## Tests

Two new tests reproduce the issue with lazy loaders + instantly resolving parents (one for `defineBasicLoader`, one for `defineColadaLoader` with a cached parent). Both fail without the fix and pass with it. Full `packages/router` suite: 1689 passing.

 Co-authored note: diagnosis guided by @posva's comment pinpointing the context reset timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added forced reload support for data loaders.
  - Reloading a parent loader now also refreshes nested loaders.

- **Bug Fixes**
  - Prevented loaders from running twice when data resolves immediately.
  - Fixed potential repeated loading loops with cached parent loaders.
  - Ensured each parent loader runs only once per navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->