### PR TITLE
fix(matcher): preserve declared path casing when building star routes

### DIFF
--- a/packages/router/src/experimental/route-resolver/matchers/matcher-pattern-path-star.ts
+++ b/packages/router/src/experimental/route-resolver/matchers/matcher-pattern-path-star.ts
@@ -19,12 +19,18 @@ export class MatcherPatternPathStar implements MatcherPatternPath<{
   pathMatch: string
 }> {
   private path: string
+  /**
+   * lowercase version of the path to match against.
+   * This is used to make the matching case insensitive.
+   */
+  private pathi: string
   constructor(path: string = '') {
-    this.path = path.toLowerCase()
+    this.path = path
+    this.pathi = path.toLowerCase()
   }
 
   match(path: string): { pathMatch: string } {
-    if (!path.toLowerCase().startsWith(this.path)) {
+    if (!path.toLowerCase().startsWith(this.pathi)) {
       miss()
     }
     return {

--- a/packages/router/src/experimental/route-resolver/matchers/matcher-pattern.spec.ts
+++ b/packages/router/src/experimental/route-resolver/matchers/matcher-pattern.spec.ts
@@ -126,6 +126,13 @@ describe('MatcherPatternPathStar', () => {
       const pattern = new MatcherPatternPathStar('/team/')
       expect(pattern.build({ pathMatch: '/hey' })).toBe('/team//hey')
     })
+
+    it('keeps the declared case of the prefix', () => {
+      const pattern = new MatcherPatternPathStar('/Team')
+      expect(pattern.build({ pathMatch: '/123' })).toBe('/Team/123')
+      // match() stays case insensitive
+      expect(pattern.match('/team/123')).toEqual({ pathMatch: '/123' })
+    })
   })
 })
 


### PR DESCRIPTION
`MatcherPatternPathStar.build()` lowercases the static part of the path:

```js
new MatcherPatternPathStar('/Team').build({ pathMatch: '/123' })
// '/team/123', expected '/Team/123'
```

The constructor only keeps `path.toLowerCase()`, so the original casing is gone by the time `build()` runs. The sibling `MatcherPatternPathStatic` already handles this by keeping the original `path` for building and a separate lowercased copy for matching (its spec asserts `build()` preserves case). I mirrored that: original for `build()`, a private lowercased field for the case-insensitive `match()`. Added a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route matching remains case-insensitive while generated paths now preserve the original capitalization of the configured prefix.

* **Tests**
  * Added coverage confirming that path building retains declared capitalization without changing case-insensitive matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->