### PR TITLE
docs: fix typo from component to components in file-based-routing document

### DIFF
--- a/packages/docs/file-based-routing/file-based-routing.md
+++ b/packages/docs/file-based-routing/file-based-routing.md
@@ -150,7 +150,7 @@ It is possible to define [named views](https://router.vuejs.org/guide/essentials
 ```js
 {
   path: '/',
-  component: {
+  components: {
     aux: () => import('src/pages/index@aux.vue')
   }
 }

--- a/packages/docs/zh/file-based-routing/file-based-routing.md
+++ b/packages/docs/zh/file-based-routing/file-based-routing.md
@@ -150,7 +150,7 @@ src/pages/
 ```js
 {
   path: '/',
-  component: {
+  components: {
     aux: () => import('src/pages/index@aux.vue')
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected named-view routing examples in the English and Chinese documentation to use the `components` configuration key.
  - Updated examples now align with the named-views routing API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->