### PR TITLE
fix(query): don't corrupt query keys that collide with Object.prototype

### DIFF
--- a/packages/router/__tests__/parseQuery.spec.ts
+++ b/packages/router/__tests__/parseQuery.spec.ts
@@ -66,6 +66,18 @@ describe('parseQuery', () => {
     })
   })
 
+  it('does not collide with Object.prototype keys', () => {
+    expect(parseQuery('toString=foo')).toEqual({
+      toString: 'foo',
+    })
+    expect(parseQuery('valueOf=bar')).toEqual({
+      valueOf: 'bar',
+    })
+    expect(parseQuery('hasOwnProperty=baz')).toEqual({
+      hasOwnProperty: 'baz',
+    })
+  })
+
   it('decodes the + as space', () => {
     expect(parseQuery('a+b=c+d')).toEqual({
       'a b': 'c d',

--- a/packages/router/src/query.ts
+++ b/packages/router/src/query.ts
@@ -54,8 +54,8 @@ export type LocationQueryRaw = Record<
  * @returns a query object
  */
 export function parseQuery(search: string): LocationQuery {
-  // TODO: in next major, use Object.create(null) and remove src/experimental/location.ts
-  const query: LocationQuery = {}
+  // TODO: in next major, remove src/experimental/location.ts
+  const query: LocationQuery = Object.create(null)
   // avoid creating an object with an empty key and empty value
   // because of split('&')
   if (search === '' || search === '?') return query


### PR DESCRIPTION
A query key that happens to be an `Object.prototype` member gets mangled:

```js
parseQuery('toString=foo')
// { toString: [ƒ toString, 'foo'] }, expected { toString: 'foo' }
```

`parseQuery` accumulates into a plain `{}` and checks for repeated keys with `key in query`. Since `in` walks the prototype chain, `toString` (and `valueOf`, `hasOwnProperty`, …) look like they already exist on the first occurrence, so the value gets wrapped in an array with the inherited function.

I switched the accumulator to `Object.create(null)` — which is what the TODO in the file and the experimental implementation already point at. Added a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query parsing for parameter names that overlap with built-in object properties, such as `toString`, `valueOf`, and `hasOwnProperty`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->